### PR TITLE
support date:[* TO ...]

### DIFF
--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -110,14 +110,14 @@ namespace Foundatio.Parsers.ElasticQueries.Extensions {
             if (elasticContext.IsDatePropertyType(nodeFullName)) {
                 string timezone = GetString(context, "TimeZone");
                 var range = new DateRangeQuery { Field = nodeFullName, TimeZone = timezone };
-                if (!String.IsNullOrWhiteSpace(node.UnescapedMin)) {
+                if (!String.IsNullOrWhiteSpace(node.UnescapedMin) && node.UnescapedMin != "*") {
                     if (node.MinInclusive.HasValue && !node.MinInclusive.Value)
                         range.GreaterThan = node.UnescapedMin;
                     else
                         range.GreaterThanOrEqualTo = node.UnescapedMin;
                 }
 
-                if (!String.IsNullOrWhiteSpace(node.UnescapedMax)) {
+                if (!String.IsNullOrWhiteSpace(node.UnescapedMax) && node.UnescapedMax != "*") {
                     if (node.MaxInclusive.HasValue && !node.MaxInclusive.Value)
                         range.LessThan = node.UnescapedMax;
                     else
@@ -127,14 +127,14 @@ namespace Foundatio.Parsers.ElasticQueries.Extensions {
                 return range;
             } else {
                 var range = new TermRangeQuery { Field = nodeFullName };
-                if (!String.IsNullOrWhiteSpace(node.UnescapedMin)) {
+                if (!String.IsNullOrWhiteSpace(node.UnescapedMin) && node.UnescapedMin != "*") {
                     if (node.MinInclusive.HasValue && !node.MinInclusive.Value)
                         range.GreaterThan = node.UnescapedMin;
                     else
                         range.GreaterThanOrEqualTo = node.UnescapedMin;
                 }
 
-                if (!String.IsNullOrWhiteSpace(node.UnescapedMax)) {
+                if (!String.IsNullOrWhiteSpace(node.UnescapedMax) && node.UnescapedMax != "*") {
                     if (node.MaxInclusive.HasValue && !node.MaxInclusive.Value)
                         range.LessThan = node.UnescapedMax;
                     else

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -958,6 +958,89 @@ namespace Foundatio.Parsers.Tests {
         }
 
         [Fact]
+        public void DateRangeWithWildcardMinQueryProcessor() {
+            var client = GetClient();
+            client.DeleteIndex("stuff");
+            client.Refresh("stuff");
+
+            client.CreateIndex("stuff");
+            client.Map<MyType>(d => d.Dynamic(true).Index("stuff"));
+            var res = client.Index(new MyType { Field1 = "value1", Field4 = 1, Field5 = DateTime.UtcNow }, i => i.Index("stuff"));
+            client.Index(new MyType { Field4 = 2 }, i => i.Index("stuff"));
+            client.Index(new MyType { Field1 = "value1", Field4 = 3, Field5 = DateTime.UtcNow }, i => i.Index("stuff"));
+            client.Refresh("stuff");
+
+            var ctx = new ElasticQueryVisitorContext { UseScoring = true };
+            ctx.Data["TimeZone"] = "America/Chicago";
+
+            var processor = new ElasticQueryParser(c => c
+                .UseMappings<MyType>(client, "stuff"));
+
+            var result =
+                processor.BuildQueryAsync("field5:[* TO 2017-01-31} OR field1:value1", ctx).Result;
+
+            var actualResponse = client.Search<MyType>(d => d.Index("stuff").Query(q => result));
+            string actualRequest = actualResponse.GetRequest();
+            _logger.LogInformation("Actual: {Request}", actualResponse);
+
+            var expectedResponse =
+                client.Search<MyType>(
+                    d =>
+                        d.Index("stuff")
+                            .Query(
+                                f =>
+                                    f.DateRange(m => m.Field(f2 => f2.Field5).LessThan("2017-01-31").TimeZone("America/Chicago")) ||
+                                    f.Match(e => e.Field(m => m.Field1).Query("value1"))));
+            string expectedRequest = expectedResponse.GetRequest();
+            _logger.LogInformation("Actual: {Request}", expectedRequest);
+
+            Assert.Equal(expectedRequest, actualRequest);
+            Assert.Equal(expectedResponse.Total, actualResponse.Total);
+        }
+
+        [Fact]
+        public void DateRangeWithWildcardMaxQueryProcessor() {
+            var client = GetClient();
+            client.DeleteIndex("stuff");
+            client.Refresh("stuff");
+
+            client.CreateIndex("stuff");
+            client.Map<MyType>(d => d.Dynamic(true).Index("stuff"));
+            var res = client.Index(new MyType { Field1 = "value1", Field4 = 1, Field5 = DateTime.UtcNow }, i => i.Index("stuff"));
+            client.Index(new MyType { Field4 = 2 }, i => i.Index("stuff"));
+            client.Index(new MyType { Field1 = "value1", Field4 = 3, Field5 = DateTime.UtcNow }, i => i.Index("stuff"));
+            client.Refresh("stuff");
+
+            var ctx = new ElasticQueryVisitorContext { UseScoring = true };
+            ctx.Data["TimeZone"] = "America/Chicago";
+
+            var processor = new ElasticQueryParser(c => c
+                .UseMappings<MyType>(client, "stuff"));
+
+            var result =
+                processor.BuildQueryAsync("field5:[2017-01-31 TO   *  } OR field1:value1", ctx).Result;
+
+            var actualResponse = client.Search<MyType>(d => d.Index("stuff").Query(q => result));
+            string actualRequest = actualResponse.GetRequest();
+            _logger.LogInformation("Actual: {Request}", actualResponse);
+
+            var expectedResponse =
+                client.Search<MyType>(
+                    d =>
+                        d.Index("stuff")
+                            .Query(
+                                f =>
+                                    f.DateRange(m => m.Field(f2 => f2.Field5).GreaterThanOrEquals("2017-01-31").TimeZone("America/Chicago")) ||
+                                    f.Match(e => e.Field(m => m.Field1).Query("value1"))));
+            string expectedRequest = expectedResponse.GetRequest();
+            _logger.LogInformation("Actual: {Request}", expectedRequest);
+
+            Assert.Equal(expectedRequest, actualRequest);
+            Assert.Equal(expectedResponse.Total, actualResponse.Total);
+        }
+
+
+        [Fact]
         public void DateRangeQueryProcessor() {
             var client = GetClient();
             client.DeleteIndex("stuff");


### PR DESCRIPTION
When doing a `[* TO blah]` query the builder was leaving the `*` in the query causing elastic to blow up when running the query. So this will not include that side of the query when it either side is a `*`