### PR TITLE
Add NestedFilterResolver for injecting filters into nested queries/aggs/sorts

### DIFF
--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -201,8 +201,9 @@ var parser = new ElasticQueryParser(c => c
     .UseMappings(client, "my-index")
     .UseNestedFilter((nestedPath, originalField, resolvedField, context) =>
     {
-        if (nestedPath == "comments")
+        if (nestedPath is "comments")
             return new TermQuery { Field = "comments.type", Value = "public" };
+
         return null;
     })
     .UseNested());

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -192,6 +192,44 @@ bool isNested = resolver.IsNestedPropertyType("comments");
 // "comments.author" -> "comments"
 ```
 
+### Filtered Nested Queries
+
+When multiple logical types share a nested array, use `UseNestedFilter()` to inject a discriminator filter:
+
+```csharp
+var parser = new ElasticQueryParser(c => c
+    .UseMappings(client, "my-index")
+    .UseNestedFilter((nestedPath, originalField, resolvedField, context) =>
+    {
+        if (nestedPath == "comments")
+            return new TermQuery { Field = "comments.type", Value = "public" };
+        return null;
+    })
+    .UseNested());
+
+// Query: comments.author:john
+// Produces:
+// {
+//   "nested": {
+//     "path": "comments",
+//     "query": {
+//       "bool": {
+//         "must": [
+//           { "term": { "comments.author": "john" } },
+//           { "term": { "comments.type": "public" } }
+//         ]
+//       }
+//     }
+//   }
+// }
+
+// Aggregation: max:comments.rating
+// Produces: nested > filter(comments.type=public) > max(comments.rating)
+
+// Sort: -comments.rating
+// Produces: sort with nested(path=comments, filter=term(comments.type, public))
+```
+
 ## Mapping Extensions
 
 ### Adding Keyword Sub-Fields

--- a/docs/guide/elastic-query-parser.md
+++ b/docs/guide/elastic-query-parser.md
@@ -79,6 +79,7 @@ var parser = new ElasticQueryParser(c => c
 | `UseIncludes(includes)` | Query include definitions |
 | `UseGeo(resolver)` | Geo location resolver |
 | `UseNested()` | Enable nested document support |
+| `UseNestedFilter(resolver)` | Nested filter resolver for injecting filters into nested queries/aggs/sorts |
 | `SetValidationOptions(options)` | Validation configuration |
 | `UseRuntimeFieldResolver(resolver)` | Runtime field support |
 
@@ -351,6 +352,54 @@ Sorting by nested fields is automatically handled with the correct `nested` cont
 // Sort descending by a nested field
 var sort = await parser.BuildSortAsync("-nested.field4");
 ```
+
+### Nested Filter Resolver
+
+When multiple logical types share a single nested array (e.g., different reseller tiers), you can inject a discriminator filter inside nested queries, aggregations, and sorts using `UseNestedFilter()`:
+
+```csharp
+var parser = new ElasticQueryParser(c => c
+    .UseMappings(client, "my-index")
+    .UseNestedFilter((nestedPath, originalField, resolvedField, context) =>
+    {
+        if (nestedPath == "resellers")
+            return new TermQuery { Field = "resellers.type", Value = "official" };
+        return null;
+    })
+    .UseNested());
+```
+
+The resolver is called once per nested field node during visitor traversal. Return `null` to skip filtering for a given field.
+
+**Queries** -- The filter is AND-ed into the nested query's inner query:
+
+```csharp
+// Input: resellers.price:10
+// Output: nested(path=resellers, query=(term(resellers.price, 10) AND term(resellers.type, official)))
+```
+
+**Aggregations** -- Each nested aggregation is wrapped in a `FilterAggregation`:
+
+```csharp
+// Input: max:resellers.price
+// Output: nested(path=resellers) > filter(term(resellers.type, official)) > max(resellers.price)
+```
+
+**Sorts** -- The filter is set on `NestedSort.Filter`:
+
+```csharp
+// Input: -resellers.price
+// Output: sort(resellers.price, desc, nested(path=resellers, filter=term(resellers.type, official)))
+```
+
+A synchronous overload is also available for resolvers that don't need async:
+
+```csharp
+.UseNestedFilter((path, orig, resolved, ctx) =>
+    path == "resellers" ? new TermQuery { Field = "resellers.type", Value = "official" } : null)
+```
+
+**Call order safety**: `UseNestedFilter()` and `UseNested()` can be called in any order. The resolver is always passed to the `NestedVisitor` correctly.
 
 ### Exists and Missing on Nested Fields
 

