### PR TITLE
Fix for parsing NOT before parens

### DIFF
--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
@@ -62,13 +62,16 @@ group_exp<IQueryNode>
   / paren_exp
 
 paren_exp<GroupNode>
-  = op:prefix_operator_exp? "(" _* node:node _* ")" boost:boost_modifier? _*
+  = not:not_exp? op:prefix_operator_exp? "(" _* node:node _* ")" boost:boost_modifier? _*
     {{
         node.HasParens = true;
         node.Prefix = op.SingleOrDefault();
 
         if (boost.Count > 0)
             node.Boost = boost.SingleOrDefault();
+
+        if (not.Any())
+          node.IsNegated = true;
 
         return node;
     }}

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserUnitTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserUnitTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Foundatio.Parsers.LuceneQueries.Nodes;
 using Xunit;
 
 namespace Foundatio.Parsers.LuceneQueries.Tests {
@@ -25,6 +26,17 @@ namespace Foundatio.Parsers.LuceneQueries.Tests {
             var actualResult = rootNode.ToString();
 
             Assert.Equal(expectedQuery, actualResult);
+        }
+
+        [Fact]
+        public void CanParseNotBeforeParens() {
+            var sut = new LuceneQueryParser();
+
+            var result = sut.Parse("NOT (dog parrot)");
+
+            Assert.IsType<GroupNode>(result.Left);
+            Assert.True((result.Left as GroupNode).HasParens);
+            Assert.True((result.Left as GroupNode).IsNegated);
         }
     }
 }


### PR DESCRIPTION
Getting an error when trying to parse something like "cat NOT (dog parrot)", which is valid syntax according to apache lucene parser and elastic systems i have tried it directly with. This change adds NOT before parens as a valid option in the peg file.