### PR TITLE
Update DefaultQueryNodeExtensions.cs

### DIFF
--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -68,10 +68,17 @@ namespace Foundatio.Parsers.ElasticQueries.Extensions {
                     }
                 }
             } else {
-                query = new TermQuery {
-                    Field = field,
-                    Value = node.UnescapedTerm
-                };
+                if (node.UnescapedTerm.EndsWith("*")) {
+                    query = new PrefixQuery {
+                        Field = field,
+                        Value = node.UnescapedTerm.TrimEnd('*')
+                    };
+                } else {
+                    query = new TermQuery {
+                        Field = field,
+                        Value = node.UnescapedTerm
+                    };
+                }
             }
 
             return query;


### PR DESCRIPTION
Add support to prefix query when the term ends with '*' for a non-analyzed field.

When parsing a query such as:
`Category.Alias:abc* AND AttributeId:123`

If the field Category.Alias is of type **keyword**, I would expect it to translate to a `PrefixQuery`, however it always translate to `TermQuery`