### PR TITLE
Fix ToString of negated groups

### DIFF
--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/GroupNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/GroupNode.cs
@@ -50,6 +50,9 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes {
         public override string ToString() {
             var builder = new StringBuilder();
 
+            if (IsNegated.HasValue && IsNegated.Value)
+                builder.Append("NOT ");
+
             builder.Append(Prefix);
 
             if (!String.IsNullOrEmpty(Field))
@@ -67,9 +70,6 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes {
                 builder.Append(" OR ");
             else if (Right != null)
                 builder.Append(" ");
-
-            if (IsNegated.HasValue && IsNegated.Value)
-                builder.Append("NOT ");
 
             if (Right != null)
                 builder.Append(Right);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserUnitTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserUnitTests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Foundatio.Parsers.LuceneQueries.Tests {
+    [Trait("TestType", "Unit")]
+    public class QueryParserUnitTests {
+
+        public static IEnumerable<object[]> QueriesAndExpectedStringOutput => new[]
+        {
+            new object[] { "NOT someField:stuff" },
+            new object[] { "NOT -someField:stuff" },
+            new object[] { "NOT someField:(stuff)" },
+            new object[] { "NOT someField:(NOT stuff)" },
+            new object[] { "NOT -someField:(stuff)" },
+        };
+
+        [Theory]
+        [MemberData(nameof(QueriesAndExpectedStringOutput))]
+        public void  CanParseQueriesAndOutputWithNoChanges(string expectedQuery) {
+            var sut = new LuceneQueryParser();
+            
+            var rootNode = sut.Parse(expectedQuery);
+            var actualResult = rootNode.ToString();
+
+            Assert.Equal(expectedQuery, actualResult);
+        }
+    }
+}


### PR DESCRIPTION
Currently a query like "NOT someField:(stuff)" will get transformed into "someField:(stuffNOT )", which is causing issues in our system. TermNode does not have this behavior. This change keeps the ToString behavior consistent between TermNode and GroupNode (as well as fixing a bug).