### PR TITLE
Add checks for navigation collections

### DIFF
--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
@@ -130,7 +130,9 @@ public class SqlQueryParser : LuceneQueryParser {
                 continue;
 
             string propertyPath = prefix + nav.Name;
-            AddEntityFields(fields, nav.TargetEntityType, entityTypeStack, propertyPath + ".", false, depth + 1);
+            bool isNavCollection = nav is IReadOnlyNavigationBase { IsCollection: true };
+
+            AddEntityFields(fields, nav.TargetEntityType, entityTypeStack, propertyPath + ".", isNavCollection, depth + 1);
         }
 
         foreach (var skipNav in entityType.GetSkipNavigations())
@@ -139,6 +141,7 @@ public class SqlQueryParser : LuceneQueryParser {
                 continue;
 
             string propertyPath = prefix + skipNav.Name;
+
             AddEntityFields(fields, skipNav.TargetEntityType, entityTypeStack, propertyPath + ".", true, depth + 1);
         }
 

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
@@ -142,7 +142,7 @@ public class SqlQueryParser : LuceneQueryParser {
 
             string propertyPath = prefix + skipNav.Name;
 
-            AddEntityFields(fields, skipNav.TargetEntityType, entityTypeStack, propertyPath + ".", true, depth + 1);
+            AddEntityFields(fields, skipNav.TargetEntityType, entityTypeStack, propertyPath + ".", skipNav.IsCollection, depth + 1);
         }
 
         entityTypeStack.Pop();

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SampleContext.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SampleContext.cs
@@ -40,6 +40,7 @@ public class Employee {
     public int Id { get; set; }
     public string FullName { get; set; }
     public string Title { get; set; }
+    public int Salary { get; set; }
     public List<Company> Companies { get; set; }
     public List<DataValue> DataValues { get; set; }
     public DateTime Created { get; set; } = DateTime.Now;

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -193,10 +193,10 @@ public class SqlQueryParserTests : TestWithLoggingBase {
 
         var context = parser.GetContext(db.Companies.EntityType);
 
-        string sqlExpected = db.Companies.Where(e => e.Employees.Any(c => c.Salary < 85_000)).ToQueryString();
-        string sqlActual = db.Companies.Where("""Employees.Any(Salary < 85000)""").ToQueryString();
+        string sqlExpected = db.Companies.Where(e => e.Employees.Any(c => c.Salary.Equals(80_000))).ToQueryString();
+        string sqlActual = db.Companies.Where("""Employees.Any(Salary.Equals(80000))""").ToQueryString();
         Assert.Equal(sqlExpected, sqlActual);
-        string sql = await parser.ToDynamicLinqAsync("employees.salary:<85000", context);
+        string sql = await parser.ToDynamicLinqAsync("employees.salary:80000", context);
         sqlActual = db.Companies.Where(sql).ToQueryString();
         Assert.Equal(sqlExpected, sqlActual);
 

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -163,6 +163,50 @@ public class SqlQueryParserTests : TestWithLoggingBase {
     }
 
     [Fact]
+    public async Task CanUseNavigationFields()
+    {
+        var sp = GetServiceProvider();
+        await using var db = await GetSampleContextWithDataAsync(sp);
+        var parser = sp.GetRequiredService<SqlQueryParser>();
+
+        var context = parser.GetContext(db.Companies.EntityType);
+
+        string sqlExpected = db.Companies.Where(e => e.DataDefinitions.Any(c => c.Key == "age")).ToQueryString();
+        string sqlActual = db.Companies.Where("""DataDefinitions.Any(Key.Equals("age"))""").ToQueryString();
+        Assert.Equal(sqlExpected, sqlActual);
+        string sql = await parser.ToDynamicLinqAsync("datadefinitions.key:age", context);
+        sqlActual = db.Companies.Where(sql).ToQueryString();
+        Assert.Equal(sqlExpected, sqlActual);
+
+        var query = db.Companies.AsQueryable();
+        var companies = await query.Where(sql).ToListAsync();
+
+        Assert.Single(companies);
+    }
+
+    [Fact]
+    public async Task CanUseSkipNavigationFields()
+    {
+        var sp = GetServiceProvider();
+        await using var db = await GetSampleContextWithDataAsync(sp);
+        var parser = sp.GetRequiredService<SqlQueryParser>();
+
+        var context = parser.GetContext(db.Companies.EntityType);
+
+        string sqlExpected = db.Companies.Where(e => e.Employees.Any(c => c.Salary < 85_000)).ToQueryString();
+        string sqlActual = db.Companies.Where("""Employees.Any(Salary < 85000)""").ToQueryString();
+        Assert.Equal(sqlExpected, sqlActual);
+        string sql = await parser.ToDynamicLinqAsync("employees.salary:<85000", context);
+        sqlActual = db.Companies.Where(sql).ToQueryString();
+        Assert.Equal(sqlExpected, sqlActual);
+
+        var query = db.Companies.AsQueryable();
+        var companies = await query.Where(sql).ToListAsync();
+
+        Assert.Single(companies);
+    }
+
+    [Fact]
     public async Task CanGenerateSql()
     {
         var sp = GetServiceProvider();
@@ -231,6 +275,7 @@ public class SqlQueryParserTests : TestWithLoggingBase {
         {
             FullName = "John Doe",
             Title = "Software Developer",
+            Salary = 80_000,
             DataValues = [ new() { Definition = company.DataDefinitions[0], NumberValue = 30 } ],
             Companies = [company]
         });
@@ -238,6 +283,7 @@ public class SqlQueryParserTests : TestWithLoggingBase {
         {
             FullName = "Jane Doe",
             Title = "Software Developer",
+            Salary = 90_000,
             DataValues = [ new() { Definition = company.DataDefinitions[0], NumberValue = 23 } ],
             Companies = [company]
         });

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -171,6 +171,8 @@ public class SqlQueryParserTests : TestWithLoggingBase {
 
         var context = parser.GetContext(db.Companies.EntityType);
 
+        Assert.Contains(db.Companies.EntityType.GetNavigations(), e => e.TargetEntityType == db.DataDefinitions.EntityType);
+
         string sqlExpected = db.Companies.Where(e => e.DataDefinitions.Any(c => c.Key == "age")).ToQueryString();
         string sqlActual = db.Companies.Where("""DataDefinitions.Any(Key.Equals("age"))""").ToQueryString();
         Assert.Equal(sqlExpected, sqlActual);
@@ -192,6 +194,8 @@ public class SqlQueryParserTests : TestWithLoggingBase {
         var parser = sp.GetRequiredService<SqlQueryParser>();
 
         var context = parser.GetContext(db.Companies.EntityType);
+
+        Assert.Contains(db.Companies.EntityType.GetSkipNavigations(), e => e.TargetEntityType == db.Employees.EntityType);
 
         string sqlExpected = db.Companies.Where(e => e.Employees.Any(c => c.Salary.Equals(80_000))).ToQueryString();
         string sqlActual = db.Companies.Where("""Employees.Any(Salary.Equals(80000))""").ToQueryString();


### PR DESCRIPTION
Updates SqlQueryParser#AddEntityFields to respect collection navigations instead of hard coding false