--- a/docs/guide/elastic-query-parser.md
+++ b/docs/guide/elastic-query-parser.md
@@ -369,7 +369,7 @@ var parser = new ElasticQueryParser(c => c
     .UseNested());
 ```
 
-The resolver is called once per nested field node during visitor traversal. Return `null` to skip filtering for a given field.
+The resolver is called for each standalone nested field node during visitor traversal. For fields inside an explicit nested group (e.g., `resellers:(...)`), the resolver is called once on the group node rather than on the individual inner field nodes. Return `null` to skip filtering for a given field or group.
 
 **Queries** -- The filter is AND-ed into the nested query's inner query:
 

--- a/docs/guide/elastic-query-parser.md
+++ b/docs/guide/elastic-query-parser.md
@@ -362,8 +362,9 @@ var parser = new ElasticQueryParser(c => c
     .UseMappings(client, "my-index")
     .UseNestedFilter((nestedPath, originalField, resolvedField, context) =>
     {
-        if (nestedPath == "resellers")
+        if (nestedPath is "resellers")
             return new TermQuery { Field = "resellers.type", Value = "official" };
+
         return null;
     })
     .UseNested());
@@ -396,7 +397,7 @@ A synchronous overload is also available for resolvers that don't need async:
 
 ```csharp
 .UseNestedFilter((path, orig, resolved, ctx) =>
-    path == "resellers" ? new TermQuery { Field = "resellers.type", Value = "official" } : null)
+    path is "resellers" ? new TermQuery { Field = "resellers.type", Value = "official" } : null)
 ```
 
 **Call order safety**: `UseNestedFilter()` and `UseNested()` can be called in any order. The resolver is always passed to the `NestedVisitor` correctly.

--- a/docs/guide/nested-queries.md
+++ b/docs/guide/nested-queries.md
@@ -479,8 +479,9 @@ var parser = new ElasticQueryParser(c => c
     .UseMappings(client, "my-index")
     .UseNestedFilter((nestedPath, originalField, resolvedField, context) =>
     {
-        if (nestedPath == "resellers")
+        if (nestedPath is "resellers")
             return new TermQuery { Field = "resellers.type", Value = "official" };
+
         return null;
     })
     .UseNested());

--- a/docs/guide/nested-queries.md
+++ b/docs/guide/nested-queries.md
@@ -453,6 +453,56 @@ The following nested query scenarios are fully supported with test coverage:
 | Mixed nested/non-nested default fields | `SetDefaultFields(["field1", "nested.field1"])` | Supported |
 | Mixed field types in defaults | Text + keyword + integer across nested/non-nested | Supported |
 | Field aliases to nested paths | `UseFieldMap({ "alias", "nested" })` | Supported |
+| Filtered nested query | `UseNestedFilter()` + `resellers.price:10` | Supported |
+| Filtered nested aggregation | `UseNestedFilter()` + `max:resellers.price` (FilterAgg wrapper) | Supported |
+| Filtered nested sort | `UseNestedFilter()` + `-resellers.price` (NestedSort.Filter) | Supported |
+| Multiple nested paths with different filters | `UseNestedFilter()` with path-based dispatch | Supported |
+
+## Nested Filter Resolver
+
+When a single nested array contains documents of different logical types (e.g., official vs third-party resellers), a discriminator filter must be injected inside the nested scope. The `UseNestedFilter()` configuration method registers a callback that runs during `NestedVisitor` traversal and stores the filter as `@NestedFilter` metadata on each node.
+
+### How It Works
+
+1. **`NestedVisitor`** calls the resolver for every field that maps to a nested type, passing the nested path, the original field name (before alias resolution), the resolved field name, and the visitor context. If the resolver returns a non-null `QueryContainer`, it is stored as `@NestedFilter` metadata on the node.
+
+2. **`CombineQueriesVisitor`** reads the `@NestedFilter` from coalesced nodes and AND-s the filter once per nested path into the inner query. For explicit grouped nested queries, the filter is applied to the group's inner query.
+
+3. **`CombineAggregationsVisitor`** reads the `@NestedFilter` and wraps each inner aggregation in a `FilterAggregation` before adding it to the `NestedAggregation`.
+
+4. **`DefaultSortNodeExtensions`** reads the `@NestedFilter` and sets `NestedSort.Filter`.
+
+### Configuration
+
+```csharp
+var parser = new ElasticQueryParser(c => c
+    .UseMappings(client, "my-index")
+    .UseNestedFilter((nestedPath, originalField, resolvedField, context) =>
+    {
+        if (nestedPath == "resellers")
+            return new TermQuery { Field = "resellers.type", Value = "official" };
+        return null;
+    })
+    .UseNested());
+```
+
+### Delegate Signature
+
+```csharp
+public delegate Task<QueryContainer> NestedFilterResolver(
+    string nestedPath,       // e.g., "resellers"
+    string originalField,    // field name before alias resolution
+    string resolvedField,    // field name after alias resolution
+    IQueryVisitorContext context);
+```
+
+A synchronous overload is available that wraps the return in `Task.FromResult`.
+
+### Known Limitations of the Filter Resolver
+
+- Default field searches (`SetDefaultFields` with nested fields) do not invoke the filter resolver.
+- When coalescing multiple fields from the same nested path in a query, the filter is taken from the first node that has one and applied once. Different discriminators for the same path require separate explicit nested groups.
+- `NestedQuery.InnerHits` and `ScoreMode` are out of scope for this feature.
 
 ## Known Limitations
 

--- a/docs/guide/nested-queries.md
+++ b/docs/guide/nested-queries.md
@@ -464,9 +464,9 @@ When a single nested array contains documents of different logical types (e.g., 
 
 ### How It Works
 
-1. **`NestedVisitor`** calls the resolver for every field that maps to a nested type, passing the nested path, the original field name (before alias resolution), the resolved field name, and the visitor context. If the resolver returns a non-null `QueryContainer`, it is stored as `@NestedFilter` metadata on the node.
+1. **`NestedVisitor`** calls the resolver whenever a node introduces or participates in a nested scope. For standalone nested field nodes (e.g., `resellers.price:10`), the resolver is called for each field. For explicit nested groups (e.g., `resellers:(resellers.name:x resellers.price:10)`), inner field nodes are skipped and the resolver is called once on the group node. If the resolver returns a non-null `QueryContainer`, it is stored as `@NestedFilter` metadata on that node.
 
-2. **`CombineQueriesVisitor`** reads the `@NestedFilter` from coalesced nodes and AND-s the filter once per nested path into the inner query. For explicit grouped nested queries, the filter is applied to the group's inner query.
+2. **`CombineQueriesVisitor`** reads the `@NestedFilter` from coalesced nodes and AND-s the filter once per nested path into the inner query. For explicit grouped nested queries, the filter stored on the group node is applied to the group's inner query.
 
 3. **`CombineAggregationsVisitor`** reads the `@NestedFilter` and wraps each inner aggregation in a `FilterAggregation` before adding it to the `NestedAggregation`.
 
@@ -498,11 +498,10 @@ public delegate Task<QueryContainer> NestedFilterResolver(
 
 A synchronous overload is available that wraps the return in `Task.FromResult`.
 
-### Known Limitations of the Filter Resolver
+### Resolver Behavior Notes
 
-- Default field searches (`SetDefaultFields` with nested fields) do not invoke the filter resolver.
-- When coalescing multiple fields from the same nested path in a query, the filter is taken from the first node that has one and applied once. Different discriminators for the same path require separate explicit nested groups.
-- `NestedQuery.InnerHits` and `ScoreMode` are out of scope for this feature.
+- For explicit nested groups, the resolver is called once on the group node, not on the individual inner field nodes. To use different discriminators for different fields within the same nested path, use separate explicit nested groups or encode the distinction via field aliases or `IQueryVisitorContext.Data`.
+- Default field searches (`SetDefaultFields` with nested fields) bypass the visitor chain and do not invoke the filter resolver.
 
 ## Known Limitations
 

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.ElasticQueries.Visitors;
@@ -10,9 +10,26 @@ using Nest;
 
 namespace Foundatio.Parsers.ElasticQueries;
 
+/// <summary>
+/// Resolves an optional filter to inject inside nested queries, aggregations, and sorts.
+/// Called once per nested field node during visitor traversal.
+/// Return null to skip filtering for a given field.
+/// </summary>
+/// <param name="nestedPath">The detected nested mapping path (e.g., "resellers").</param>
+/// <param name="originalField">The field name before alias resolution (from GetOriginalField()).</param>
+/// <param name="resolvedField">The field name after alias resolution (the current node.Field).</param>
+/// <param name="context">The visitor context, providing Data dictionary for arbitrary state.</param>
+public delegate Task<QueryContainer> NestedFilterResolver(
+    string nestedPath,
+    string originalField,
+    string resolvedField,
+    IQueryVisitorContext context
+);
+
 public class ElasticQueryParserConfiguration
 {
     private ILogger _logger = NullLogger.Instance;
+    private int? _nestedPriority;
 
     public ElasticQueryParserConfiguration()
     {
@@ -28,6 +45,7 @@ public class ElasticQueryParserConfiguration
     public string[] DefaultFields { get; private set; }
     public QueryFieldResolver FieldResolver { get; private set; }
     public IncludeResolver IncludeResolver { get; private set; }
+    public NestedFilterResolver NestedFilterResolver { get; private set; }
     public RuntimeFieldResolver RuntimeFieldResolver { get; private set; }
     public bool? EnableRuntimeFieldResolver { get; private set; }
     public ElasticMappingResolver MappingResolver { get; private set; }
@@ -116,7 +134,29 @@ public class ElasticQueryParserConfiguration
 
     public ElasticQueryParserConfiguration UseNested(int priority = 300)
     {
-        return AddVisitor(new NestedVisitor(), priority);
+        _nestedPriority = priority;
+        RemoveVisitor<NestedVisitor>();
+
+        return AddVisitor(new NestedVisitor(NestedFilterResolver), priority);
+    }
+
+    public ElasticQueryParserConfiguration UseNestedFilter(NestedFilterResolver resolver)
+    {
+        NestedFilterResolver = resolver;
+        if (_nestedPriority.HasValue)
+        {
+            RemoveVisitor<NestedVisitor>();
+            AddVisitor(new NestedVisitor(resolver), _nestedPriority.Value);
+        }
+
+        return this;
+    }
+
+    public ElasticQueryParserConfiguration UseNestedFilter(
+        Func<string, string, string, IQueryVisitorContext, QueryContainer> resolver)
+    {
+        return UseNestedFilter((path, orig, resolved, ctx) =>
+            Task.FromResult(resolver(path, orig, resolved, ctx)));
     }
 
     #region Combined Visitor Management

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -156,6 +156,9 @@ public class ElasticQueryParserConfiguration
     public ElasticQueryParserConfiguration UseNestedFilter(
         Func<string, string, string, IQueryVisitorContext, QueryContainer> resolver)
     {
+        if (resolver is null)
+            return UseNestedFilter((NestedFilterResolver)null);
+
         return UseNestedFilter((path, orig, resolved, ctx) =>
             Task.FromResult(resolver(path, orig, resolved, ctx)));
     }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -12,7 +12,8 @@ namespace Foundatio.Parsers.ElasticQueries;
 
 /// <summary>
 /// Resolves an optional filter to inject inside nested queries, aggregations, and sorts.
-/// Called once per nested field node during visitor traversal.
+/// Called for each nested field node that is not inside an explicit nested group, and once
+/// for each explicit nested group node during visitor traversal.
 /// Return null to skip filtering for a given field.
 /// </summary>
 /// <param name="nestedPath">The detected nested mapping path (e.g., "resellers").</param>

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -163,8 +163,6 @@ public class ElasticQueryParserConfiguration
             Task.FromResult(resolver(path, orig, resolved, ctx)));
     }
 
-    #region Combined Visitor Management
-
     public ElasticQueryParserConfiguration AddVisitor(IChainableQueryVisitor visitor, int priority = 0)
     {
         QueryVisitor.AddVisitor(visitor, priority);
@@ -210,10 +208,6 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    #endregion
-
-    #region Query Visitor Management
-
     public ElasticQueryParserConfiguration AddQueryVisitor(IChainableQueryVisitor visitor, int priority = 0)
     {
         QueryVisitor.AddVisitor(visitor, priority);
@@ -248,10 +242,6 @@ public class ElasticQueryParserConfiguration
 
         return this;
     }
-
-    #endregion
-
-    #region Sort Visitor Management
 
     public ElasticQueryParserConfiguration AddSortVisitor(IChainableQueryVisitor visitor, int priority = 0)
     {
@@ -288,10 +278,6 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    #endregion
-
-    #region Aggregation Visitor Management
-
     public ElasticQueryParserConfiguration AddAggregationVisitor(IChainableQueryVisitor visitor, int priority = 0)
     {
         AggregationVisitor.AddVisitor(visitor, priority);
@@ -326,8 +312,6 @@ public class ElasticQueryParserConfiguration
 
         return this;
     }
-
-    #endregion
 
     public ElasticQueryParserConfiguration UseMappings<T>(Func<TypeMappingDescriptor<T>, TypeMappingDescriptor<T>> mappingBuilder, IElasticClient client, string index) where T : class
     {

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
@@ -27,8 +27,12 @@ public static class DefaultSortNodeExtensions
         string nestedPath = node.GetNestedPath();
         if (nestedPath is not null)
         {
+            var nestedSort = new NestedSort { Path = nestedPath };
             var nestedFilter = node.GetNestedFilter();
-            sort.Nested = new NestedSort { Path = nestedPath, Filter = nestedFilter };
+            if (nestedFilter is not null)
+                nestedSort.Filter = nestedFilter;
+
+            sort.Nested = nestedSort;
         }
 
         return sort;

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
@@ -26,7 +26,10 @@ public static class DefaultSortNodeExtensions
 
         string nestedPath = node.GetNestedPath();
         if (nestedPath is not null)
-            sort.Nested = new NestedSort { Path = nestedPath };
+        {
+            var nestedFilter = node.GetNestedFilter();
+            sort.Nested = new NestedSort { Path = nestedPath, Filter = nestedFilter };
+        }
 
         return sort;
     }

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryNodeExtensions.cs
@@ -104,4 +104,23 @@ public static class QueryNodeExtensions
     {
         node.Data.Remove(NestedPathKey);
     }
+
+    private const string NestedFilterKey = "@NestedFilter";
+    public static QueryContainer GetNestedFilter(this IQueryNode node)
+    {
+        if (!node.Data.TryGetValue(NestedFilterKey, out object value))
+            return null;
+
+        return value as QueryContainer;
+    }
+
+    public static void SetNestedFilter(this IQueryNode node, QueryContainer filter)
+    {
+        node.Data[NestedFilterKey] = filter;
+    }
+
+    public static void RemoveNestedFilter(this IQueryNode node)
+    {
+        node.Data.Remove(NestedFilterKey);
+    }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
@@ -62,7 +62,24 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
 
             foreach (var (child, aggregation) in childAggregations)
             {
-                nestedAgg.Aggregations[((IAggregation)aggregation).Name] = (AggregationContainer)aggregation;
+                var nestedFilter = child.GetNestedFilter();
+                if (nestedFilter is not null)
+                {
+                    var filteredAgg = new FilterAggregation("filtered_" + ((IAggregation)aggregation).Name)
+                    {
+                        Filter = nestedFilter,
+                        Aggregations = new AggregationDictionary
+                        {
+                            [((IAggregation)aggregation).Name] = (AggregationContainer)aggregation
+                        }
+                    };
+                    nestedAgg.Aggregations[((IAggregation)filteredAgg).Name] = (AggregationContainer)filteredAgg;
+                }
+                else
+                {
+                    nestedAgg.Aggregations[((IAggregation)aggregation).Name] = (AggregationContainer)aggregation;
+                }
+
                 AddTermsOrder(termsAggregation, child, aggregation);
             }
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
@@ -54,7 +54,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
 
         foreach (var (nestedPath, childAggregations) in nestedAggregations)
         {
-            var nestedAgg = new NestedAggregation("nested_" + nestedPath)
+            var nestedAgg = new NestedAggregation($"nested_{nestedPath}")
             {
                 Path = nestedPath,
                 Aggregations = new AggregationDictionary()
@@ -65,7 +65,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
                 var nestedFilter = child.GetNestedFilter();
                 if (nestedFilter is not null)
                 {
-                    var filteredAgg = new FilterAggregation("filtered_" + ((IAggregation)aggregation).Name)
+                    var filteredAgg = new FilterAggregation($"filtered_{((IAggregation)aggregation).Name}")
                     {
                         Filter = nestedFilter,
                         Aggregations = new AggregationDictionary
@@ -80,7 +80,10 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
                     nestedAgg.Aggregations[((IAggregation)aggregation).Name] = (AggregationContainer)aggregation;
                 }
 
-                AddTermsOrder(termsAggregation, child, aggregation);
+                if (nestedFilter is not null)
+                    AddTermsOrder(termsAggregation, child, aggregation, $"nested_{nestedPath}>filtered_{((IAggregation)aggregation).Name}>");
+                else
+                    AddTermsOrder(termsAggregation, child, aggregation);
             }
 
             if (container is BucketAggregationBase bucketContainer)
@@ -90,7 +93,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
             }
         }
 
-        if (node.Parent == null)
+        if (node.Parent is null)
             node.SetAggregation(container);
     }
 
@@ -105,16 +108,19 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
         AddTermsOrder(termsAggregation, child, aggregation);
     }
 
-    private static void AddTermsOrder(ITermsAggregation termsAggregation, IFieldQueryNode child, AggregationBase aggregation)
+    private static void AddTermsOrder(ITermsAggregation termsAggregation, IFieldQueryNode child, AggregationBase aggregation, string bucketPathPrefix = null)
     {
-        if (termsAggregation is null || (child.Prefix != "-" && child.Prefix != "+"))
+        if (termsAggregation is null || child.Prefix is not "-" and not "+")
             return;
+
+        string aggName = ((IAggregation)aggregation).Name;
+        string key = bucketPathPrefix is not null ? $"{bucketPathPrefix}{aggName}" : aggName;
 
         termsAggregation.Order ??= new List<TermsOrder>();
         termsAggregation.Order.Add(new TermsOrder
         {
-            Key = ((IAggregation)aggregation).Name,
-            Order = child.Prefix == "-" ? SortOrder.Descending : SortOrder.Ascending
+            Key = key,
+            Order = child.Prefix is "-" ? SortOrder.Descending : SortOrder.Ascending
         });
     }
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -68,6 +68,7 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         foreach (var (path, pathQueries) in nestedQueries)
         {
             QueryContainer combinedInner = null;
+            QueryContainer nestedFilter = null;
             foreach (var (child, innerQuery) in pathQueries)
             {
                 QueryContainer q = innerQuery;
@@ -75,7 +76,11 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
                     q = !q;
 
                 combinedInner = Combine(combinedInner, q, op);
+                nestedFilter ??= child.GetNestedFilter();
             }
+
+            if (nestedFilter is not null)
+                combinedInner &= nestedFilter;
 
             QueryBase combinedNested = new NestedQuery { Path = path, Query = combinedInner };
             container = Combine(container, combinedNested, op);
@@ -83,7 +88,18 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
 
         if (nested is not null)
         {
-            nested.Query = container;
+            var nestedFilter = node.GetNestedFilter();
+            if (nestedFilter is not null)
+            {
+                QueryContainer inner = container;
+                inner &= nestedFilter;
+                nested.Query = inner;
+            }
+            else
+            {
+                nested.Query = container;
+            }
+
             node.SetQuery(nested);
         }
         else

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -111,17 +111,17 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
     private static GroupOperator GetEffectiveOperator(GroupNode node, IElasticQueryVisitorContext context)
     {
         var op = node.GetOperator(context);
-        if (op == GroupOperator.Or && node.IsRequired())
+        if (op is GroupOperator.Or && node.IsRequired())
             op = GroupOperator.And;
         return op;
     }
 
     private static QueryBase Combine(QueryBase left, QueryBase right, GroupOperator op)
     {
-        if (op == GroupOperator.And)
+        if (op is GroupOperator.And)
             return left & right;
 
-        if (op == GroupOperator.Or)
+        if (op is GroupOperator.Or)
             return left | right;
 
         return left;
@@ -129,10 +129,10 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
 
     private static QueryContainer Combine(QueryContainer left, QueryContainer right, GroupOperator op)
     {
-        if (op == GroupOperator.And)
+        if (op is GroupOperator.And)
             return left & right;
 
-        if (op == GroupOperator.Or)
+        if (op is GroupOperator.Or)
             return left | right;
 
         return left;

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -19,33 +19,32 @@ public class NestedVisitor : ChainableQueryVisitor
         _filterResolver = filterResolver;
     }
 
-    public override async Task VisitAsync(GroupNode node, IQueryVisitorContext context)
+    public override Task VisitAsync(GroupNode node, IQueryVisitorContext context)
     {
         if (String.IsNullOrEmpty(node.Field))
-        {
-            await base.VisitAsync(node, context).ConfigureAwait(false);
-            return;
-        }
+            return base.VisitAsync(node, context);
 
         string nestedProperty = GetNestedProperty(node.Field, context);
         if (nestedProperty is null)
-        {
-            await base.VisitAsync(node, context).ConfigureAwait(false);
-            return;
-        }
+            return base.VisitAsync(node, context);
 
         node.SetNestedPath(nestedProperty);
         if (context.QueryType is not QueryTypes.Aggregation and not QueryTypes.Sort)
             node.SetQuery(new NestedQuery { Path = nestedProperty });
 
         if (_filterResolver is not null)
-        {
-            string originalField = node.GetOriginalField();
-            ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
-            var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
-            if (filter is not null)
-                node.SetNestedFilter(filter);
-        }
+            return VisitGroupWithFilterAsync(node, nestedProperty, context);
+
+        return base.VisitAsync(node, context);
+    }
+
+    private async Task VisitGroupWithFilterAsync(GroupNode node, string nestedProperty, IQueryVisitorContext context)
+    {
+        string originalField = node.GetOriginalField();
+        ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
+        var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
+        if (filter is not null)
+            node.SetNestedFilter(filter);
 
         await base.VisitAsync(node, context).ConfigureAwait(false);
     }
@@ -70,23 +69,37 @@ public class NestedVisitor : ChainableQueryVisitor
         return HandleNestedFieldNodeAsync(node, context);
     }
 
-    private async Task HandleNestedFieldNodeAsync(IFieldQueryNode node, IQueryVisitorContext context)
+    private Task HandleNestedFieldNodeAsync(IFieldQueryNode node, IQueryVisitorContext context)
     {
         if (IsInsideNestedGroup(node))
-            return;
+            return Task.CompletedTask;
 
         string nestedProperty = GetNestedProperty(node.Field, context);
         if (nestedProperty is null)
-            return;
+            return Task.CompletedTask;
 
         if (_filterResolver is not null)
+            return HandleNestedFieldWithFilterAsync(node, nestedProperty, context);
+
+        if (context.QueryType is QueryTypes.Aggregation or QueryTypes.Sort)
         {
-            string originalField = node.GetOriginalField();
-            ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
-            var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
-            if (filter is not null)
-                node.SetNestedFilter(filter);
+            node.SetNestedPath(nestedProperty);
+            return Task.CompletedTask;
         }
+
+        if (context.QueryType is QueryTypes.Query)
+            return WrapInNestedQueryAsync(node, nestedProperty, context);
+
+        return Task.CompletedTask;
+    }
+
+    private async Task HandleNestedFieldWithFilterAsync(IFieldQueryNode node, string nestedProperty, IQueryVisitorContext context)
+    {
+        string originalField = node.GetOriginalField();
+        ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
+        var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
+        if (filter is not null)
+            node.SetNestedFilter(filter);
 
         if (context.QueryType is QueryTypes.Aggregation or QueryTypes.Sort)
         {
@@ -100,6 +113,15 @@ public class NestedVisitor : ChainableQueryVisitor
 
             node.SetQuery(new NestedQuery { Path = nestedProperty, Query = innerQuery });
         }
+    }
+
+    private static async Task WrapInNestedQueryAsync(IFieldQueryNode node, string nestedProperty, IQueryVisitorContext context)
+    {
+        var innerQuery = await node.GetQueryAsync(() => node.GetDefaultQueryAsync(context)).ConfigureAwait(false);
+        if (innerQuery is null)
+            return;
+
+        node.SetQuery(new NestedQuery { Path = nestedProperty, Query = innerQuery });
     }
 
     private static bool IsInsideNestedGroup(IQueryNode node)

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -41,6 +41,7 @@ public class NestedVisitor : ChainableQueryVisitor
         if (_filterResolver is not null)
         {
             string originalField = node.GetOriginalField();
+            ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
             var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
             if (filter is not null)
                 node.SetNestedFilter(filter);
@@ -71,7 +72,6 @@ public class NestedVisitor : ChainableQueryVisitor
 
     private async Task HandleNestedFieldNodeAsync(IFieldQueryNode node, IQueryVisitorContext context)
     {
-        // Skip if inside a group that references a nested path
         if (IsInsideNestedGroup(node))
             return;
 
@@ -82,6 +82,7 @@ public class NestedVisitor : ChainableQueryVisitor
         if (_filterResolver is not null)
         {
             string originalField = node.GetOriginalField();
+            ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
             var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
             if (filter is not null)
                 node.SetNestedFilter(filter);
@@ -91,7 +92,7 @@ public class NestedVisitor : ChainableQueryVisitor
         {
             node.SetNestedPath(nestedProperty);
         }
-        else if (context.QueryType == QueryTypes.Query)
+        else if (context.QueryType is QueryTypes.Query)
         {
             var innerQuery = await node.GetQueryAsync(() => node.GetDefaultQueryAsync(context)).ConfigureAwait(false);
             if (innerQuery is null)

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Foundatio.Parsers.ElasticQueries.Extensions;
 using Foundatio.Parsers.LuceneQueries;
+using Foundatio.Parsers.LuceneQueries.Extensions;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Parsers.LuceneQueries.Visitors;
 using Nest;
@@ -11,20 +12,41 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors;
 
 public class NestedVisitor : ChainableQueryVisitor
 {
-    public override Task VisitAsync(GroupNode node, IQueryVisitorContext context)
+    private readonly NestedFilterResolver _filterResolver;
+
+    public NestedVisitor(NestedFilterResolver filterResolver = null)
+    {
+        _filterResolver = filterResolver;
+    }
+
+    public override async Task VisitAsync(GroupNode node, IQueryVisitorContext context)
     {
         if (String.IsNullOrEmpty(node.Field))
-            return base.VisitAsync(node, context);
+        {
+            await base.VisitAsync(node, context);
+            return;
+        }
 
         string nestedProperty = GetNestedProperty(node.Field, context);
         if (nestedProperty is null)
-            return base.VisitAsync(node, context);
+        {
+            await base.VisitAsync(node, context);
+            return;
+        }
 
         node.SetNestedPath(nestedProperty);
         if (context.QueryType is not QueryTypes.Aggregation and not QueryTypes.Sort)
             node.SetQuery(new NestedQuery { Path = nestedProperty });
 
-        return base.VisitAsync(node, context);
+        if (_filterResolver is not null)
+        {
+            string originalField = node.GetOriginalField();
+            var filter = await _filterResolver(nestedProperty, originalField, node.Field, context);
+            if (filter is not null)
+                node.SetNestedFilter(filter);
+        }
+
+        await base.VisitAsync(node, context);
     }
 
     public override Task VisitAsync(TermNode node, IQueryVisitorContext context)
@@ -56,6 +78,14 @@ public class NestedVisitor : ChainableQueryVisitor
         string nestedProperty = GetNestedProperty(node.Field, context);
         if (nestedProperty is null)
             return;
+
+        if (_filterResolver is not null)
+        {
+            string originalField = node.GetOriginalField();
+            var filter = await _filterResolver(nestedProperty, originalField, node.Field, context);
+            if (filter is not null)
+                node.SetNestedFilter(filter);
+        }
 
         if (context.QueryType is QueryTypes.Aggregation or QueryTypes.Sort)
         {

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -23,14 +23,14 @@ public class NestedVisitor : ChainableQueryVisitor
     {
         if (String.IsNullOrEmpty(node.Field))
         {
-            await base.VisitAsync(node, context);
+            await base.VisitAsync(node, context).ConfigureAwait(false);
             return;
         }
 
         string nestedProperty = GetNestedProperty(node.Field, context);
         if (nestedProperty is null)
         {
-            await base.VisitAsync(node, context);
+            await base.VisitAsync(node, context).ConfigureAwait(false);
             return;
         }
 
@@ -41,12 +41,12 @@ public class NestedVisitor : ChainableQueryVisitor
         if (_filterResolver is not null)
         {
             string originalField = node.GetOriginalField();
-            var filter = await _filterResolver(nestedProperty, originalField, node.Field, context);
+            var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
             if (filter is not null)
                 node.SetNestedFilter(filter);
         }
 
-        await base.VisitAsync(node, context);
+        await base.VisitAsync(node, context).ConfigureAwait(false);
     }
 
     public override Task VisitAsync(TermNode node, IQueryVisitorContext context)
@@ -82,7 +82,7 @@ public class NestedVisitor : ChainableQueryVisitor
         if (_filterResolver is not null)
         {
             string originalField = node.GetOriginalField();
-            var filter = await _filterResolver(nestedProperty, originalField, node.Field, context);
+            var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
             if (filter is not null)
                 node.SetNestedFilter(filter);
         }
@@ -93,7 +93,7 @@ public class NestedVisitor : ChainableQueryVisitor
         }
         else if (context.QueryType == QueryTypes.Query)
         {
-            var innerQuery = await node.GetQueryAsync(() => node.GetDefaultQueryAsync(context));
+            var innerQuery = await node.GetQueryAsync(() => node.GetDefaultQueryAsync(context)).ConfigureAwait(false);
             if (innerQuery is null)
                 return;
 

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParserConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries;
@@ -157,8 +157,6 @@ public class SqlQueryParserConfiguration
         return "DateOnly.Parse(\"" + dateOnlyValue + "\")";
     }
 
-    #region Combined Visitor Management
-
     public SqlQueryParserConfiguration AddVisitor(IChainableQueryVisitor visitor, int priority = 0)
     {
         QueryVisitor.AddVisitor(visitor, priority);
@@ -204,10 +202,6 @@ public class SqlQueryParserConfiguration
         return this;
     }
 
-    #endregion
-
-    #region Query Visitor Management
-
     public SqlQueryParserConfiguration AddQueryVisitor(IChainableQueryVisitor visitor, int priority = 0)
     {
         QueryVisitor.AddVisitor(visitor, priority);
@@ -242,10 +236,6 @@ public class SqlQueryParserConfiguration
 
         return this;
     }
-
-    #endregion
-
-    #region Sort Visitor Management
 
     public SqlQueryParserConfiguration AddSortVisitor(IChainableQueryVisitor visitor, int priority = 0)
     {
@@ -282,10 +272,6 @@ public class SqlQueryParserConfiguration
         return this;
     }
 
-    #endregion
-
-    #region Aggregation Visitor Management
-
     public SqlQueryParserConfiguration AddAggregationVisitor(IChainableQueryVisitor visitor, int priority = 0)
     {
         AggregationVisitor.AddVisitor(visitor, priority);
@@ -321,7 +307,6 @@ public class SqlQueryParserConfiguration
         return this;
     }
 
-    #endregion
 }
 
 public delegate bool EntityTypeNavigationFilter(INavigation navigation);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
@@ -1375,4 +1375,482 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         public string Payload { get; set; }
         public IList<MyType> Nested { get; set; } = new List<MyType>();
     }
+
+    #region Nested Filter Resolver Tests
+
+    [Fact]
+    public async Task NestedFilterQuery_WithResellerFilter_AddsFilterToNestedInnerQuery()
+    {
+        // Arrange
+        string index = CreateRandomIndex<Product>(d => d.Properties(p => p
+            .Text(e => e.Name(n => n.Name))
+            .Keyword(e => e.Name(n => n.Category))
+            .Nested<Reseller>(r => r.Name(n => n.Resellers.First()).Properties(p1 => p1
+                .Keyword(e => e.Name(n => n.Name))
+                .Number(e => e.Name(n => n.Price).Type(NumberType.Double))
+            ))
+        ));
+
+        await Client.IndexManyAsync([
+            new Product
+            {
+                Name = "Widget",
+                Resellers =
+                {
+                    new Reseller { Name = "Official", Price = 10.0 },
+                    new Reseller { Name = "ThirdParty", Price = 8.0 }
+                }
+            }
+        ], cancellationToken: TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, ct: TestCancellationToken);
+
+        var processor = new ElasticQueryParser(c => c
+            .SetLoggerFactory(Log)
+            .UseMappings<Product>(Client)
+            .UseNestedFilter((path, orig, resolved, ctx) =>
+                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+            .UseNested());
+
+        // Act
+        var result = await processor.BuildQueryAsync("resellers.price:10", new ElasticQueryVisitorContext { UseScoring = true });
+
+        // Assert
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Query(_ => result));
+        string actualRequest = actualResponse.GetRequest();
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = Client.Search<Product>(d => d.Index(index)
+            .Query(q => q.Nested(n => n
+                .Path("resellers")
+                .Query(q2 => q2.Term(t => t.Field("resellers.price").Value(10.0))
+                    && q2.Term(t => t.Field("resellers.name").Value("Official"))))));
+
+        string expectedRequest = expectedResponse.GetRequest();
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+        Assert.Equal(expectedResponse.Total, actualResponse.Total);
+    }
+
+    [Fact]
+    public async Task NestedFilterQuery_WithMultipleFieldsSamePath_AppliesFilterOnceInCoalescedQuery()
+    {
+        // Arrange
+        string index = CreateRandomIndex<Product>(d => d.Properties(p => p
+            .Text(e => e.Name(n => n.Name))
+            .Nested<Reseller>(r => r.Name(n => n.Resellers.First()).Properties(p1 => p1
+                .Keyword(e => e.Name(n => n.Name))
+                .Number(e => e.Name(n => n.Price).Type(NumberType.Double))
+            ))
+        ));
+
+        await Client.IndexManyAsync([
+            new Product
+            {
+                Name = "Widget",
+                Resellers =
+                {
+                    new Reseller { Name = "Official", Price = 10.0 },
+                    new Reseller { Name = "ThirdParty", Price = 8.0 }
+                }
+            }
+        ], cancellationToken: TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, ct: TestCancellationToken);
+
+        var processor = new ElasticQueryParser(c => c
+            .SetLoggerFactory(Log)
+            .UseMappings<Product>(Client)
+            .UseNestedFilter((path, orig, resolved, ctx) =>
+                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+            .UseNested());
+
+        // Act
+        var result = await processor.BuildQueryAsync("resellers.name:Official AND resellers.price:10", new ElasticQueryVisitorContext { UseScoring = true });
+
+        // Assert
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Query(_ => result));
+        string actualRequest = actualResponse.GetRequest();
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = Client.Search<Product>(d => d.Index(index)
+            .Query(q => q.Nested(n => n
+                .Path("resellers")
+                .Query(q2 => q2.Term(t => t.Field("resellers.name").Value("Official"))
+                    && q2.Term(t => t.Field("resellers.price").Value(10.0))
+                    && q2.Term(t => t.Field("resellers.name").Value("Official"))))));
+
+        string expectedRequest = expectedResponse.GetRequest();
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+        Assert.Equal(expectedResponse.Total, actualResponse.Total);
+    }
+
+    [Fact]
+    public async Task NestedFilterAggregation_WithResellerFilter_WrapsInFilterAggregation()
+    {
+        // Arrange
+        string index = CreateRandomIndex<Product>(d => d.Properties(p => p
+            .Text(e => e.Name(n => n.Name))
+            .Nested<Reseller>(r => r.Name(n => n.Resellers.First()).Properties(p1 => p1
+                .Keyword(e => e.Name(n => n.Name))
+                .Number(e => e.Name(n => n.Price).Type(NumberType.Double))
+            ))
+        ));
+
+        await Client.IndexManyAsync([
+            new Product
+            {
+                Name = "Widget",
+                Resellers =
+                {
+                    new Reseller { Name = "Official", Price = 10.0 },
+                    new Reseller { Name = "ThirdParty", Price = 8.0 }
+                }
+            }
+        ], cancellationToken: TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, ct: TestCancellationToken);
+
+        var processor = new ElasticQueryParser(c => c
+            .SetLoggerFactory(Log)
+            .UseMappings<Product>(Client)
+            .UseNestedFilter((path, orig, resolved, ctx) =>
+                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+            .UseNested());
+
+        // Act
+        var result = await processor.BuildAggregationsAsync("max:resellers.price");
+
+        // Assert
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result));
+        string actualRequest = actualResponse.GetRequest();
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = Client.Search<Product>(d => d.Index(index)
+            .Aggregations(a => a
+                .Nested("nested_resellers", n => n
+                    .Path("resellers")
+                    .Aggregations(na => na
+                        .Filter("filtered_max_resellers.price", f => f
+                            .Filter(fq => fq.Term(t => t.Field("resellers.name").Value("Official")))
+                            .Aggregations(fa => fa
+                                .Max("max_resellers.price", m => m
+                                    .Field("resellers.price")
+                                    .Meta(m2 => m2.Add("@field_type", "double")))))))));
+
+        string expectedRequest = expectedResponse.GetRequest();
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+    }
+
+    [Fact]
+    public async Task NestedFilterSort_WithResellerFilter_SetsNestedSortFilter()
+    {
+        // Arrange
+        string index = CreateRandomIndex<Product>(d => d.Properties(p => p
+            .Text(e => e.Name(n => n.Name))
+            .Nested<Reseller>(r => r.Name(n => n.Resellers.First()).Properties(p1 => p1
+                .Keyword(e => e.Name(n => n.Name))
+                .Number(e => e.Name(n => n.Price).Type(NumberType.Double))
+            ))
+        ));
+
+        await Client.IndexManyAsync([
+            new Product
+            {
+                Name = "Widget",
+                Resellers =
+                {
+                    new Reseller { Name = "Official", Price = 10.0 },
+                    new Reseller { Name = "ThirdParty", Price = 8.0 }
+                }
+            }
+        ], cancellationToken: TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, ct: TestCancellationToken);
+
+        var processor = new ElasticQueryParser(c => c
+            .SetLoggerFactory(Log)
+            .UseMappings<Product>(Client)
+            .UseNestedFilter((path, orig, resolved, ctx) =>
+                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+            .UseNested());
+
+        // Act
+        var sort = await processor.BuildSortAsync("-resellers.price");
+
+        // Assert
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Sort(sort));
+        string actualRequest = actualResponse.GetRequest();
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = Client.Search<Product>(d => d.Index(index)
+            .Sort(s => s.Field(f => f
+                .Field("resellers.price")
+                .Order(SortOrder.Descending)
+                .UnmappedType(FieldType.Double)
+                .Nested(n => n
+                    .Path("resellers")
+                    .Filter(fq => fq.Term(t => t.Field("resellers.name").Value("Official")))))));
+
+        string expectedRequest = expectedResponse.GetRequest();
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+        Assert.True(actualResponse.IsValid);
+    }
+
+    [Fact]
+    public async Task NestedFilterQuery_WithGroupedNestedFields_AddsFilterToGroupInnerQuery()
+    {
+        // Arrange
+        string index = CreateRandomIndex<Product>(d => d.Properties(p => p
+            .Text(e => e.Name(n => n.Name))
+            .Nested<Reseller>(r => r.Name(n => n.Resellers.First()).Properties(p1 => p1
+                .Keyword(e => e.Name(n => n.Name))
+                .Number(e => e.Name(n => n.Price).Type(NumberType.Double))
+            ))
+        ));
+
+        await Client.IndexManyAsync([
+            new Product
+            {
+                Name = "Widget",
+                Resellers =
+                {
+                    new Reseller { Name = "Official", Price = 10.0 },
+                    new Reseller { Name = "ThirdParty", Price = 8.0 }
+                }
+            }
+        ], cancellationToken: TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, ct: TestCancellationToken);
+
+        var processor = new ElasticQueryParser(c => c
+            .SetLoggerFactory(Log)
+            .UseMappings<Product>(Client)
+            .UseNestedFilter((path, orig, resolved, ctx) =>
+                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+            .UseNested());
+
+        // Act
+        var result = await processor.BuildQueryAsync("resellers:(resellers.name:Official resellers.price:10)", new ElasticQueryVisitorContext { UseScoring = true });
+
+        // Assert
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Query(_ => result));
+        string actualRequest = actualResponse.GetRequest();
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = Client.Search<Product>(d => d.Index(index)
+            .Query(q => q.Nested(n => n
+                .Path("resellers")
+                .Query(q2 => q2.Term(t => t.Field("resellers.name").Value("Official"))
+                    && q2.Term(t => t.Field("resellers.price").Value(10.0))
+                    && q2.Term(t => t.Field("resellers.name").Value("Official"))))));
+
+        string expectedRequest = expectedResponse.GetRequest();
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+        Assert.Equal(expectedResponse.Total, actualResponse.Total);
+    }
+
+    [Fact]
+    public async Task NestedFilterQuery_WithNullResolver_ProducesUnfilteredNestedQuery()
+    {
+        // Arrange
+        string index = CreateRandomIndex<Product>(d => d.Properties(p => p
+            .Text(e => e.Name(n => n.Name))
+            .Nested<Reseller>(r => r.Name(n => n.Resellers.First()).Properties(p1 => p1
+                .Keyword(e => e.Name(n => n.Name))
+                .Number(e => e.Name(n => n.Price).Type(NumberType.Double))
+            ))
+        ));
+
+        await Client.IndexManyAsync([
+            new Product
+            {
+                Name = "Widget",
+                Resellers = { new Reseller { Name = "Official", Price = 10.0 } }
+            }
+        ], cancellationToken: TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, ct: TestCancellationToken);
+
+        var processor = new ElasticQueryParser(c => c
+            .SetLoggerFactory(Log)
+            .UseMappings<Product>(Client)
+            .UseNestedFilter((path, orig, resolved, ctx) => (QueryContainer)null)
+            .UseNested());
+
+        // Act
+        var result = await processor.BuildQueryAsync("resellers.price:10", new ElasticQueryVisitorContext { UseScoring = true });
+
+        // Assert
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Query(_ => result));
+        string actualRequest = actualResponse.GetRequest();
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = Client.Search<Product>(d => d.Index(index)
+            .Query(q => q.Nested(n => n
+                .Path("resellers")
+                .Query(q2 => q2.Term(t => t.Field("resellers.price").Value(10.0))))));
+
+        string expectedRequest = expectedResponse.GetRequest();
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+        Assert.Equal(expectedResponse.Total, actualResponse.Total);
+    }
+
+    [Fact]
+    public async Task NestedFilterQuery_WithMultiplePaths_AppliesDifferentFiltersPerPath()
+    {
+        // Arrange
+        string index = CreateRandomIndex<MultiNestedProduct>(d => d.Properties(p => p
+            .Text(e => e.Name(n => n.Name))
+            .Nested<Reseller>(r => r.Name(n => n.Resellers.First()).Properties(p1 => p1
+                .Keyword(e => e.Name(n => n.Name))
+                .Number(e => e.Name(n => n.Price).Type(NumberType.Double))
+            ))
+            .Nested<Tag>(r => r.Name(n => n.Tags.First()).Properties(p1 => p1
+                .Keyword(e => e.Name(n => n.Label))
+            ))
+        ));
+
+        await Client.IndexManyAsync([
+            new MultiNestedProduct
+            {
+                Name = "Widget",
+                Resellers = { new Reseller { Name = "Official", Price = 10.0 } },
+                Tags = { new Tag { Label = "sale" } }
+            }
+        ], cancellationToken: TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, ct: TestCancellationToken);
+
+        var processor = new ElasticQueryParser(c => c
+            .SetLoggerFactory(Log)
+            .UseMappings<MultiNestedProduct>(Client)
+            .UseNestedFilter((path, orig, resolved, ctx) => path switch
+            {
+                "resellers" => new TermQuery { Field = "resellers.name", Value = "Official" },
+                "tags" => new TermQuery { Field = "tags.label", Value = "sale" },
+                _ => null
+            })
+            .UseNested());
+
+        // Act
+        var result = await processor.BuildQueryAsync("resellers.price:10 AND tags.label:sale", new ElasticQueryVisitorContext { UseScoring = true });
+
+        // Assert
+        var actualResponse = Client.Search<MultiNestedProduct>(d => d.Index(index).Query(_ => result));
+        string actualRequest = actualResponse.GetRequest();
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = Client.Search<MultiNestedProduct>(d => d.Index(index)
+            .Query(q =>
+                q.Nested(n => n
+                    .Path("resellers")
+                    .Query(q2 => q2.Term(t => t.Field("resellers.price").Value(10.0))
+                        && q2.Term(t => t.Field("resellers.name").Value("Official"))))
+                && q.Nested(n => n
+                    .Path("tags")
+                    .Query(q2 => q2.Term(t => t.Field("tags.label").Value("sale"))
+                        && q2.Term(t => t.Field("tags.label").Value("sale"))))));
+
+        string expectedRequest = expectedResponse.GetRequest();
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+        Assert.Equal(expectedResponse.Total, actualResponse.Total);
+    }
+
+    [Fact]
+    public async Task NestedFilterAggregation_WithMultipleFields_EachGetsOwnFilterAggregation()
+    {
+        // Arrange
+        string index = CreateRandomIndex<Product>(d => d.Properties(p => p
+            .Text(e => e.Name(n => n.Name))
+            .Nested<Reseller>(r => r.Name(n => n.Resellers.First()).Properties(p1 => p1
+                .Keyword(e => e.Name(n => n.Name))
+                .Number(e => e.Name(n => n.Price).Type(NumberType.Double))
+            ))
+        ));
+
+        await Client.IndexManyAsync([
+            new Product
+            {
+                Name = "Widget",
+                Resellers =
+                {
+                    new Reseller { Name = "Official", Price = 10.0 },
+                    new Reseller { Name = "ThirdParty", Price = 8.0 }
+                }
+            }
+        ], cancellationToken: TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, ct: TestCancellationToken);
+
+        var processor = new ElasticQueryParser(c => c
+            .SetLoggerFactory(Log)
+            .UseMappings<Product>(Client)
+            .UseNestedFilter((path, orig, resolved, ctx) =>
+                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+            .UseNested());
+
+        // Act
+        var result = await processor.BuildAggregationsAsync("max:resellers.price terms:resellers.name");
+
+        // Assert
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result));
+        string actualRequest = actualResponse.GetRequest();
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = Client.Search<Product>(d => d.Index(index)
+            .Aggregations(a => a
+                .Nested("nested_resellers", n => n
+                    .Path("resellers")
+                    .Aggregations(na => na
+                        .Filter("filtered_terms_resellers.name", f => f
+                            .Filter(fq => fq.Term(t => t.Field("resellers.name").Value("Official")))
+                            .Aggregations(fa => fa
+                                .Terms("terms_resellers.name", ts => ts
+                                    .Field("resellers.name")
+                                    .Meta(m => m.Add("@field_type", "keyword")))))
+                        .Filter("filtered_max_resellers.price", f => f
+                            .Filter(fq => fq.Term(t => t.Field("resellers.name").Value("Official")))
+                            .Aggregations(fa => fa
+                                .Max("max_resellers.price", m => m
+                                    .Field("resellers.price")
+                                    .Meta(m2 => m2.Add("@field_type", "double")))))))));
+
+        string expectedRequest = expectedResponse.GetRequest();
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+    }
+
+    public class Product
+    {
+        public string Name { get; set; }
+        public string Category { get; set; }
+        public IList<Reseller> Resellers { get; set; } = new List<Reseller>();
+    }
+
+    public class MultiNestedProduct
+    {
+        public string Name { get; set; }
+        public IList<Reseller> Resellers { get; set; } = new List<Reseller>();
+        public IList<Tag> Tags { get; set; } = new List<Tag>();
+    }
+
+    public class Reseller
+    {
+        public string Name { get; set; }
+        public double Price { get; set; }
+    }
+
+    public class Tag
+    {
+        public string Label { get; set; }
+    }
+
+    #endregion
 }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
@@ -1376,8 +1376,6 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         public IList<MyType> Nested { get; set; } = new List<MyType>();
     }
 
-    #region Nested Filter Resolver Tests
-
     [Fact]
     public async Task NestedFilterQuery_WithResellerFilter_AddsFilterToNestedInnerQuery()
     {
@@ -1408,7 +1406,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
             .SetLoggerFactory(Log)
             .UseMappings<Product>(Client)
             .UseNestedFilter((path, orig, resolved, ctx) =>
-                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+                path is "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
             .UseNested());
 
         // Act
@@ -1461,7 +1459,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
             .SetLoggerFactory(Log)
             .UseMappings<Product>(Client)
             .UseNestedFilter((path, orig, resolved, ctx) =>
-                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+                path is "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
             .UseNested());
 
         // Act
@@ -1515,7 +1513,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
             .SetLoggerFactory(Log)
             .UseMappings<Product>(Client)
             .UseNestedFilter((path, orig, resolved, ctx) =>
-                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+                path is "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
             .UseNested());
 
         // Act
@@ -1573,7 +1571,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
             .SetLoggerFactory(Log)
             .UseMappings<Product>(Client)
             .UseNestedFilter((path, orig, resolved, ctx) =>
-                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+                path is "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
             .UseNested());
 
         // Act
@@ -1629,7 +1627,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
             .SetLoggerFactory(Log)
             .UseMappings<Product>(Client)
             .UseNestedFilter((path, orig, resolved, ctx) =>
-                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+                path is "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
             .UseNested());
 
         // Act
@@ -1792,7 +1790,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
             .SetLoggerFactory(Log)
             .UseMappings<Product>(Client)
             .UseNestedFilter((path, orig, resolved, ctx) =>
-                path == "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
+                path is "resellers" ? new TermQuery { Field = "resellers.name", Value = "Official" } : null)
             .UseNested());
 
         // Act
@@ -1851,6 +1849,4 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
     {
         public string Label { get; set; }
     }
-
-    #endregion
 }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
@@ -1808,18 +1808,18 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
                 .Nested("nested_resellers", n => n
                     .Path("resellers")
                     .Aggregations(na => na
-                        .Filter("filtered_terms_resellers.name", f => f
-                            .Filter(fq => fq.Term(t => t.Field("resellers.name").Value("Official")))
-                            .Aggregations(fa => fa
-                                .Terms("terms_resellers.name", ts => ts
-                                    .Field("resellers.name")
-                                    .Meta(m => m.Add("@field_type", "keyword")))))
                         .Filter("filtered_max_resellers.price", f => f
                             .Filter(fq => fq.Term(t => t.Field("resellers.name").Value("Official")))
                             .Aggregations(fa => fa
                                 .Max("max_resellers.price", m => m
                                     .Field("resellers.price")
-                                    .Meta(m2 => m2.Add("@field_type", "double")))))))));
+                                    .Meta(m2 => m2.Add("@field_type", "double")))))
+                        .Filter("filtered_terms_resellers.name", f => f
+                            .Filter(fq => fq.Term(t => t.Field("resellers.name").Value("Official")))
+                            .Aggregations(fa => fa
+                                .Terms("terms_resellers.name", ts => ts
+                                    .Field("resellers.name")
+                                    .Meta(m => m.Add("@field_type", "keyword")))))))));
 
         string expectedRequest = expectedResponse.GetRequest();
         _logger.LogInformation("Expected: {Request}", expectedRequest);


### PR DESCRIPTION
## Nested Filter Resolver

Adds `UseNestedFilter()` to `ElasticQueryParserConfiguration`, allowing consumers to inject discriminator filters inside nested queries, aggregations, and sorts. This addresses the common Elasticsearch pattern where a single nested array contains documents of different logical types (e.g., official vs third-party resellers, table section rows keyed by section) and each query/aggregation/sort must be scoped to a specific subset.

### Motivation

Without this feature, consumers must build custom visitors that manually wrap `NestedQuery`, `FilterAggregation`, and `NestedSort.Filter` -- duplicating logic that the built-in `NestedVisitor` and combining visitors already handle. This is brittle and breaks when the framework changes nested handling internals.

### Design

A new `NestedFilterResolver` delegate is called during `NestedVisitor` traversal for each node that introduces or participates in a nested scope:

```csharp
public delegate Task<QueryContainer> NestedFilterResolver(
    string nestedPath, string originalField, string resolvedField, IQueryVisitorContext context);
