### PR TITLE
Add multiple consecutive operator validation

### DIFF
--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
@@ -136,7 +136,7 @@ fieldname<FieldInfo> -lexical
     }}
 
 term<TermNode>
-  = not:not_exp? op:prefix_operator_exp? term:quoted_term proximity:proximity_modifier? boost:boost_modifier? _*
+  = not:not_exp? op:prefix_operator_exp? !operator_exp term:quoted_term proximity:proximity_modifier? boost:boost_modifier? _*
       {{
         var result = new TermNode { Term = term, IsQuotedTerm = true };
 
@@ -153,7 +153,7 @@ term<TermNode>
 
         return result;
     }}
-  / not:not_exp? op:prefix_operator_exp? term:unquoted_term proximity:proximity_modifier? boost:boost_modifier? _*
+  / not:not_exp? op:prefix_operator_exp? !operator_exp term:unquoted_term proximity:proximity_modifier? boost:boost_modifier? _*
     {{
         var result = new TermNode { Term = term };
 
@@ -170,6 +170,7 @@ term<TermNode>
 
         return result;
     }}
+  / not:not_exp? prefix:prefix_operator_exp? op:operator_exp #error{ "Unexpected operator '" + op + "'." }
 
 // https://lucene.apache.org/core/2_9_4/queryparsersyntax.html#Escaping%20Special%20Characters
 escape_sequence

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserUnitTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserUnitTests.cs
@@ -15,6 +15,9 @@ namespace Foundatio.Parsers.LuceneQueries.Tests {
             new object[] { "NOT someField:(stuff)" },
             new object[] { "NOT someField:(NOT stuff)" },
             new object[] { "NOT -someField:(stuff)" },
+            new object[] { "something AND NOT otherthing" },
+            new object[] { "something AND otherthing" },
+            new object[] { "something OR otherthing" },
         };
 
         [Theory]
@@ -37,6 +40,24 @@ namespace Foundatio.Parsers.LuceneQueries.Tests {
             Assert.IsType<GroupNode>(result.Left);
             Assert.True((result.Left as GroupNode).HasParens);
             Assert.True((result.Left as GroupNode).IsNegated);
+        }
+
+        [Fact]
+        public void MultipleOperatorsIsNotValid() {
+            var sut = new LuceneQueryParser();
+
+            Assert.Throws<FormatException>(() => {
+                var result = sut.Parse("something AND NOT OR otherthing");
+            });
+        }
+
+        [Fact]
+        public void DoubleOperatorsIsNotValid() {
+            var sut = new LuceneQueryParser();
+
+            Assert.Throws<FormatException>(() => {
+                var result = sut.Parse("something AND OR otherthing");
+            });
         }
     }
 }


### PR DESCRIPTION
If you parse something like this "something AND NOT OR otherthing" it does NOT report an error. Instead it treats the extra "OR" as a term. Sending this query on causes errors in downstream search services however. This added validation catches this case and throws an appropriate format exception.