### PR TITLE
Fixed a bug where aggs couldn't be validated.

### DIFF
--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -189,9 +189,14 @@ public static class QueryNodeExtensions
     }
 
     private const string OperationTypeKey = "@OperationType";
+    public static bool HasOperationType(this IQueryNode node)
+    {
+        return node.Data.ContainsKey(OperationTypeKey);
+    }
+
     public static string GetOperationType(this IQueryNode node)
     {
-        if (!node.Data.TryGetValue(OperationTypeKey, out var value))
+        if (!node.Data.TryGetValue(OperationTypeKey, out object value))
             return null;
 
         return (string)value;

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/AssignOperationTypeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/AssignOperationTypeVisitor.cs
@@ -17,11 +17,6 @@ public class AssignOperationTypeVisitor : ChainableQueryVisitor
 
         if (node.Left is not TermNode leftTerm)
         {
-            // For sub aggregations we need to see if there is a parent with parens
-            var closestParentWithParens = node.GetGroupNode();
-            if (closestParentWithParens is { HasParens: true })
-                return base.VisitAsync(node, context);
-
             context.AddValidationError($"Aggregations ({node.Field}) must specify a field.");
             return Task.CompletedTask;
         }
@@ -44,14 +39,6 @@ public class AssignOperationTypeVisitor : ChainableQueryVisitor
     public override void Visit(TermNode node, IQueryVisitorContext context)
     {
         if (node.HasOperationType())
-            return;
-
-        if (String.IsNullOrEmpty(node.Field))
-            return;
-
-        // For sub aggregations we need to see if there is a parent with parens
-        var closestParentWithParens = node.GetGroupNode();
-        if (closestParentWithParens is { HasParens: true })
             return;
 
         if (String.IsNullOrEmpty(node.Field) && !String.IsNullOrEmpty(node.Term))

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
@@ -60,6 +60,9 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
 
             if (resolvedField == null)
             {
+                if (context.QueryType is QueryTypes.Aggregation && node.Field.StartsWith("@"))
+                    return;
+
                 // add field to unresolved fields list
                 context.GetValidationResult().UnresolvedFields.Add(node.Field);
                 return;


### PR DESCRIPTION
The tests failed due to the visitor running as part of parse. This visitor mutates the node and thus fails on second pass of getting validation.