```

The resolver stores results as `@NestedFilter` metadata on AST nodes. Downstream visitors consume it:

- **`CombineQueriesVisitor`** -- AND-s the filter once per nested path into the coalesced inner query
- **`CombineAggregationsVisitor`** -- wraps each nested child aggregation in a `FilterAggregation`
- **`DefaultSortNodeExtensions`** -- sets `NestedSort.Filter` on the field sort

`UseNestedFilter()` and `UseNested()` are call-order safe via tracked `_nestedPriority`. Both async and sync overloads are provided.

### Changes

| File | Change |
|------|--------|
| `ElasticQueryParserConfiguration.cs` | `NestedFilterResolver` delegate, `UseNestedFilter()` (async+sync), `_nestedPriority` tracking |
| `QueryNodeExtensions.cs` | `GetNestedFilter` / `SetNestedFilter` / `RemoveNestedFilter` |
| `NestedVisitor.cs` | Accepts resolver, calls it for nested nodes, stores `@NestedFilter` metadata |
| `CombineQueriesVisitor.cs` | Reads `@NestedFilter`, applies once per coalesced nested path + explicit groups |
| `CombineAggregationsVisitor.cs` | Reads `@NestedFilter`, wraps in `FilterAggregation` per child |
| `DefaultSortNodeExtensions.cs` | Reads `@NestedFilter`, sets `NestedSort.Filter` (only when non-null) |
| `ElasticNestedQueryParserTests.cs` | 8 new integration tests (Product/Reseller/Tag model) |
| `docs/guide/*.md` | Documentation for all three doc pages |

### Test Coverage

| Test | Scenario |
|------|----------|
| `NestedFilterQuery_WithResellerFilter_AddsFilterToNestedInnerQuery` | Single field query with filter |
| `NestedFilterQuery_WithMultipleFieldsSamePath_AppliesFilterOnceInCoalescedQuery` | Multiple fields coalesced, filter applied once |
| `NestedFilterAggregation_WithResellerFilter_WrapsInFilterAggregation` | Aggregation wrapped in FilterAgg |
| `NestedFilterSort_WithResellerFilter_SetsNestedSortFilter` | Sort with NestedSort.Filter |
| `NestedFilterQuery_WithGroupedNestedFields_AddsFilterToGroupInnerQuery` | Explicit grouped nested query |
| `NestedFilterQuery_WithNullResolver_ProducesUnfilteredNestedQuery` | Null-returning resolver (no filter) |
| `NestedFilterQuery_WithMultiplePaths_AppliesDifferentFiltersPerPath` | Multiple nested paths, different filters |
| `NestedFilterAggregation_WithMultipleFields_EachGetsOwnFilterAggregation` | Multiple agg fields each get own FilterAgg |
