### PR TITLE
Fix NRT errors and enable TreatWarningsAsErrors

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -15,6 +15,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
     <PackageIcon>foundatio-icon.png</PackageIcon>

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -174,9 +174,9 @@ public class ElasticMappingResolver : IDisposable
                 fieldMapping.Name = new PropertyName(clrOrigin.ClrOrigin);
 
             if (depth == 0)
-                resolvedFieldName += _inferrer?.PropertyName(fieldMapping.Name) ?? fieldMapping.Name?.Name ?? fieldPart;
+                resolvedFieldName += _inferrer!.PropertyName(fieldMapping.Name);
             else
-                resolvedFieldName += "." + (_inferrer?.PropertyName(fieldMapping.Name) ?? fieldMapping.Name?.Name ?? fieldPart);
+                resolvedFieldName += "." + _inferrer!.PropertyName(fieldMapping.Name);
 
             if (depth == fieldParts.Length - 1)
             {
@@ -232,10 +232,10 @@ public class ElasticMappingResolver : IDisposable
         return GetMapping(field, followAlias)?.Property;
     }
 
-    public string GetResolvedField(string? field)
+    public string? GetResolvedField(string? field)
     {
         var result = GetMapping(field, true);
-        return result?.FullPath ?? field ?? String.Empty;
+        return result?.FullPath ?? field;
     }
 
     public string GetResolvedField(Field field)
@@ -243,7 +243,7 @@ public class ElasticMappingResolver : IDisposable
         if (_inferrer == null)
             throw new InvalidOperationException("Unable to resolve Field without inferrer");
 
-        return GetResolvedField(_inferrer.Field(field));
+        return GetResolvedField(_inferrer.Field(field))!;
     }
 
     public string? GetSortFieldName(string? field)

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -12,9 +12,9 @@ namespace Foundatio.Parsers.ElasticQueries;
 
 public class ElasticMappingResolver : IDisposable
 {
-    private ITypeMapping _serverMapping;
-    private readonly ITypeMapping _codeMapping;
-    private readonly Inferrer _inferrer;
+    private ITypeMapping? _serverMapping;
+    private readonly ITypeMapping? _codeMapping;
+    private readonly Inferrer? _inferrer;
     private readonly ConcurrentDictionary<string, FieldMapping> _mappingCache = new();
     private readonly object _mappingLock = new();
     private readonly SemaphoreSlim _fetchSemaphore = new(1, 1);
@@ -24,7 +24,7 @@ public class ElasticMappingResolver : IDisposable
 
     public static ElasticMappingResolver NullInstance = new(() => null);
 
-    public ElasticMappingResolver(Func<ITypeMapping> getMapping, Inferrer inferrer = null, TimeProvider timeProvider = null, ILogger logger = null)
+    public ElasticMappingResolver(Func<ITypeMapping?> getMapping, Inferrer? inferrer = null, TimeProvider? timeProvider = null, ILogger? logger = null)
     {
         GetServerMappingFunc = getMapping;
         _inferrer = inferrer;
@@ -32,7 +32,7 @@ public class ElasticMappingResolver : IDisposable
         _logger = logger ?? NullLogger.Instance;
     }
 
-    public ElasticMappingResolver(ITypeMapping codeMapping, Inferrer inferrer, Func<ITypeMapping> getMapping, TimeProvider timeProvider = null, ILogger logger = null)
+    public ElasticMappingResolver(ITypeMapping codeMapping, Inferrer inferrer, Func<ITypeMapping?> getMapping, TimeProvider? timeProvider = null, ILogger? logger = null)
         : this(getMapping, inferrer, timeProvider, logger)
     {
         _codeMapping = codeMapping;
@@ -59,7 +59,7 @@ public class ElasticMappingResolver : IDisposable
         _logger.LogInformation("Mapping refresh triggered.");
     }
 
-    public FieldMapping GetMapping(string field, bool followAlias = false)
+    public FieldMapping? GetMapping(string? field, bool followAlias = false)
     {
         if (String.IsNullOrWhiteSpace(field))
             return null;
@@ -99,7 +99,7 @@ public class ElasticMappingResolver : IDisposable
 
         // Snapshot server mapping under lock so readers see a consistent pair of
         // _serverMapping + _lastMappingUpdateTicks (both are set together in GetServerMapping).
-        ITypeMapping serverMapping;
+        ITypeMapping? serverMapping;
         DateTime? mappingServerTime;
         lock (_mappingLock)
         {
@@ -124,14 +124,14 @@ public class ElasticMappingResolver : IDisposable
         for (int depth = 0; depth < fieldParts.Length; depth++)
         {
             string fieldPart = fieldParts[depth];
-            IProperty fieldMapping = null;
+            IProperty? fieldMapping = null;
             if (currentProperties == null || !currentProperties.TryGetValue(fieldPart, out fieldMapping))
             {
                 // check to see if there is an name match
                 if (currentProperties != null)
                     fieldMapping = currentProperties.Values.FirstOrDefault(m =>
                     {
-                        string propertyName = _inferrer.PropertyName(m?.Name);
+                        string? propertyName = _inferrer?.PropertyName(m?.Name);
                         return propertyName != null && propertyName.Equals(fieldPart, StringComparison.OrdinalIgnoreCase);
                     });
 
@@ -174,9 +174,9 @@ public class ElasticMappingResolver : IDisposable
                 fieldMapping.Name = new PropertyName(clrOrigin.ClrOrigin);
 
             if (depth == 0)
-                resolvedFieldName += _inferrer.PropertyName(fieldMapping.Name);
+                resolvedFieldName += _inferrer?.PropertyName(fieldMapping.Name) ?? fieldMapping.Name?.Name ?? fieldPart;
             else
-                resolvedFieldName += "." + _inferrer.PropertyName(fieldMapping.Name);
+                resolvedFieldName += "." + (_inferrer?.PropertyName(fieldMapping.Name) ?? fieldMapping.Name?.Name ?? fieldPart);
 
             if (depth == fieldParts.Length - 1)
             {
@@ -214,7 +214,7 @@ public class ElasticMappingResolver : IDisposable
         return notFoundMapping;
     }
 
-    public FieldMapping GetMapping(Field field, bool followAlias = false)
+    public FieldMapping? GetMapping(Field field, bool followAlias = false)
     {
         if (_inferrer == null)
             throw new InvalidOperationException("Unable to resolve Field without inferrer");
@@ -222,20 +222,20 @@ public class ElasticMappingResolver : IDisposable
         return GetMapping(_inferrer.Field(field), followAlias);
     }
 
-    public IProperty GetMappingProperty(string field, bool followAlias = false)
+    public IProperty? GetMappingProperty(string? field, bool followAlias = false)
     {
         return GetMapping(field, followAlias)?.Property;
     }
 
-    public IProperty GetMappingProperty(Field field, bool followAlias = false)
+    public IProperty? GetMappingProperty(Field field, bool followAlias = false)
     {
         return GetMapping(field, followAlias)?.Property;
     }
 
-    public string GetResolvedField(string field)
+    public string GetResolvedField(string? field)
     {
         var result = GetMapping(field, true);
-        return result?.FullPath ?? field;
+        return result?.FullPath ?? field ?? String.Empty;
     }
 
     public string GetResolvedField(Field field)
@@ -246,32 +246,32 @@ public class ElasticMappingResolver : IDisposable
         return GetResolvedField(_inferrer.Field(field));
     }
 
-    public string GetSortFieldName(string field)
+    public string? GetSortFieldName(string? field)
     {
         return GetNonAnalyzedFieldName(field, ElasticMapping.SortFieldName);
     }
 
     public string GetSortFieldName(Field field)
     {
-        return GetNonAnalyzedFieldName(GetResolvedField(field), ElasticMapping.SortFieldName);
+        return GetNonAnalyzedFieldName(GetResolvedField(field), ElasticMapping.SortFieldName)!;
     }
 
-    public string GetAggregationsFieldName(string field)
+    public string? GetAggregationsFieldName(string? field)
     {
         return GetNonAnalyzedFieldName(field, ElasticMapping.KeywordFieldName);
     }
 
     public string GetAggregationsFieldName(Field field)
     {
-        return GetNonAnalyzedFieldName(field, ElasticMapping.KeywordFieldName);
+        return GetNonAnalyzedFieldName(field, ElasticMapping.KeywordFieldName)!;
     }
 
-    public string GetNonAnalyzedFieldName(Field field, string preferredSubField = null)
+    public string GetNonAnalyzedFieldName(Field field, string? preferredSubField = null)
     {
-        return GetNonAnalyzedFieldName(GetResolvedField(field), preferredSubField);
+        return GetNonAnalyzedFieldName(GetResolvedField(field), preferredSubField)!;
     }
 
-    public string GetNonAnalyzedFieldName(string field, string preferredSubField = null)
+    public string? GetNonAnalyzedFieldName(string? field, string? preferredSubField = null)
     {
         if (String.IsNullOrEmpty(field))
             return field;
@@ -302,17 +302,17 @@ public class ElasticMappingResolver : IDisposable
         return mapping.FullPath;
     }
 
-    public bool IsPropertyAnalyzed(string field)
+    public bool IsPropertyAnalyzed(string? field)
     {
         // assume default is analyzed
         if (String.IsNullOrEmpty(field))
             return true;
 
         var property = GetMapping(field, true);
-        if (!property.Found)
+        if (property is null || !property.Found)
             return false;
 
-        return IsPropertyAnalyzed(property.Property);
+        return IsPropertyAnalyzed(property.Property!);
     }
 
     public bool IsPropertyAnalyzed(IProperty property)
@@ -323,7 +323,7 @@ public class ElasticMappingResolver : IDisposable
         return false;
     }
 
-    public bool IsNestedPropertyType(string field)
+    public bool IsNestedPropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
@@ -331,7 +331,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is INestedProperty;
     }
 
-    public bool IsGeoPropertyType(string field)
+    public bool IsGeoPropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
@@ -339,7 +339,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is IGeoPointProperty;
     }
 
-    public bool IsNumericPropertyType(string field)
+    public bool IsNumericPropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
@@ -347,7 +347,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is INumberProperty;
     }
 
-    public bool IsBooleanPropertyType(string field)
+    public bool IsBooleanPropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
@@ -355,7 +355,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is IBooleanProperty;
     }
 
-    public bool IsDatePropertyType(string field)
+    public bool IsDatePropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
@@ -363,7 +363,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is IDateProperty;
     }
 
-    public FieldType GetFieldType(string field)
+    public FieldType GetFieldType(string? field)
     {
         if (String.IsNullOrWhiteSpace(field))
             return FieldType.None;
@@ -407,12 +407,12 @@ public class ElasticMappingResolver : IDisposable
         };
     }
 
-    private IProperties MergeProperties(IProperties codeProperties, IProperties serverProperties)
+    private IProperties? MergeProperties(IProperties? codeProperties, IProperties? serverProperties)
     {
         if (codeProperties == null && serverProperties == null)
             return null;
 
-        IProperties mergedCodeProperties = null;
+        IProperties? mergedCodeProperties = null;
         // resolve code mapping property expressions using inferrer
         if (codeProperties != null)
         {
@@ -482,7 +482,7 @@ public class ElasticMappingResolver : IDisposable
         return properties;
     }
 
-    private Func<ITypeMapping> GetServerMappingFunc { get; set; }
+    private Func<ITypeMapping?>? GetServerMappingFunc { get; set; }
     private long _lastMappingUpdateTicks;
 
     private bool IsSnapshotCurrent(long snapshotEpoch, DateTime? snapshotServerTime)
@@ -524,7 +524,7 @@ public class ElasticMappingResolver : IDisposable
                     return false;
             }
 
-            ITypeMapping newMapping;
+            ITypeMapping? newMapping;
             try
             {
                 newMapping = GetServerMappingFunc();
@@ -554,7 +554,7 @@ public class ElasticMappingResolver : IDisposable
         }
     }
 
-    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, IElasticClient client, ILogger logger = null) where T : class
+    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, IElasticClient client, ILogger? logger = null) where T : class
     {
         logger ??= NullLogger.Instance;
 
@@ -569,7 +569,7 @@ public class ElasticMappingResolver : IDisposable
         }, logger);
     }
 
-    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, IElasticClient client, string index, ILogger logger = null) where T : class
+    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, IElasticClient client, string index, ILogger? logger = null) where T : class
     {
         logger ??= NullLogger.Instance;
 
@@ -584,14 +584,14 @@ public class ElasticMappingResolver : IDisposable
         }, logger);
     }
 
-    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, Inferrer inferrer, Func<ITypeMapping> getMapping, ILogger logger = null) where T : class
+    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, Inferrer inferrer, Func<ITypeMapping?> getMapping, ILogger? logger = null) where T : class
     {
         var codeMapping = new TypeMappingDescriptor<T>();
         codeMapping = mappingBuilder(codeMapping) as TypeMappingDescriptor<T>;
-        return new ElasticMappingResolver(codeMapping, inferrer, getMapping, logger: logger);
+        return new ElasticMappingResolver(codeMapping!, inferrer, getMapping, logger: logger);
     }
 
-    public static ElasticMappingResolver Create<T>(IElasticClient client, ILogger logger = null)
+    public static ElasticMappingResolver Create<T>(IElasticClient client, ILogger? logger = null)
     {
         logger ??= NullLogger.Instance;
 
@@ -606,7 +606,7 @@ public class ElasticMappingResolver : IDisposable
         }, client.Infer, logger);
     }
 
-    public static ElasticMappingResolver Create(IElasticClient client, string index, ILogger logger = null)
+    public static ElasticMappingResolver Create(IElasticClient client, string index, ILogger? logger = null)
     {
         logger ??= NullLogger.Instance;
 
@@ -621,7 +621,7 @@ public class ElasticMappingResolver : IDisposable
         }, client.Infer, logger);
     }
 
-    public static ElasticMappingResolver Create(Func<ITypeMapping> getMapping, Inferrer inferrer, ILogger logger = null)
+    public static ElasticMappingResolver Create(Func<ITypeMapping?> getMapping, Inferrer? inferrer, ILogger? logger = null)
     {
         return new ElasticMappingResolver(getMapping, inferrer, logger: logger);
     }
@@ -634,7 +634,7 @@ public class ElasticMappingResolver : IDisposable
 
 public class FieldMapping
 {
-    public FieldMapping(string path, IProperty property, DateTime? serverMapTime, long epoch = 0)
+    public FieldMapping(string path, IProperty? property, DateTime? serverMapTime, long epoch = 0)
     {
         FullPath = path;
         Property = property;
@@ -644,7 +644,7 @@ public class FieldMapping
 
     public bool Found => Property != null;
     public string FullPath { get; private set; }
-    public IProperty Property { get; private set; }
+    public IProperty? Property { get; private set; }
     public DateTime Date { get; private set; } = DateTime.UtcNow;
     internal DateTime? ServerMapTime { get; private set; }
     internal long Epoch { get; private set; }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -125,7 +125,7 @@ public class ElasticQueryParser : LuceneQueryParser
         if (elasticContext.MappingResolver != null)
         {
             var resolvedField = elasticContext.MappingResolver.GetMapping(field);
-            if (resolvedField?.Found == true)
+            if (resolvedField?.Found is true)
                 return resolvedField.FullPath;
         }
 

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -215,14 +215,12 @@ public class ElasticQueryParser : LuceneQueryParser
         return await BuildAggregationsAsync(result, context).ConfigureAwait(false);
     }
 
-#pragma warning disable IDE0060 // Remove unused parameter
     public async Task<AggregationContainer?> BuildAggregationsAsync(IQueryNode? aggregations, IElasticQueryVisitorContext? context = null)
     {
         if (aggregations == null)
             return null;
 
-#pragma warning restore IDE0060 // Remove unused parameter
-        return await aggregations.GetAggregationAsync().ConfigureAwait(false) ?? new AggregationContainer();
+        return await aggregations.GetAggregationAsync().ConfigureAwait(false);
     }
 
     public async Task<QueryValidationResult> ValidateSortAsync(string query, QueryValidationOptions? options = null, IElasticQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -77,7 +77,7 @@ public class ElasticQueryParser : LuceneQueryParser
         context.SetFieldResolver(async (field, context) =>
         {
             string? resolvedField = null;
-            if (context.Data.TryGetValue("@OriginalContextResolver", out object? data) && data is QueryFieldResolver resolver)
+            if (context?.Data.TryGetValue("@OriginalContextResolver", out object? data) is true && data is QueryFieldResolver resolver)
             {
                 string? contextResolvedField = await resolver(field, context).ConfigureAwait(false);
                 if (contextResolvedField != null)
@@ -110,7 +110,7 @@ public class ElasticQueryParser : LuceneQueryParser
         }
     }
 
-    private async Task<string?> MappingFieldResolver(string? field, IQueryVisitorContext context)
+    private async Task<string?> MappingFieldResolver(string? field, IQueryVisitorContext? context)
     {
         if (field == null)
             return null;
@@ -235,8 +235,9 @@ public class ElasticQueryParser : LuceneQueryParser
         return context.GetValidationResult();
     }
 
-    public async Task<IEnumerable<IFieldSort>> BuildSortAsync(string sort, IElasticQueryVisitorContext? context = null)
+    public async Task<IEnumerable<IFieldSort>> BuildSortAsync(string? sort, IElasticQueryVisitorContext? context = null)
     {
+        sort ??= String.Empty;
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Sort;
 

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,7 +15,7 @@ namespace Foundatio.Parsers.ElasticQueries;
 
 public class ElasticQueryParser : LuceneQueryParser
 {
-    public ElasticQueryParser(Action<ElasticQueryParserConfiguration> configure = null)
+    public ElasticQueryParser(Action<ElasticQueryParserConfiguration>? configure = null)
     {
         var config = new ElasticQueryParserConfiguration();
         configure?.Invoke(config);
@@ -24,7 +24,7 @@ public class ElasticQueryParser : LuceneQueryParser
 
     public ElasticQueryParserConfiguration Configuration { get; }
 
-    public override async Task<IQueryNode> ParseAsync(string query, IQueryVisitorContext context = null)
+    public override async Task<IQueryNode?> ParseAsync(string query, IQueryVisitorContext? context = null)
     {
         query ??= String.Empty;
         context ??= new ElasticQueryVisitorContext();
@@ -33,6 +33,9 @@ public class ElasticQueryParser : LuceneQueryParser
         try
         {
             var result = await base.ParseAsync(query, context).ConfigureAwait(false);
+            if (result is null)
+                return null;
+
             switch (context.QueryType)
             {
                 case QueryTypes.Aggregation:
@@ -52,7 +55,7 @@ public class ElasticQueryParser : LuceneQueryParser
         {
             var cursor = ex.Data["cursor"] as Cursor;
             context.GetValidationResult().QueryType = context.QueryType;
-            context.AddValidationError(ex.Message, cursor.Column);
+            context.AddValidationError(ex.Message, cursor?.Column ?? 0);
 
             return null;
         }
@@ -66,29 +69,29 @@ public class ElasticQueryParser : LuceneQueryParser
         if (Configuration.RuntimeFieldResolver != null && context.GetRuntimeFieldResolver() == null)
             context.SetRuntimeFieldResolver(Configuration.RuntimeFieldResolver);
 
-        context.SetMappingResolver(Configuration.MappingResolver);
+        context.SetMappingResolver(Configuration.MappingResolver ?? ElasticMappingResolver.NullInstance);
 
         if (!context.Data.ContainsKey("@OriginalContextResolver"))
-            context.SetValue("@OriginalContextResolver", context.GetFieldResolver());
+            context.SetValue("@OriginalContextResolver", context.GetFieldResolver()!);
 
         context.SetFieldResolver(async (field, context) =>
         {
-            string resolvedField = null;
-            if (context.Data.TryGetValue("@OriginalContextResolver", out object data) && data is QueryFieldResolver resolver)
+            string? resolvedField = null;
+            if (context.Data.TryGetValue("@OriginalContextResolver", out object? data) && data is QueryFieldResolver resolver)
             {
-                string contextResolvedField = await resolver(field, context).ConfigureAwait(false);
+                string? contextResolvedField = await resolver(field, context).ConfigureAwait(false);
                 if (contextResolvedField != null)
                     resolvedField = contextResolvedField;
             }
 
             if (Configuration.FieldResolver != null)
             {
-                string configResolvedField = await Configuration.FieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
+                string? configResolvedField = await Configuration.FieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
                 if (configResolvedField != null)
                     resolvedField = configResolvedField;
             }
 
-            string mappingResolvedField = await MappingFieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
+            string? mappingResolvedField = await MappingFieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
             if (mappingResolvedField != null)
                 resolvedField = mappingResolvedField;
 
@@ -100,13 +103,14 @@ public class ElasticQueryParser : LuceneQueryParser
 
         if (context.QueryType == QueryTypes.Query)
         {
-            context.SetDefaultFields(Configuration.DefaultFields);
+            if (Configuration.DefaultFields is not null)
+                context.SetDefaultFields(Configuration.DefaultFields);
             if (Configuration.IncludeResolver != null && context.GetIncludeResolver() == null)
                 context.SetIncludeResolver(Configuration.IncludeResolver);
         }
     }
 
-    private async Task<string> MappingFieldResolver(string field, IQueryVisitorContext context)
+    private async Task<string?> MappingFieldResolver(string? field, IQueryVisitorContext context)
     {
         if (field == null)
             return null;
@@ -121,7 +125,7 @@ public class ElasticQueryParser : LuceneQueryParser
         if (elasticContext.MappingResolver != null)
         {
             var resolvedField = elasticContext.MappingResolver.GetMapping(field);
-            if (resolvedField.Found)
+            if (resolvedField?.Found == true)
                 return resolvedField.FullPath;
         }
 
@@ -139,7 +143,7 @@ public class ElasticQueryParser : LuceneQueryParser
             var newRuntimeField = await elasticContext.RuntimeFieldResolver(field);
             if (newRuntimeField != null)
             {
-                elasticContext.RuntimeFields.Add(newRuntimeField);
+                elasticContext.RuntimeFields?.Add(newRuntimeField);
                 return newRuntimeField.Name;
             }
         }
@@ -147,18 +151,19 @@ public class ElasticQueryParser : LuceneQueryParser
         return null;
     }
 
-    public async Task<QueryValidationResult> ValidateQueryAsync(string query, QueryValidationOptions options = null, IElasticQueryVisitorContext context = null)
+    public async Task<QueryValidationResult> ValidateQueryAsync(string query, QueryValidationOptions? options = null, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Query;
-        context.SetValidationOptions(options);
+        if (options is not null)
+            context.SetValidationOptions(options);
 
         await ParseAsync(query, context).ConfigureAwait(false);
 
         return context.GetValidationResult();
     }
 
-    public async Task<QueryContainer> BuildQueryAsync(string query, IElasticQueryVisitorContext context = null)
+    public async Task<QueryContainer> BuildQueryAsync(string query, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Query;
@@ -166,10 +171,13 @@ public class ElasticQueryParser : LuceneQueryParser
         var result = await ParseAsync(query, context).ConfigureAwait(false);
         context.ThrowIfInvalid();
 
+        if (result is null)
+            throw new FormatException("Failed to parse query.");
+
         return await BuildQueryAsync(result, context).ConfigureAwait(false);
     }
 
-    public async Task<QueryContainer> BuildQueryAsync(IQueryNode query, IElasticQueryVisitorContext context = null)
+    public async Task<QueryContainer> BuildQueryAsync(IQueryNode query, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         var q = await query.GetQueryAsync() ?? new MatchAllQuery();
@@ -184,18 +192,19 @@ public class ElasticQueryParser : LuceneQueryParser
         return q;
     }
 
-    public async Task<QueryValidationResult> ValidateAggregationsAsync(string query, QueryValidationOptions options = null, IElasticQueryVisitorContext context = null)
+    public async Task<QueryValidationResult> ValidateAggregationsAsync(string query, QueryValidationOptions? options = null, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Aggregation;
-        context.SetValidationOptions(options);
+        if (options is not null)
+            context.SetValidationOptions(options);
 
         await ParseAsync(query, context).ConfigureAwait(false);
 
         return context.GetValidationResult();
     }
 
-    public async Task<AggregationContainer> BuildAggregationsAsync(string aggregations, IElasticQueryVisitorContext context = null)
+    public async Task<AggregationContainer?> BuildAggregationsAsync(string aggregations, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Aggregation;
@@ -207,27 +216,28 @@ public class ElasticQueryParser : LuceneQueryParser
     }
 
 #pragma warning disable IDE0060 // Remove unused parameter
-    public async Task<AggregationContainer> BuildAggregationsAsync(IQueryNode aggregations, IElasticQueryVisitorContext context = null)
+    public async Task<AggregationContainer?> BuildAggregationsAsync(IQueryNode? aggregations, IElasticQueryVisitorContext? context = null)
     {
         if (aggregations == null)
             return null;
 
 #pragma warning restore IDE0060 // Remove unused parameter
-        return await aggregations?.GetAggregationAsync();
+        return await aggregations.GetAggregationAsync().ConfigureAwait(false) ?? new AggregationContainer();
     }
 
-    public async Task<QueryValidationResult> ValidateSortAsync(string query, QueryValidationOptions options = null, IElasticQueryVisitorContext context = null)
+    public async Task<QueryValidationResult> ValidateSortAsync(string query, QueryValidationOptions? options = null, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Sort;
-        context.SetValidationOptions(options);
+        if (options is not null)
+            context.SetValidationOptions(options);
 
         await ParseAsync(query, context).ConfigureAwait(false);
 
         return context.GetValidationResult();
     }
 
-    public async Task<IEnumerable<IFieldSort>> BuildSortAsync(string sort, IElasticQueryVisitorContext context = null)
+    public async Task<IEnumerable<IFieldSort>> BuildSortAsync(string sort, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Sort;
@@ -235,10 +245,13 @@ public class ElasticQueryParser : LuceneQueryParser
         var result = await ParseAsync(sort, context).ConfigureAwait(false);
         context.ThrowIfInvalid();
 
+        if (result is null)
+            throw new FormatException("Failed to parse sort.");
+
         return await BuildSortAsync(result, context).ConfigureAwait(false);
     }
 
-    public Task<IEnumerable<IFieldSort>> BuildSortAsync(IQueryNode sort, IElasticQueryVisitorContext context = null)
+    public Task<IEnumerable<IFieldSort>> BuildSortAsync(IQueryNode sort, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         return GetSortFieldsVisitor.RunAsync(sort, context);

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -20,7 +20,7 @@ namespace Foundatio.Parsers.ElasticQueries;
 /// <param name="originalField">The field name before alias resolution (from GetOriginalField()).</param>
 /// <param name="resolvedField">The field name after alias resolution (the current node.Field).</param>
 /// <param name="context">The visitor context, providing Data dictionary for arbitrary state.</param>
-public delegate Task<QueryContainer> NestedFilterResolver(
+public delegate Task<QueryContainer?> NestedFilterResolver(
     string nestedPath,
     string originalField,
     string resolvedField,
@@ -154,7 +154,7 @@ public class ElasticQueryParserConfiguration
     }
 
     public ElasticQueryParserConfiguration UseNestedFilter(
-        Func<string, string, string, IQueryVisitorContext, QueryContainer>? resolver)
+        Func<string, string, string, IQueryVisitorContext, QueryContainer?>? resolver)
     {
         if (resolver is null)
             return UseNestedFilter((NestedFilterResolver?)null);

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -38,19 +38,19 @@ public class ElasticQueryParserConfiguration
         AddSortVisitor(new TermToFieldVisitor(), 0);
         AddAggregationVisitor(new AssignOperationTypeVisitor(), 0);
         AddAggregationVisitor(new CombineAggregationsVisitor(), 10000);
-        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver != null ? FieldResolver(field, context) : Task.FromResult<string>(null)), 10);
+        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver != null ? FieldResolver(field, context) : Task.FromResult<string?>(null)), 10);
         AddVisitor(new ValidationVisitor(), 30);
     }
 
     public ILoggerFactory LoggerFactory { get; private set; } = NullLoggerFactory.Instance;
-    public string[] DefaultFields { get; private set; }
-    public QueryFieldResolver FieldResolver { get; private set; }
-    public IncludeResolver IncludeResolver { get; private set; }
-    public NestedFilterResolver NestedFilterResolver { get; private set; }
-    public RuntimeFieldResolver RuntimeFieldResolver { get; private set; }
+    public string[]? DefaultFields { get; private set; }
+    public QueryFieldResolver? FieldResolver { get; private set; }
+    public IncludeResolver? IncludeResolver { get; private set; }
+    public NestedFilterResolver? NestedFilterResolver { get; private set; }
+    public RuntimeFieldResolver? RuntimeFieldResolver { get; private set; }
     public bool? EnableRuntimeFieldResolver { get; private set; }
-    public ElasticMappingResolver MappingResolver { get; private set; }
-    public QueryValidationOptions ValidationOptions { get; private set; }
+    public ElasticMappingResolver? MappingResolver { get; private set; }
+    public QueryValidationOptions? ValidationOptions { get; private set; }
     public ChainedQueryVisitor SortVisitor { get; } = new ChainedQueryVisitor();
     public ChainedQueryVisitor QueryVisitor { get; } = new ChainedQueryVisitor();
     public ChainedQueryVisitor AggregationVisitor { get; } = new ChainedQueryVisitor();
@@ -58,7 +58,7 @@ public class ElasticQueryParserConfiguration
     public ElasticQueryParserConfiguration SetLoggerFactory(ILoggerFactory loggerFactory)
     {
         LoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
-        _logger = loggerFactory.CreateLogger<ElasticQueryParserConfiguration>();
+        _logger = LoggerFactory.CreateLogger<ElasticQueryParserConfiguration>();
 
         return this;
     }
@@ -69,7 +69,7 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    public ElasticQueryParserConfiguration UseFieldResolver(QueryFieldResolver resolver, int priority = 10)
+    public ElasticQueryParserConfiguration UseFieldResolver(QueryFieldResolver? resolver, int priority = 10)
     {
         FieldResolver = resolver;
         ReplaceVisitor<FieldResolverQueryVisitor>(new FieldResolverQueryVisitor(resolver), priority);
@@ -77,7 +77,7 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    public ElasticQueryParserConfiguration UseFieldMap(IDictionary<string, string> fields, int priority = 10)
+    public ElasticQueryParserConfiguration UseFieldMap(IDictionary<string, string>? fields, int priority = 10)
     {
         if (fields != null)
             return UseFieldResolver(fields.ToHierarchicalFieldResolver(), priority);
@@ -90,12 +90,12 @@ public class ElasticQueryParserConfiguration
         return UseGeo(location => Task.FromResult(resolveGeoLocation(location)), priority);
     }
 
-    public ElasticQueryParserConfiguration UseGeo(Func<string, Task<string>> resolveGeoLocation, int priority = 200)
+    public ElasticQueryParserConfiguration UseGeo(Func<string, Task<string>>? resolveGeoLocation, int priority = 200)
     {
         return AddVisitor(new GeoVisitor(resolveGeoLocation), priority);
     }
 
-    public ElasticQueryParserConfiguration UseIncludes(IncludeResolver includeResolver, ShouldSkipIncludeFunc shouldSkipInclude = null, int priority = 0)
+    public ElasticQueryParserConfiguration UseIncludes(IncludeResolver includeResolver, ShouldSkipIncludeFunc? shouldSkipInclude = null, int priority = 0)
     {
         IncludeResolver = includeResolver;
 
@@ -117,12 +117,12 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    public ElasticQueryParserConfiguration UseIncludes(Func<string, string> resolveInclude, ShouldSkipIncludeFunc shouldSkipInclude = null, int priority = 0)
+    public ElasticQueryParserConfiguration UseIncludes(Func<string, string?> resolveInclude, ShouldSkipIncludeFunc? shouldSkipInclude = null, int priority = 0)
     {
         return UseIncludes(name => Task.FromResult(resolveInclude(name)), shouldSkipInclude, priority);
     }
 
-    public ElasticQueryParserConfiguration UseIncludes(IDictionary<string, string> includes, ShouldSkipIncludeFunc shouldSkipInclude = null, int priority = 0)
+    public ElasticQueryParserConfiguration UseIncludes(IDictionary<string, string> includes, ShouldSkipIncludeFunc? shouldSkipInclude = null, int priority = 0)
     {
         return UseIncludes(name => includes.ContainsKey(name) ? includes[name] : null, shouldSkipInclude, priority);
     }
@@ -141,7 +141,7 @@ public class ElasticQueryParserConfiguration
         return AddVisitor(new NestedVisitor(NestedFilterResolver), priority);
     }
 
-    public ElasticQueryParserConfiguration UseNestedFilter(NestedFilterResolver resolver)
+    public ElasticQueryParserConfiguration UseNestedFilter(NestedFilterResolver? resolver)
     {
         NestedFilterResolver = resolver;
         if (_nestedPriority.HasValue)
@@ -154,10 +154,10 @@ public class ElasticQueryParserConfiguration
     }
 
     public ElasticQueryParserConfiguration UseNestedFilter(
-        Func<string, string, string, IQueryVisitorContext, QueryContainer> resolver)
+        Func<string, string, string, IQueryVisitorContext, QueryContainer>? resolver)
     {
         if (resolver is null)
-            return UseNestedFilter((NestedFilterResolver)null);
+            return UseNestedFilter((NestedFilterResolver?)null);
 
         return UseNestedFilter((path, orig, resolved, ctx) =>
             Task.FromResult(resolver(path, orig, resolved, ctx)));
@@ -341,7 +341,7 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    public ElasticQueryParserConfiguration UseMappings(Func<ITypeMapping> getMapping, Inferrer inferrer = null)
+    public ElasticQueryParserConfiguration UseMappings(Func<ITypeMapping> getMapping, Inferrer? inferrer = null)
     {
         MappingResolver = ElasticMappingResolver.Create(getMapping, inferrer, logger: _logger);
 

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -38,7 +38,7 @@ public class ElasticQueryParserConfiguration
         AddSortVisitor(new TermToFieldVisitor(), 0);
         AddAggregationVisitor(new AssignOperationTypeVisitor(), 0);
         AddAggregationVisitor(new CombineAggregationsVisitor(), 10000);
-        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver != null ? FieldResolver(field, context) : Task.FromResult<string?>(null)), 10);
+        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver is not null ? FieldResolver(field, context) : Task.FromResult<string?>(null)), 10);
         AddVisitor(new ValidationVisitor(), 30);
     }
 

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -59,7 +59,7 @@ public static class DefaultAggregationNodeExtensions
             return null;
 
         var property = elasticContext.MappingResolver.GetMappingProperty(field, true);
-        string? originalField = node.GetOriginalField()?.Unescape();
+        string? originalField = node.GetOriginalField().Unescape();
 
         switch (node.GetOperationType())
         {
@@ -119,7 +119,7 @@ public static class DefaultAggregationNodeExtensions
 
         var property = elasticContext.MappingResolver.GetMappingProperty(node.UnescapedField, true);
         string? timezone = !String.IsNullOrWhiteSpace(node.UnescapedBoost) ? node.UnescapedBoost : node.GetTimeZone(await elasticContext.GetTimeZoneAsync());
-        string? originalField = node.GetOriginalField()?.Unescape();
+        string? originalField = node.GetOriginalField().Unescape();
 
         switch (node.GetOperationType())
         {

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -395,6 +395,7 @@ public static class DefaultAggregationNodeExtensions
                 case "@include":
                     if (termNode.UnescapedTerm is null)
                         break;
+
                     if (termNode.IsRegexTerm)
                     {
                         termsAggregation.Include = new TermsInclude(termNode.UnescapedTerm);

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -59,7 +59,7 @@ public static class DefaultAggregationNodeExtensions
             return null;
 
         var property = elasticContext.MappingResolver.GetMappingProperty(field, true);
-        string originalField = node.GetOriginalField()?.Unescape() ?? node.UnescapedField ?? String.Empty;
+        string? originalField = node.GetOriginalField()?.Unescape();
 
         switch (node.GetOperationType())
         {
@@ -93,7 +93,7 @@ public static class DefaultAggregationNodeExtensions
                     Field = field,
                     Size = node.GetProximityAsInt32(),
                     MinimumDocumentCount = node.GetBoostAsInt32(),
-                    Meta = new Dictionary<string, object> { { "@field_type", property?.Type! } }
+                    Meta = BuildFieldTypeMeta(property?.Type)
                 };
 
                 if (agg.Size.HasValue && (agg.Size * 1.5 + 10) > MAX_BUCKET_SIZE)
@@ -119,7 +119,7 @@ public static class DefaultAggregationNodeExtensions
 
         var property = elasticContext.MappingResolver.GetMappingProperty(node.UnescapedField, true);
         string? timezone = !String.IsNullOrWhiteSpace(node.UnescapedBoost) ? node.UnescapedBoost : node.GetTimeZone(await elasticContext.GetTimeZoneAsync());
-        string originalField = node.GetOriginalField()?.Unescape() ?? node.UnescapedField ?? String.Empty;
+        string? originalField = node.GetOriginalField()?.Unescape();
 
         switch (node.GetOperationType())
         {
@@ -183,7 +183,7 @@ public static class DefaultAggregationNodeExtensions
                     Field = aggField,
                     Size = node.GetProximityAsInt32(),
                     MinimumDocumentCount = node.GetBoostAsInt32(),
-                    Meta = new Dictionary<string, object> { { "@field_type", property?.Type! } }
+                    Meta = BuildFieldTypeMeta(property?.Type)
                 };
 
                 if (agg.Size.HasValue && (agg.Size * 1.5 + 10) > MAX_BUCKET_SIZE)
@@ -195,11 +195,8 @@ public static class DefaultAggregationNodeExtensions
         return null;
     }
 
-    private static Dictionary<string, object>? BuildFieldTypeMeta(string? fieldType, string? timezone = null)
+    private static Dictionary<string, object> BuildFieldTypeMeta(string? fieldType, string? timezone = null)
     {
-        if (fieldType is null && timezone is null)
-            return null;
-
         var meta = new Dictionary<string, object>();
         if (fieldType is not null)
             meta["@field_type"] = fieldType;
@@ -384,23 +381,27 @@ public static class DefaultAggregationNodeExtensions
             switch (termNode?.Field)
             {
                 case "@exclude":
+                    if (termNode.UnescapedTerm is null)
+                        break;
                     if (termNode.IsRegexTerm)
                     {
                         termsAggregation.Exclude = new TermsExclude(termNode.UnescapedTerm);
                     }
                     else
                     {
-                        termsAggregation.Exclude = termsAggregation.Exclude.AddValue(termNode.UnescapedTerm!);
+                        termsAggregation.Exclude = termsAggregation.Exclude.AddValue(termNode.UnescapedTerm);
                     }
                     break;
                 case "@include":
+                    if (termNode.UnescapedTerm is null)
+                        break;
                     if (termNode.IsRegexTerm)
                     {
                         termsAggregation.Include = new TermsInclude(termNode.UnescapedTerm);
                     }
                     else
                     {
-                        termsAggregation.Include = termsAggregation.Include.AddValue(termNode.UnescapedTerm!);
+                        termsAggregation.Include = termsAggregation.Include.AddValue(termNode.UnescapedTerm);
                     }
                     break;
                 case "@missing":

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -383,6 +383,7 @@ public static class DefaultAggregationNodeExtensions
                 case "@exclude":
                     if (termNode.UnescapedTerm is null)
                         break;
+
                     if (termNode.IsRegexTerm)
                     {
                         termsAggregation.Exclude = new TermsExclude(termNode.UnescapedTerm);

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -78,10 +78,10 @@ public static class DefaultAggregationNodeExtensions
                 {
                     Field = field,
                     Precision = precision,
-                    Aggregations = new AverageAggregation("avg_lat", new Field("_script"))
+                    Aggregations = new AverageAggregation("avg_lat", null!)
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lat")
-                    } && new AverageAggregation("avg_lon", new Field("_script"))
+                    } && new AverageAggregation("avg_lon", null!)
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lon")
                     }
@@ -168,10 +168,10 @@ public static class DefaultAggregationNodeExtensions
                 {
                     Field = aggField,
                     Precision = precision,
-                    Aggregations = new AverageAggregation("avg_lat", new Field("_script"))
+                    Aggregations = new AverageAggregation("avg_lat", null!)
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lat")
-                    } && new AverageAggregation("avg_lon", new Field("_script"))
+                    } && new AverageAggregation("avg_lon", null!)
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lon")
                     }

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -78,15 +78,13 @@ public static class DefaultAggregationNodeExtensions
                 {
                     Field = field,
                     Precision = precision,
-#pragma warning disable CS8625 // Field is null because these aggregations use Script instead
-                    Aggregations = new AverageAggregation("avg_lat", null)
+                    Aggregations = new AverageAggregation("avg_lat", new Field("_script"))
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lat")
-                    } && new AverageAggregation("avg_lon", null)
+                    } && new AverageAggregation("avg_lon", new Field("_script"))
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lon")
                     }
-#pragma warning restore CS8625
                 };
 
             case AggregationType.Terms:
@@ -170,15 +168,13 @@ public static class DefaultAggregationNodeExtensions
                 {
                     Field = aggField,
                     Precision = precision,
-#pragma warning disable CS8625 // Field is null because these aggregations use Script instead
-                    Aggregations = new AverageAggregation("avg_lat", null)
+                    Aggregations = new AverageAggregation("avg_lat", new Field("_script"))
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lat")
-                    } && new AverageAggregation("avg_lon", null)
+                    } && new AverageAggregation("avg_lon", new Field("_script"))
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lon")
                     }
-#pragma warning restore CS8625
                 };
 
             case AggregationType.Terms:

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -59,7 +59,7 @@ public static class DefaultAggregationNodeExtensions
             return null;
 
         var property = elasticContext.MappingResolver.GetMappingProperty(field, true);
-        string originalField = node.GetOriginalField()?.Unescape() ?? String.Empty;
+        string originalField = node.GetOriginalField()?.Unescape() ?? node.UnescapedField ?? String.Empty;
 
         switch (node.GetOperationType())
         {
@@ -93,7 +93,7 @@ public static class DefaultAggregationNodeExtensions
                     Field = field,
                     Size = node.GetProximityAsInt32(),
                     MinimumDocumentCount = node.GetBoostAsInt32(),
-                    Meta = property?.Type is not null ? new Dictionary<string, object> { { "@field_type", property.Type } } : null
+                    Meta = new Dictionary<string, object> { { "@field_type", property?.Type! } }
                 };
 
                 if (agg.Size.HasValue && (agg.Size * 1.5 + 10) > MAX_BUCKET_SIZE)
@@ -119,7 +119,7 @@ public static class DefaultAggregationNodeExtensions
 
         var property = elasticContext.MappingResolver.GetMappingProperty(node.UnescapedField, true);
         string? timezone = !String.IsNullOrWhiteSpace(node.UnescapedBoost) ? node.UnescapedBoost : node.GetTimeZone(await elasticContext.GetTimeZoneAsync());
-        string originalField = node.GetOriginalField()?.Unescape() ?? String.Empty;
+        string originalField = node.GetOriginalField()?.Unescape() ?? node.UnescapedField ?? String.Empty;
 
         switch (node.GetOperationType())
         {
@@ -183,7 +183,7 @@ public static class DefaultAggregationNodeExtensions
                     Field = aggField,
                     Size = node.GetProximityAsInt32(),
                     MinimumDocumentCount = node.GetBoostAsInt32(),
-                    Meta = property?.Type is not null ? new Dictionary<string, object> { { "@field_type", property.Type } } : null
+                    Meta = new Dictionary<string, object> { { "@field_type", property?.Type! } }
                 };
 
                 if (agg.Size.HasValue && (agg.Size * 1.5 + 10) > MAX_BUCKET_SIZE)

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Exceptionless.DateTimeExtensions;
@@ -16,9 +16,9 @@ public static class DefaultAggregationNodeExtensions
     // NOTE: We may want to read this dynamically from server settings.
     public const int MAX_BUCKET_SIZE = 10000;
 
-    public static async Task<AggregationBase> GetDefaultAggregationAsync(this IQueryNode node, IQueryVisitorContext context)
+    public static async Task<AggregationBase?> GetDefaultAggregationAsync(this IQueryNode node, IQueryVisitorContext context)
     {
-        AggregationBase aggregation = null;
+        AggregationBase? aggregation = null;
         if (node is GroupNode groupNode)
             aggregation = await groupNode.GetDefaultAggregationAsync(context);
 
@@ -46,7 +46,7 @@ public static class DefaultAggregationNodeExtensions
         return aggregation;
     }
 
-    public static async Task<AggregationBase> GetDefaultAggregationAsync(this GroupNode node, IQueryVisitorContext context)
+    public static async Task<AggregationBase?> GetDefaultAggregationAsync(this GroupNode node, IQueryVisitorContext context)
     {
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
@@ -54,9 +54,12 @@ public static class DefaultAggregationNodeExtensions
         if (!node.HasParens || String.IsNullOrEmpty(node.Field) || node.Left != null)
             return null;
 
-        string field = elasticContext.MappingResolver.GetAggregationsFieldName(node.UnescapedField);
+        string? field = elasticContext.MappingResolver.GetAggregationsFieldName(node.UnescapedField);
+        if (field is null)
+            return null;
+
         var property = elasticContext.MappingResolver.GetMappingProperty(field, true);
-        string originalField = node.GetOriginalField().Unescape();
+        string originalField = node.GetOriginalField()?.Unescape() ?? String.Empty;
 
         switch (node.GetOperationType())
         {
@@ -75,6 +78,7 @@ public static class DefaultAggregationNodeExtensions
                 {
                     Field = field,
                     Precision = precision,
+#pragma warning disable CS8625 // Field is null because these aggregations use Script instead
                     Aggregations = new AverageAggregation("avg_lat", null)
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lat")
@@ -82,6 +86,7 @@ public static class DefaultAggregationNodeExtensions
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lon")
                     }
+#pragma warning restore CS8625
                 };
 
             case AggregationType.Terms:
@@ -90,11 +95,11 @@ public static class DefaultAggregationNodeExtensions
                     Field = field,
                     Size = node.GetProximityAsInt32(),
                     MinimumDocumentCount = node.GetBoostAsInt32(),
-                    Meta = new Dictionary<string, object> { { "@field_type", property?.Type } }
+                    Meta = property?.Type is not null ? new Dictionary<string, object> { { "@field_type", property.Type } } : null
                 };
 
                 if (agg.Size.HasValue && (agg.Size * 1.5 + 10) > MAX_BUCKET_SIZE)
-                    agg.ShardSize = Math.Max((int)agg.Size, MAX_BUCKET_SIZE);
+                    agg.ShardSize = Math.Max(agg.Size.Value, MAX_BUCKET_SIZE);
 
                 return agg;
 
@@ -105,35 +110,38 @@ public static class DefaultAggregationNodeExtensions
         return null;
     }
 
-    public static async Task<AggregationBase> GetDefaultAggregationAsync(this TermNode node, IQueryVisitorContext context)
+    public static async Task<AggregationBase?> GetDefaultAggregationAsync(this TermNode node, IQueryVisitorContext context)
     {
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        string aggField = elasticContext.MappingResolver.GetAggregationsFieldName(node.UnescapedField);
+        string? aggField = elasticContext.MappingResolver.GetAggregationsFieldName(node.UnescapedField);
+        if (aggField is null)
+            return null;
+
         var property = elasticContext.MappingResolver.GetMappingProperty(node.UnescapedField, true);
-        string timezone = !String.IsNullOrWhiteSpace(node.UnescapedBoost) ? node.UnescapedBoost : node.GetTimeZone(await elasticContext.GetTimeZoneAsync());
-        string originalField = node.GetOriginalField().Unescape();
+        string? timezone = !String.IsNullOrWhiteSpace(node.UnescapedBoost) ? node.UnescapedBoost : node.GetTimeZone(await elasticContext.GetTimeZoneAsync());
+        string originalField = node.GetOriginalField()?.Unescape() ?? String.Empty;
 
         switch (node.GetOperationType())
         {
             case AggregationType.Min:
-                return new MinAggregation("min_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type }, { "@timezone", timezone } } };
+                return new MinAggregation("min_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type, timezone) };
 
             case AggregationType.Max:
-                return new MaxAggregation("max_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type }, { "@timezone", timezone } } };
+                return new MaxAggregation("max_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type, timezone) };
 
             case AggregationType.Avg:
-                return new AverageAggregation("avg_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type } } };
+                return new AverageAggregation("avg_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type) };
 
             case AggregationType.Sum:
-                return new SumAggregation("sum_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type } } };
+                return new SumAggregation("sum_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type) };
 
             case AggregationType.Stats:
-                return new StatsAggregation("stats_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type } } };
+                return new StatsAggregation("stats_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type) };
 
             case AggregationType.ExtendedStats:
-                return new ExtendedStatsAggregation("exstats_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type } } };
+                return new ExtendedStatsAggregation("exstats_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type) };
 
             case AggregationType.Cardinality:
                 return new CardinalityAggregation("cardinality_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), PrecisionThreshold = node.GetBoostAsInt32() };
@@ -162,6 +170,7 @@ public static class DefaultAggregationNodeExtensions
                 {
                     Field = aggField,
                     Precision = precision,
+#pragma warning disable CS8625 // Field is null because these aggregations use Script instead
                     Aggregations = new AverageAggregation("avg_lat", null)
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lat")
@@ -169,6 +178,7 @@ public static class DefaultAggregationNodeExtensions
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lon")
                     }
+#pragma warning restore CS8625
                 };
 
             case AggregationType.Terms:
@@ -177,11 +187,11 @@ public static class DefaultAggregationNodeExtensions
                     Field = aggField,
                     Size = node.GetProximityAsInt32(),
                     MinimumDocumentCount = node.GetBoostAsInt32(),
-                    Meta = new Dictionary<string, object> { { "@field_type", property?.Type } }
+                    Meta = property?.Type is not null ? new Dictionary<string, object> { { "@field_type", property.Type } } : null
                 };
 
                 if (agg.Size.HasValue && (agg.Size * 1.5 + 10) > MAX_BUCKET_SIZE)
-                    agg.ShardSize = Math.Max((int)agg.Size, MAX_BUCKET_SIZE);
+                    agg.ShardSize = Math.Max(agg.Size.Value, MAX_BUCKET_SIZE);
 
                 return agg;
         }
@@ -189,9 +199,23 @@ public static class DefaultAggregationNodeExtensions
         return null;
     }
 
-    private static AggregationBase GetPercentilesAggregation(string originalField, string field, string proximity, string boost, IQueryVisitorContext context)
+    private static Dictionary<string, object>? BuildFieldTypeMeta(string? fieldType, string? timezone = null)
     {
-        List<double> percents = null;
+        if (fieldType is null && timezone is null)
+            return null;
+
+        var meta = new Dictionary<string, object>();
+        if (fieldType is not null)
+            meta["@field_type"] = fieldType;
+        if (timezone is not null)
+            meta["@timezone"] = timezone;
+
+        return meta;
+    }
+
+    private static AggregationBase GetPercentilesAggregation(string originalField, string field, string? proximity, string? boost, IQueryVisitorContext context)
+    {
+        List<double>? percents = null;
         if (!String.IsNullOrWhiteSpace(proximity))
         {
             string[] percentStrings = proximity.Split(',');
@@ -209,7 +233,7 @@ public static class DefaultAggregationNodeExtensions
         };
     }
 
-    private static AggregationBase GetHistogramAggregation(string originalField, string field, string proximity, string boost, IQueryVisitorContext context)
+    private static AggregationBase GetHistogramAggregation(string originalField, string field, string? proximity, string? boost, IQueryVisitorContext context)
     {
         double interval = 50;
         if (Double.TryParse(proximity, out double prox))
@@ -223,16 +247,16 @@ public static class DefaultAggregationNodeExtensions
         };
     }
 
-    private static AggregationBase GetDateHistogramAggregation(string originalField, string field, string proximity, string boost, IQueryVisitorContext context)
+    private static AggregationBase GetDateHistogramAggregation(string originalField, string field, string? proximity, string? boost, IQueryVisitorContext context)
     {
         // NOTE: StartDate and EndDate are set in the Repositories QueryBuilderContext.
         var start = context.GetDate("StartDate");
         var end = context.GetDate("EndDate");
         bool isValidRange = start.HasValue && start.Value > DateTime.MinValue && end.HasValue && end.Value < DateTime.MaxValue && start.Value <= end.Value;
-        var bounds = isValidRange ? new ExtendedBounds<DateMath> { Minimum = start.Value, Maximum = end.Value } : null;
+        var bounds = isValidRange ? new ExtendedBounds<DateMath> { Minimum = start!.Value, Maximum = end!.Value } : null;
 
         var interval = GetInterval(proximity, start, end);
-        string timezone = TryConvertTimeUnitToUtcOffset(boost);
+        string? timezone = TryConvertTimeUnitToUtcOffset(boost);
         var agg = new DateHistogramAggregation(originalField)
         {
             Field = field,
@@ -247,7 +271,7 @@ public static class DefaultAggregationNodeExtensions
         return agg;
     }
 
-    private static string TryConvertTimeUnitToUtcOffset(string boost)
+    private static string? TryConvertTimeUnitToUtcOffset(string? boost)
     {
         if (String.IsNullOrEmpty(boost))
             return null;
@@ -267,7 +291,7 @@ public static class DefaultAggregationNodeExtensions
         return "+" + timezoneOffset.Value.ToString("hh\\:mm");
     }
 
-    private static Union<DateInterval, Time> GetInterval(string proximity, DateTime? start, DateTime? end)
+    private static Union<DateInterval, Time> GetInterval(string? proximity, DateTime? start, DateTime? end)
     {
         if (String.IsNullOrEmpty(proximity))
             return GetInterval(start, end);
@@ -370,7 +394,7 @@ public static class DefaultAggregationNodeExtensions
                     }
                     else
                     {
-                        termsAggregation.Exclude = termsAggregation.Exclude.AddValue(termNode.UnescapedTerm);
+                        termsAggregation.Exclude = termsAggregation.Exclude.AddValue(termNode.UnescapedTerm!);
                     }
                     break;
                 case "@include":
@@ -380,7 +404,7 @@ public static class DefaultAggregationNodeExtensions
                     }
                     else
                     {
-                        termsAggregation.Include = termsAggregation.Include.AddValue(termNode.UnescapedTerm);
+                        termsAggregation.Include = termsAggregation.Include.AddValue(termNode.UnescapedTerm!);
                     }
                     break;
                 case "@missing":

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -30,7 +30,7 @@ public static class DefaultQueryNodeExtensions
         return null;
     }
 
-    public static QueryBase GetDefaultQuery(this TermNode node, IQueryVisitorContext context)
+    public static QueryBase? GetDefaultQuery(this TermNode node, IQueryVisitorContext context)
     {
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
@@ -65,12 +65,12 @@ public static class DefaultQueryNodeExtensions
         return GetMultiFieldQuery(node, defaultFields, elasticContext);
     }
 
-    private static QueryBase GetSingleFieldQuery(TermNode node, string field, IElasticQueryVisitorContext context)
+    private static QueryBase? GetSingleFieldQuery(TermNode node, string field, IElasticQueryVisitorContext context)
     {
         if (context.MappingResolver.IsPropertyAnalyzed(field))
         {
             // MatchQuery treats '*' as literal; PrefixQuery only works on non-analyzed fields.
-            if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") == true)
+            if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") is true)
             {
                 return new QueryStringQuery
                 {
@@ -97,7 +97,7 @@ public static class DefaultQueryNodeExtensions
             };
         }
 
-        if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") == true)
+        if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") is true)
         {
             return new PrefixQuery
             {
@@ -107,14 +107,9 @@ public static class DefaultQueryNodeExtensions
         }
 
         if (node.UnescapedTerm is null)
-        {
-            return new TermQuery
-            {
-                Field = field,
-                Value = node.UnescapedTerm
-            };
-        }
+            return null;
 
+        // For non-analyzed fields, try to convert value to appropriate type
         object termValue = GetTypedValue(node.UnescapedTerm, field, context);
 
         return new TermQuery
@@ -139,7 +134,7 @@ public static class DefaultQueryNodeExtensions
         };
     }
 
-    private static QueryBase GetMultiFieldQuery(TermNode node, string[]? fields, IElasticQueryVisitorContext context)
+    private static QueryBase? GetMultiFieldQuery(TermNode node, string[]? fields, IElasticQueryVisitorContext context)
     {
         // Handle null or empty fields - use default multi_match behavior
         if (fields is null or { Length: 0 })
@@ -187,7 +182,9 @@ public static class DefaultQueryNodeExtensions
         // Add individual queries for non-analyzed fields
         foreach (string field in nonAnalyzedFields)
         {
-            queries.Add(GetSingleFieldQuery(node, field, context));
+            var query = GetSingleFieldQuery(node, field, context);
+            if (query is not null)
+                queries.Add(query);
         }
 
         return new BoolQuery
@@ -198,7 +195,7 @@ public static class DefaultQueryNodeExtensions
 
     private static QueryBase GetAnalyzedFieldsQuery(TermNode node, string[] fields)
     {
-        if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") == true)
+        if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") is true)
         {
             return new QueryStringQuery
             {
@@ -228,14 +225,14 @@ public static class DefaultQueryNodeExtensions
         return query;
     }
 
-    private static QueryBase GetNonAnalyzedFieldsQuery(TermNode node, List<string> fields, IElasticQueryVisitorContext context)
+    private static QueryBase? GetNonAnalyzedFieldsQuery(TermNode node, List<string> fields, IElasticQueryVisitorContext context)
     {
         // For a single non-analyzed field, use single query
         if (fields.Count == 1)
             return GetSingleFieldQuery(node, fields[0], context);
 
         // Multiple non-analyzed fields - combine with bool should
-        var queries = fields.Select(f => GetSingleFieldQuery(node, f, context)).ToList();
+        var queries = fields.Select(f => GetSingleFieldQuery(node, f, context)).Where(q => q is not null).ToList();
         return new BoolQuery
         {
             Should = queries.Select(q => (QueryContainer)q).ToList()
@@ -289,9 +286,12 @@ public static class DefaultQueryNodeExtensions
 
         foreach (var (nestedPath, fields) in fieldsByNestedPath)
         {
-            QueryBase query = fields.Count == 1
+            QueryBase? query = fields.Count == 1
                 ? GetSingleFieldQuery(node, fields[0], context)
                 : GetMultiFieldQuery(node, fields.ToArray(), context);
+
+            if (query is null)
+                continue;
 
             if (!String.IsNullOrEmpty(nestedPath))
             {

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -316,7 +316,7 @@ public static class DefaultQueryNodeExtensions
         string? field = node.UnescapedField;
         if (elasticContext.MappingResolver.IsDatePropertyType(field))
         {
-            var range = new DateRangeQuery { Field = field, TimeZone = node.Boost ?? node.GetTimeZone(await elasticContext.GetTimeZoneAsync()) };
+            var range = new DateRangeQuery { Field = field, TimeZone = node.Boost ?? node.GetTimeZone(await elasticContext.GetTimeZoneAsync().ConfigureAwait(false)) };
             if (!String.IsNullOrWhiteSpace(node.UnescapedMin) && node.UnescapedMin != "*")
             {
                 if (node.MinInclusive.HasValue && !node.MinInclusive.Value)

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -62,7 +62,7 @@ public static class DefaultQueryNodeExtensions
         }
 
         // Fallback for no fields
-        return GetMultiFieldQuery(node, defaultFields!, elasticContext);
+        return GetMultiFieldQuery(node, defaultFields, elasticContext);
     }
 
     private static QueryBase GetSingleFieldQuery(TermNode node, string field, IElasticQueryVisitorContext context)
@@ -131,7 +131,7 @@ public static class DefaultQueryNodeExtensions
         };
     }
 
-    private static QueryBase GetMultiFieldQuery(TermNode node, string[] fields, IElasticQueryVisitorContext context)
+    private static QueryBase GetMultiFieldQuery(TermNode node, string[]? fields, IElasticQueryVisitorContext context)
     {
         // Handle null or empty fields - use default multi_match behavior
         if (fields is null or { Length: 0 })

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -13,13 +13,13 @@ namespace Foundatio.Parsers.ElasticQueries.Extensions;
 
 public static class DefaultQueryNodeExtensions
 {
-    public static async Task<QueryBase> GetDefaultQueryAsync(this IQueryNode node, IQueryVisitorContext context)
+    public static async Task<QueryBase?> GetDefaultQueryAsync(this IQueryNode node, IQueryVisitorContext context)
     {
         if (node is TermNode termNode)
             return termNode.GetDefaultQuery(context);
 
         if (node is TermRangeNode termRangeNode)
-            return await termRangeNode.GetDefaultQueryAsync(context);
+            return await termRangeNode.GetDefaultQueryAsync(context).ConfigureAwait(false);
 
         if (node is ExistsNode existsNode)
             return existsNode.GetDefaultQuery(context);
@@ -35,8 +35,8 @@ public static class DefaultQueryNodeExtensions
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        string field = node.UnescapedField;
-        string[] defaultFields = node.GetDefaultFields(elasticContext.DefaultFields);
+        string? field = node.UnescapedField;
+        string[]? defaultFields = node.GetDefaultFields(elasticContext.DefaultFields);
 
         // If a specific field is set, use single-field query
         if (!String.IsNullOrEmpty(field))
@@ -62,7 +62,7 @@ public static class DefaultQueryNodeExtensions
         }
 
         // Fallback for no fields
-        return GetMultiFieldQuery(node, defaultFields, elasticContext);
+        return GetMultiFieldQuery(node, defaultFields!, elasticContext);
     }
 
     private static QueryBase GetSingleFieldQuery(TermNode node, string field, IElasticQueryVisitorContext context)
@@ -70,7 +70,7 @@ public static class DefaultQueryNodeExtensions
         if (context.MappingResolver.IsPropertyAnalyzed(field))
         {
             // MatchQuery treats '*' as literal; PrefixQuery only works on non-analyzed fields.
-            if (!node.IsQuotedTerm && node.UnescapedTerm.EndsWith("*"))
+            if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") == true)
             {
                 return new QueryStringQuery
                 {
@@ -97,7 +97,7 @@ public static class DefaultQueryNodeExtensions
             };
         }
 
-        if (!node.IsQuotedTerm && node.UnescapedTerm.EndsWith("*"))
+        if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") == true)
         {
             return new PrefixQuery
             {
@@ -107,7 +107,7 @@ public static class DefaultQueryNodeExtensions
         }
 
         // For non-analyzed fields, try to convert value to appropriate type
-        object termValue = GetTypedValue(node.UnescapedTerm, field, context);
+        object termValue = GetTypedValue(node.UnescapedTerm!, field, context);
 
         return new TermQuery
         {
@@ -190,7 +190,7 @@ public static class DefaultQueryNodeExtensions
 
     private static QueryBase GetAnalyzedFieldsQuery(TermNode node, string[] fields)
     {
-        if (!node.IsQuotedTerm && node.UnescapedTerm.EndsWith("*"))
+        if (!node.IsQuotedTerm && node.UnescapedTerm!.EndsWith("*"))
         {
             return new QueryStringQuery
             {
@@ -252,9 +252,9 @@ public static class DefaultQueryNodeExtensions
         return result;
     }
 
-    private static string GetNestedPath(string fullName, IElasticQueryVisitorContext context)
+    private static string? GetNestedPath(string fullName, IElasticQueryVisitorContext context)
     {
-        string[] nameParts = fullName?.Split('.');
+        string[]? nameParts = fullName?.Split('.');
 
         if (nameParts is null or { Length: 0 })
             return null;
@@ -274,6 +274,7 @@ public static class DefaultQueryNodeExtensions
 
         return null;
     }
+
 
     private static QueryBase GetSplitNestedQuery(TermNode node, Dictionary<string, List<string>> fieldsByNestedPath, IElasticQueryVisitorContext context)
     {
@@ -313,7 +314,7 @@ public static class DefaultQueryNodeExtensions
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        string field = node.UnescapedField;
+        string? field = node.UnescapedField;
         if (elasticContext.MappingResolver.IsDatePropertyType(field))
         {
             var range = new DateRangeQuery { Field = field, TimeZone = node.Boost ?? node.GetTimeZone(await elasticContext.GetTimeZoneAsync()) };

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -275,7 +275,6 @@ public static class DefaultQueryNodeExtensions
         return null;
     }
 
-
     private static QueryBase GetSplitNestedQuery(TermNode node, Dictionary<string, List<string>> fieldsByNestedPath, IElasticQueryVisitorContext context)
     {
         var queryContainers = new List<QueryContainer>();

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -106,8 +106,16 @@ public static class DefaultQueryNodeExtensions
             };
         }
 
-        // For non-analyzed fields, try to convert value to appropriate type
-        object termValue = GetTypedValue(node.UnescapedTerm!, field, context);
+        if (node.UnescapedTerm is null)
+        {
+            return new TermQuery
+            {
+                Field = field,
+                Value = node.UnescapedTerm
+            };
+        }
+
+        object termValue = GetTypedValue(node.UnescapedTerm, field, context);
 
         return new TermQuery
         {
@@ -190,7 +198,7 @@ public static class DefaultQueryNodeExtensions
 
     private static QueryBase GetAnalyzedFieldsQuery(TermNode node, string[] fields)
     {
-        if (!node.IsQuotedTerm && node.UnescapedTerm!.EndsWith("*"))
+        if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") == true)
         {
             return new QueryStringQuery
             {

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
@@ -14,7 +14,7 @@ public static class DefaultSortNodeExtensions
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        string field = elasticContext.MappingResolver.GetSortFieldName(node.UnescapedField);
+        string? field = elasticContext.MappingResolver.GetSortFieldName(node.UnescapedField);
         var fieldType = elasticContext.MappingResolver.GetFieldType(field);
 
         var sort = new FieldSort
@@ -24,7 +24,7 @@ public static class DefaultSortNodeExtensions
             Order = node.IsNodeOrGroupNegated() ? SortOrder.Descending : SortOrder.Ascending
         };
 
-        string nestedPath = node.GetNestedPath();
+        string? nestedPath = node.GetNestedPath();
         if (nestedPath is not null)
         {
             var nestedSort = new NestedSort { Path = nestedPath };

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/ElasticExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/ElasticExtensions.cs
@@ -37,7 +37,7 @@ public static class ElasticExtensions
     }
 
     // TODO: Handle IFailureReason/BulkIndexByScrollFailure and other bulk response types.
-    public static string GetErrorMessage(this IElasticsearchResponse elasticResponse, string message = null, bool normalize = false, bool includeResponse = false, bool includeDebugInformation = false)
+    public static string GetErrorMessage(this IElasticsearchResponse elasticResponse, string? message = null, bool normalize = false, bool includeResponse = false, bool includeDebugInformation = false)
     {
         if (elasticResponse == null)
             return String.Empty;
@@ -55,7 +55,7 @@ public static class ElasticExtensions
             sb.AppendLine($"Original: [{response.OriginalException.GetType().Name}] {response.OriginalException.Message}");
 
         if (response?.ServerError?.Error != null)
-            sb.AppendLine($"Server Error (Index={response.ServerError.Error?.Index}): {response.ServerError.Error.Reason}");
+            sb.AppendLine($"Server Error (Index={response.ServerError.Error.Index}): {response.ServerError.Error.Reason}");
 
         if (elasticResponse is BulkResponse bulkResponse)
             sb.AppendLine($"Bulk: {String.Join("\r\n", bulkResponse.ItemsWithErrors.Select(i => i.Error))}");
@@ -65,16 +65,16 @@ public static class ElasticExtensions
 
         if (elasticResponse.ApiCall?.RequestBodyInBytes != null)
         {
-            string body = Encoding.UTF8.GetString(elasticResponse.ApiCall?.RequestBodyInBytes);
+            string body = Encoding.UTF8.GetString(elasticResponse.ApiCall.RequestBodyInBytes);
             if (normalize)
                 body = JsonUtility.Normalize(body);
             sb.AppendLine(body);
         }
 
-        var apiCall = response.ApiCall;
-        if (includeResponse && apiCall.ResponseBodyInBytes != null && apiCall.ResponseBodyInBytes.Length > 0 && apiCall.ResponseBodyInBytes.Length < 20000)
+        var apiCall = response?.ApiCall;
+        if (includeResponse && apiCall?.ResponseBodyInBytes != null && apiCall.ResponseBodyInBytes.Length > 0 && apiCall.ResponseBodyInBytes.Length < 20000)
         {
-            string body = Encoding.UTF8.GetString(apiCall?.ResponseBodyInBytes);
+            string body = Encoding.UTF8.GetString(apiCall.ResponseBodyInBytes);
             if (normalize)
                 body = JsonUtility.Normalize(body);
 
@@ -93,7 +93,7 @@ public static class ElasticExtensions
         return GetErrorMessage(elasticResponse, null, normalize, includeResponse, includeDebugInformation);
     }
 
-    public static async Task<bool> WaitForReadyAsync(this IElasticClient client, CancellationToken cancellationToken, ILogger logger = null)
+    public static async Task<bool> WaitForReadyAsync(this IElasticClient client, CancellationToken cancellationToken, ILogger? logger = null)
     {
         var nodes = client.ConnectionSettings.ConnectionPool.Nodes.Select(n => n.Uri.ToString());
         var startTime = DateTime.UtcNow;
@@ -116,7 +116,7 @@ public static class ElasticExtensions
         return false;
     }
 
-    public static bool WaitForReady(this IElasticClient client, CancellationToken cancellationToken, ILogger logger = null)
+    public static bool WaitForReady(this IElasticClient client, CancellationToken cancellationToken, ILogger? logger = null)
     {
         var nodes = client.ConnectionSettings.ConnectionPool.Nodes.Select(n => n.Uri.ToString());
         var startTime = DateTime.UtcNow;

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/ElasticExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/ElasticExtensions.cs
@@ -72,7 +72,7 @@ public static class ElasticExtensions
         }
 
         var apiCall = response?.ApiCall;
-        if (includeResponse && apiCall?.ResponseBodyInBytes != null && apiCall.ResponseBodyInBytes.Length > 0 && apiCall.ResponseBodyInBytes.Length < 20000)
+        if (includeResponse && apiCall?.ResponseBodyInBytes is not null && apiCall.ResponseBodyInBytes.Length > 0 && apiCall.ResponseBodyInBytes.Length < 20000)
         {
             string body = Encoding.UTF8.GetString(apiCall.ResponseBodyInBytes);
             if (normalize)

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/ElasticMappingExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/ElasticMappingExtensions.cs
@@ -13,7 +13,7 @@ public static class ElasticMapping
     /// <summary>
     /// Not chainable with AddSortField. Use AddKeywordAndSortFields to add both.
     /// </summary>
-    public static TextPropertyDescriptor<T> AddKeywordField<T>(this TextPropertyDescriptor<T> descriptor, string normalizer) where T : class
+    public static TextPropertyDescriptor<T> AddKeywordField<T>(this TextPropertyDescriptor<T> descriptor, string? normalizer) where T : class
     {
         return descriptor.Fields(f => f.Keyword(s => s.Name(KeywordFieldName).Normalizer(normalizer).IgnoreAbove(256)));
     }
@@ -34,7 +34,7 @@ public static class ElasticMapping
         return descriptor.Fields(f => f.Keyword(s => s.Name(SortFieldName).Normalizer(normalizer).IgnoreAbove(256)));
     }
 
-    public static TextPropertyDescriptor<T> AddKeywordAndSortFields<T>(this TextPropertyDescriptor<T> descriptor, string sortNormalizer = "sort", string keywordNormalizer = null) where T : class
+    public static TextPropertyDescriptor<T> AddKeywordAndSortFields<T>(this TextPropertyDescriptor<T> descriptor, string sortNormalizer = "sort", string? keywordNormalizer = null) where T : class
     {
         return descriptor.Fields(f => f
             .Keyword(s => s.Name(KeywordFieldName).Normalizer(keywordNormalizer).IgnoreAbove(256))

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryNodeExtensions.cs
@@ -15,7 +15,7 @@ public static class QueryNodeExtensions
             if (getDefaultValue == null)
                 return Task.FromResult<QueryBase?>(null);
 
-            return getDefaultValue?.Invoke()!;
+            return getDefaultValue.Invoke();
         }
 
         return Task.FromResult(value as QueryBase);
@@ -49,7 +49,7 @@ public static class QueryNodeExtensions
             if (getDefaultValue == null)
                 return Task.FromResult<AggregationBase?>(null);
 
-            return getDefaultValue?.Invoke()!;
+            return getDefaultValue.Invoke();
         }
 
         return Task.FromResult(value as AggregationBase);

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryNodeExtensions.cs
@@ -8,14 +8,14 @@ namespace Foundatio.Parsers.ElasticQueries.Extensions;
 public static class QueryNodeExtensions
 {
     private const string QueryKey = "@Query";
-    public static Task<QueryBase> GetQueryAsync(this IQueryNode node, Func<Task<QueryBase>> getDefaultValue = null)
+    public static Task<QueryBase?> GetQueryAsync(this IQueryNode node, Func<Task<QueryBase?>>? getDefaultValue = null)
     {
-        if (!node.Data.TryGetValue(QueryKey, out object value))
+        if (!node.Data.TryGetValue(QueryKey, out object? value))
         {
             if (getDefaultValue == null)
-                return Task.FromResult<QueryBase>(null);
+                return Task.FromResult<QueryBase?>(null);
 
-            return getDefaultValue?.Invoke();
+            return getDefaultValue?.Invoke()!;
         }
 
         return Task.FromResult(value as QueryBase);
@@ -33,23 +33,23 @@ public static class QueryNodeExtensions
     }
 
     private const string SourceFilterKey = "@SourceFilter";
-    public static SourceFilter GetSourceFilter(this IQueryNode node, Func<SourceFilter> getDefaultValue = null)
+    public static SourceFilter? GetSourceFilter(this IQueryNode node, Func<SourceFilter>? getDefaultValue = null)
     {
-        if (!node.Data.TryGetValue(SourceFilterKey, out object value))
+        if (!node.Data.TryGetValue(SourceFilterKey, out object? value))
             return getDefaultValue?.Invoke();
 
         return value as SourceFilter;
     }
 
     private const string AggregationKey = "@Aggregation";
-    public static Task<AggregationBase> GetAggregationAsync(this IQueryNode node, Func<Task<AggregationBase>> getDefaultValue = null)
+    public static Task<AggregationBase?> GetAggregationAsync(this IQueryNode node, Func<Task<AggregationBase?>>? getDefaultValue = null)
     {
-        if (!node.Data.TryGetValue(AggregationKey, out object value))
+        if (!node.Data.TryGetValue(AggregationKey, out object? value))
         {
             if (getDefaultValue == null)
-                return Task.FromResult<AggregationBase>(null);
+                return Task.FromResult<AggregationBase?>(null);
 
-            return getDefaultValue?.Invoke();
+            return getDefaultValue?.Invoke()!;
         }
 
         return Task.FromResult(value as AggregationBase);
@@ -66,9 +66,9 @@ public static class QueryNodeExtensions
     }
 
     private const string SortKey = "@Sort";
-    public static IFieldSort GetSort(this IQueryNode node, Func<IFieldSort> getDefaultValue = null)
+    public static IFieldSort? GetSort(this IQueryNode node, Func<IFieldSort>? getDefaultValue = null)
     {
-        if (!node.Data.TryGetValue(SortKey, out object value))
+        if (!node.Data.TryGetValue(SortKey, out object? value))
             return getDefaultValue?.Invoke();
 
         return value as IFieldSort;
@@ -85,9 +85,9 @@ public static class QueryNodeExtensions
     }
 
     private const string NestedPathKey = "@NestedPath";
-    public static string GetNestedPath(this IQueryNode node)
+    public static string? GetNestedPath(this IQueryNode node)
     {
-        if (!node.Data.TryGetValue(NestedPathKey, out object value))
+        if (!node.Data.TryGetValue(NestedPathKey, out object? value))
             return null;
 
         return value as string;
@@ -106,9 +106,9 @@ public static class QueryNodeExtensions
     }
 
     private const string NestedFilterKey = "@NestedFilter";
-    public static QueryContainer GetNestedFilter(this IQueryNode node)
+    public static QueryContainer? GetNestedFilter(this IQueryNode node)
     {
-        if (!node.Data.TryGetValue(NestedFilterKey, out object value))
+        if (!node.Data.TryGetValue(NestedFilterKey, out object? value))
             return null;
 
         return value as QueryContainer;

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryNodeExtensions.cs
@@ -21,9 +21,12 @@ public static class QueryNodeExtensions
         return Task.FromResult(value as QueryBase);
     }
 
-    public static void SetQuery(this IQueryNode node, QueryBase container)
+    public static void SetQuery(this IQueryNode node, QueryBase? container)
     {
-        node.Data[QueryKey] = container;
+        if (container is null)
+            node.Data.Remove(QueryKey);
+        else
+            node.Data[QueryKey] = container;
     }
 
     public static void RemoveQuery(this IQueryNode node)

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
@@ -18,7 +18,7 @@ public static class QueryVisitorContextExtensions
         return elasticContext.EnableRuntimeFieldResolver;
     }
 
-    public static RuntimeFieldResolver GetRuntimeFieldResolver(this IQueryVisitorContext context)
+    public static RuntimeFieldResolver? GetRuntimeFieldResolver(this IQueryVisitorContext context)
     {
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
@@ -46,13 +46,13 @@ public static class QueryVisitorContextExtensions
         return context;
     }
 
-    public static Task<string> GetTimeZoneAsync(this IQueryVisitorContext context)
+    public static Task<string?> GetTimeZoneAsync(this IQueryVisitorContext context)
     {
         var elasticContext = context as IElasticQueryVisitorContext;
         if (elasticContext?.DefaultTimeZone != null)
-            return elasticContext.DefaultTimeZone.Invoke();
+            return elasticContext.DefaultTimeZone.Invoke()!;
 
-        return Task.FromResult<string>(null);
+        return Task.FromResult<string?>(null);
     }
 
     public static T SetMappingResolver<T>(this T context, ElasticMappingResolver mappingResolver) where T : IQueryVisitorContext

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
@@ -194,7 +194,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
 
         if (container is null)
         {
-            container = new GlobalAggregation("root");
+            container = new ChildrenAggregation(null, null);
             currentNode!.SetAggregation(container);
         }
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
@@ -34,7 +34,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
             if (aggregation is null)
                 continue;
 
-            string nestedPath = child.GetNestedPath();
+            string? nestedPath = child.GetNestedPath();
             if (nestedPath is not null)
             {
                 if (!nestedAggregations.ContainsKey(nestedPath))
@@ -97,7 +97,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
             node.SetAggregation(container);
     }
 
-    private static void AddAggregation(AggregationBase container, ITermsAggregation termsAggregation, IFieldQueryNode child, AggregationBase aggregation)
+    private static void AddAggregation(AggregationBase container, ITermsAggregation? termsAggregation, IFieldQueryNode child, AggregationBase aggregation)
     {
         if (container is BucketAggregationBase bucketContainer)
         {
@@ -108,7 +108,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
         AddTermsOrder(termsAggregation, child, aggregation);
     }
 
-    private static void AddTermsOrder(ITermsAggregation termsAggregation, IFieldQueryNode child, AggregationBase aggregation, string bucketPathPrefix = null)
+    private static void AddTermsOrder(ITermsAggregation? termsAggregation, IFieldQueryNode child, AggregationBase aggregation, string? bucketPathPrefix = null)
     {
         if (termsAggregation is null || child.Prefix is not "-" and not "+")
             return;
@@ -172,7 +172,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
 
     private async Task<AggregationBase> GetParentContainerAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        AggregationBase container = null;
+        AggregationBase? container = null;
         var currentNode = node;
         while (container is null && currentNode is not null)
         {
@@ -194,8 +194,8 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
 
         if (container is null)
         {
-            container = new ChildrenAggregation(null, null);
-            currentNode.SetAggregation(container);
+            container = new GlobalAggregation("root");
+            currentNode!.SetAggregation(container);
         }
 
         return container;

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -104,7 +104,8 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         }
         else
         {
-            node.SetQuery(container!);
+            if (container is not null)
+                node.SetQuery(container);
         }
     }
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -104,8 +104,7 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         }
         else
         {
-            if (container is not null)
-                node.SetQuery(container);
+            node.SetQuery(container);
         }
     }
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -19,8 +19,8 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        QueryBase query = await node.GetQueryAsync(() => node.GetDefaultQueryAsync(context)).ConfigureAwait(false);
-        QueryBase container = query;
+        QueryBase? query = await node.GetQueryAsync(() => node.GetDefaultQueryAsync(context)).ConfigureAwait(false);
+        QueryBase? container = query;
         var nested = query as NestedQuery;
 
         // Reset container for non-root nested groups so children combine into a fresh
@@ -67,8 +67,8 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
 
         foreach (var (path, pathQueries) in nestedQueries)
         {
-            QueryContainer combinedInner = null;
-            QueryContainer nestedFilter = null;
+            QueryContainer? combinedInner = null;
+            QueryContainer? nestedFilter = null;
             foreach (var (child, innerQuery) in pathQueries)
             {
                 QueryContainer q = innerQuery;
@@ -104,7 +104,7 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         }
         else
         {
-            node.SetQuery(container);
+            node.SetQuery(container!);
         }
     }
 
@@ -116,8 +116,11 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         return op;
     }
 
-    private static QueryBase Combine(QueryBase left, QueryBase right, GroupOperator op)
+    private static QueryBase? Combine(QueryBase? left, QueryBase right, GroupOperator op)
     {
+        if (left is null)
+            return right;
+
         if (op is GroupOperator.And)
             return left & right;
 
@@ -127,8 +130,11 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         return left;
     }
 
-    private static QueryContainer Combine(QueryContainer left, QueryContainer right, GroupOperator op)
+    private static QueryContainer? Combine(QueryContainer? left, QueryContainer right, GroupOperator op)
     {
+        if (left is null)
+            return right;
+
         if (op is GroupOperator.And)
             return left & right;
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/ElasticQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/ElasticQueryVisitorContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -7,10 +7,10 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors;
 
 public class ElasticQueryVisitorContext : QueryVisitorContext, IElasticQueryVisitorContext
 {
-    public Func<Task<string>> DefaultTimeZone { get; set; }
+    public Func<Task<string>>? DefaultTimeZone { get; set; }
     public bool UseScoring { get; set; }
-    public ElasticMappingResolver MappingResolver { get; set; }
+    public ElasticMappingResolver MappingResolver { get; set; } = ElasticMappingResolver.NullInstance;
     public ICollection<ElasticRuntimeField> RuntimeFields { get; } = new List<ElasticRuntimeField>();
     public bool? EnableRuntimeFieldResolver { get; set; }
-    public RuntimeFieldResolver RuntimeFieldResolver { get; set; }
+    public RuntimeFieldResolver? RuntimeFieldResolver { get; set; }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
@@ -10,9 +10,9 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors;
 
 public class GeoVisitor : ChainableQueryVisitor
 {
-    private readonly Func<string, Task<string>> _resolveGeoLocation;
+    private readonly Func<string, Task<string>>? _resolveGeoLocation;
 
-    public GeoVisitor(Func<string, Task<string>> resolveGeoLocation = null)
+    public GeoVisitor(Func<string, Task<string>>? resolveGeoLocation = null)
     {
         _resolveGeoLocation = resolveGeoLocation;
     }
@@ -22,7 +22,7 @@ public class GeoVisitor : ChainableQueryVisitor
         if (context.QueryType != QueryTypes.Query || context is not IElasticQueryVisitorContext elasticContext || !elasticContext.MappingResolver.IsGeoPropertyType(node.Field))
             return;
 
-        string location = _resolveGeoLocation != null ? await _resolveGeoLocation(node.Term).ConfigureAwait(false) ?? node.Term : node.Term;
+        string? location = _resolveGeoLocation != null ? await _resolveGeoLocation(node.Term!).ConfigureAwait(false) ?? node.Term : node.Term;
         var query = new GeoDistanceQuery { Field = node.Field, Location = location, Distance = node.Proximity ?? Distance.Miles(10) };
         node.SetQuery(query);
     }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
@@ -22,7 +22,10 @@ public class GeoVisitor : ChainableQueryVisitor
         if (context.QueryType != QueryTypes.Query || context is not IElasticQueryVisitorContext elasticContext || !elasticContext.MappingResolver.IsGeoPropertyType(node.Field))
             return;
 
-        string? location = _resolveGeoLocation != null ? await _resolveGeoLocation(node.Term!).ConfigureAwait(false) ?? node.Term : node.Term;
+        if (String.IsNullOrEmpty(node.Term))
+            return;
+
+        string? location = _resolveGeoLocation is not null ? await _resolveGeoLocation(node.Term).ConfigureAwait(false) ?? node.Term : node.Term;
         var query = new GeoDistanceQuery { Field = node.Field, Location = location, Distance = node.Proximity ?? Distance.Miles(10) };
         node.SetQuery(query);
     }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
@@ -24,14 +24,15 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<IEnumerable<I
         _fields.Add(sort);
     }
 
-    public override async Task<IEnumerable<IFieldSort>> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IEnumerable<IFieldSort>> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        await node.AcceptAsync(this, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        await node.AcceptAsync(this, context).ConfigureAwait(false);
         return _fields;
     }
 
     public static Task<IEnumerable<IFieldSort>> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext();
         return new GetSortFieldsVisitor().AcceptAsync(node, context);
     }
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
@@ -18,7 +18,7 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<IEnumerable<I
             return;
 
         var sort = node.GetSort(() => node.GetDefaultSort(context));
-        if (sort.SortKey == null)
+        if (sort?.SortKey == null)
             return;
 
         _fields.Add(sort);
@@ -30,12 +30,12 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<IEnumerable<I
         return _fields;
     }
 
-    public static Task<IEnumerable<IFieldSort>> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task<IEnumerable<IFieldSort>> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GetSortFieldsVisitor().AcceptAsync(node, context);
+        return new GetSortFieldsVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
     }
 
-    public static IEnumerable<IFieldSort> Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static IEnumerable<IFieldSort> Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
@@ -18,21 +18,21 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<IEnumerable<I
             return;
 
         var sort = node.GetSort(() => node.GetDefaultSort(context));
-        if (sort?.SortKey == null)
+        if (sort?.SortKey is null)
             return;
 
         _fields.Add(sort);
     }
 
-    public override async Task<IEnumerable<IFieldSort>> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IEnumerable<IFieldSort>> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
+        await node.AcceptAsync(this, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return _fields;
     }
 
     public static Task<IEnumerable<IFieldSort>> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GetSortFieldsVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
+        return new GetSortFieldsVisitor().AcceptAsync(node, context);
     }
 
     public static IEnumerable<IFieldSort> Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
@@ -26,13 +26,14 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<IEnumerable<I
 
     public override async Task<IEnumerable<IFieldSort>> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(context);
+        await node.AcceptAsync(this, context).ConfigureAwait(false);
         return _fields;
     }
 
     public static Task<IEnumerable<IFieldSort>> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GetSortFieldsVisitor().AcceptAsync(node, context);
+        return new GetSortFieldsVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
     }
 
     public static IEnumerable<IFieldSort> Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
@@ -26,7 +26,7 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<IEnumerable<I
 
     public override async Task<IEnumerable<IFieldSort>> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context!).ConfigureAwait(false);
+        await node.AcceptAsync(this, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return _fields;
     }
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
@@ -26,14 +26,13 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<IEnumerable<I
 
     public override async Task<IEnumerable<IFieldSort>> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
+        await node.AcceptAsync(this, context!).ConfigureAwait(false);
         return _fields;
     }
 
     public static Task<IEnumerable<IFieldSort>> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GetSortFieldsVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
+        return new GetSortFieldsVisitor().AcceptAsync(node, context);
     }
 
     public static IEnumerable<IFieldSort> Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/IElasticQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/IElasticQueryVisitorContext.cs
@@ -13,7 +13,7 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors
         /// <summary>
         /// Provides the default timezone for date queries when not explicitly specified.
         /// </summary>
-        Func<Task<string>> DefaultTimeZone { get; set; }
+        Func<Task<string>>? DefaultTimeZone { get; set; }
 
         /// <summary>
         /// Whether to use scoring queries (query context) instead of filters (filter context).
@@ -38,7 +38,7 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors
         /// <summary>
         /// Resolves field names to runtime field definitions for dynamic field support.
         /// </summary>
-        RuntimeFieldResolver RuntimeFieldResolver { get; set; }
+        RuntimeFieldResolver? RuntimeFieldResolver { get; set; }
     }
 }
 
@@ -49,7 +49,7 @@ namespace Foundatio.Parsers
     /// </summary>
     /// <param name="field">The field name to resolve.</param>
     /// <returns>The runtime field definition, or null if the field should not be a runtime field.</returns>
-    public delegate Task<ElasticRuntimeField> RuntimeFieldResolver(string field);
+    public delegate Task<ElasticRuntimeField?> RuntimeFieldResolver(string field);
 
     /// <summary>
     /// Defines an Elasticsearch runtime field for dynamic field computation.
@@ -59,7 +59,7 @@ namespace Foundatio.Parsers
         /// <summary>
         /// The name of the runtime field.
         /// </summary>
-        public string Name { get; set; }
+        public required string Name { get; set; }
 
         /// <summary>
         /// The data type of the runtime field.
@@ -69,7 +69,7 @@ namespace Foundatio.Parsers
         /// <summary>
         /// The Painless script that computes the field value.
         /// </summary>
-        public string Script { get; set; }
+        public required string Script { get; set; }
     }
 
     /// <summary>

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -12,9 +12,9 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors;
 
 public class NestedVisitor : ChainableQueryVisitor
 {
-    private readonly NestedFilterResolver _filterResolver;
+    private readonly NestedFilterResolver? _filterResolver;
 
-    public NestedVisitor(NestedFilterResolver filterResolver = null)
+    public NestedVisitor(NestedFilterResolver? filterResolver = null)
     {
         _filterResolver = filterResolver;
     }
@@ -24,7 +24,7 @@ public class NestedVisitor : ChainableQueryVisitor
         if (String.IsNullOrEmpty(node.Field))
             return base.VisitAsync(node, context);
 
-        string nestedProperty = GetNestedProperty(node.Field, context);
+        string? nestedProperty = GetNestedProperty(node.Field, context);
         if (nestedProperty is null)
             return base.VisitAsync(node, context);
 
@@ -40,9 +40,9 @@ public class NestedVisitor : ChainableQueryVisitor
 
     private async Task VisitGroupWithFilterAsync(GroupNode node, string nestedProperty, IQueryVisitorContext context)
     {
-        string originalField = node.GetOriginalField();
+        string? originalField = node.GetOriginalField();
         ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
-        var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
+        var filter = await _filterResolver!(nestedProperty, originalField!, node.Field!, context).ConfigureAwait(false);
         if (filter is not null)
             node.SetNestedFilter(filter);
 
@@ -74,7 +74,7 @@ public class NestedVisitor : ChainableQueryVisitor
         if (IsInsideNestedGroup(node))
             return Task.CompletedTask;
 
-        string nestedProperty = GetNestedProperty(node.Field, context);
+        string? nestedProperty = GetNestedProperty(node.Field, context);
         if (nestedProperty is null)
             return Task.CompletedTask;
 
@@ -95,9 +95,9 @@ public class NestedVisitor : ChainableQueryVisitor
 
     private async Task HandleNestedFieldWithFilterAsync(IFieldQueryNode node, string nestedProperty, IQueryVisitorContext context)
     {
-        string originalField = node.GetOriginalField();
+        string? originalField = node.GetOriginalField();
         ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
-        var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
+        var filter = await _filterResolver!(nestedProperty, originalField!, node.Field!, context).ConfigureAwait(false);
         if (filter is not null)
             node.SetNestedFilter(filter);
 
@@ -138,9 +138,9 @@ public class NestedVisitor : ChainableQueryVisitor
         return false;
     }
 
-    private static string GetNestedProperty(string fullName, IQueryVisitorContext context)
+    private static string? GetNestedProperty(string? fullName, IQueryVisitorContext context)
     {
-        string[] nameParts = fullName?.Split('.');
+        string[]? nameParts = fullName?.Split('.');
 
         if (nameParts is null || context is not IElasticQueryVisitorContext elasticContext || nameParts is { Length: 0 })
             return null;

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -274,7 +274,7 @@ public static class QueryNodeExtensions
                 if (defaultFields == null || defaultFields.Length == 0)
                     fields.Add("");
                 else
-                    foreach (string defaultField in fields)
+                    foreach (string defaultField in defaultFields)
                         fields.Add(defaultField);
             }
         }

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -36,7 +36,7 @@ public static class QueryNodeExtensions
             return false;
 
         if (node is IFieldQueryNode fieldNode)
-            return (fieldNode.IsNegated.HasValue && fieldNode.IsNegated.Value == true) || (!String.IsNullOrEmpty(fieldNode.Prefix) && (fieldNode.Prefix == "-" || fieldNode.Prefix == "!"));
+            return fieldNode.IsNegated is true || (!String.IsNullOrEmpty(fieldNode.Prefix) && fieldNode.Prefix is "-" or "!");
 
         return false;
     }
@@ -123,7 +123,7 @@ public static class QueryNodeExtensions
         if (node.IsRequired())
             return false;
 
-        return node.IsExcluded() || node.GetGroupNode()?.IsExcluded() == true;
+        return node.IsExcluded() || node.GetGroupNode()?.IsExcluded() is true;
     }
 
     public static GroupNode? GetRootNode(this IQueryNode node)

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -123,10 +123,10 @@ public static class QueryNodeExtensions
         if (node.IsRequired())
             return false;
 
-        return node.IsExcluded() || node.GetGroupNode().IsExcluded();
+        return node.IsExcluded() || node.GetGroupNode()?.IsExcluded() == true;
     }
 
-    public static GroupNode GetRootNode(this IQueryNode node)
+    public static GroupNode? GetRootNode(this IQueryNode node)
     {
         if (node == null)
             return null;
@@ -143,7 +143,7 @@ public static class QueryNodeExtensions
         return null;
     }
 
-    public static GroupNode GetGroupNode(this IQueryNode node, bool onlyParensOrRoot = true)
+    public static GroupNode? GetGroupNode(this IQueryNode node, bool onlyParensOrRoot = true)
     {
         if (node == null)
             return null;
@@ -161,9 +161,9 @@ public static class QueryNodeExtensions
     }
 
     private const string TimeZoneKey = "@TimeZone";
-    public static string GetTimeZone(this IFieldQueryNode node, string defaultTimeZone = null)
+    public static string? GetTimeZone(this IFieldQueryNode node, string? defaultTimeZone = null)
     {
-        if (!node.Data.TryGetValue(TimeZoneKey, out object value))
+        if (!node.Data.TryGetValue(TimeZoneKey, out object? value))
             return defaultTimeZone;
 
         return value as string;
@@ -175,9 +175,9 @@ public static class QueryNodeExtensions
     }
 
     private const string OriginalFieldKey = "@OriginalField";
-    public static string GetOriginalField(this IFieldQueryNode node)
+    public static string? GetOriginalField(this IFieldQueryNode node)
     {
-        if (!node.Data.TryGetValue(OriginalFieldKey, out object value))
+        if (!node.Data.TryGetValue(OriginalFieldKey, out object? value))
             return node.Field;
 
         return value as string;
@@ -194,33 +194,35 @@ public static class QueryNodeExtensions
         return node.Data.ContainsKey(OperationTypeKey);
     }
 
-    public static string GetOperationType(this IQueryNode node)
+    public static string? GetOperationType(this IQueryNode node)
     {
-        if (!node.Data.TryGetValue(OperationTypeKey, out object value))
+        if (!node.Data.TryGetValue(OperationTypeKey, out object? value))
             return null;
 
-        return (string)value;
+        return (string?)value;
     }
 
-    public static void SetOperationType(this IQueryNode node, string operationType)
+    public static void SetOperationType(this IQueryNode node, string? operationType)
     {
-        node.Data[OperationTypeKey] = operationType;
+        if (operationType is null)
+            node.Data.Remove(OperationTypeKey);
+        else
+            node.Data[OperationTypeKey] = operationType;
     }
 
-    public static string[] GetDefaultFields(this IQueryNode node, string[] rootDefaultFields)
+    public static string[]? GetDefaultFields(this IQueryNode node, string[]? rootDefaultFields)
     {
         var scopedNode = GetGroupNode(node);
-        return !String.IsNullOrEmpty(scopedNode?.Field) ? [scopedNode.Field] : rootDefaultFields;
+        return !String.IsNullOrEmpty(scopedNode?.Field) ? [scopedNode!.Field!] : rootDefaultFields;
     }
 
-    public static GroupOperator GetOperator(this IQueryNode node, IQueryVisitorContext context)
+    public static GroupOperator GetOperator(this IQueryNode node, IQueryVisitorContext? context)
     {
         var defaultOperator = GroupOperator.And;
         if (context != null && context.DefaultOperator != GroupOperator.Default)
             defaultOperator = context.DefaultOperator;
 
-        if (node is not GroupNode groupNode)
-            groupNode = node.Parent as GroupNode;
+        var groupNode = node as GroupNode ?? node.Parent as GroupNode;
 
         if (groupNode == null)
             return defaultOperator;
@@ -235,12 +237,12 @@ public static class QueryNodeExtensions
 
     private const string ReferencedFieldsKey = "@ReferencedFields";
     private const string CurrentGroupReferencedFieldsKey = "@CurrentGroupReferencedFields";
-    public static ISet<string> GetReferencedFields<T>(this T node, IQueryVisitorContext context = null, bool currentGroupOnly = false) where T : IQueryNode
+    public static ISet<string> GetReferencedFields<T>(this T node, IQueryVisitorContext? context = null, bool currentGroupOnly = false) where T : IQueryNode
     {
-        if (!currentGroupOnly && node.Data.TryGetValue(ReferencedFieldsKey, out object allFieldsObject) && allFieldsObject is ISet<string> allFields)
+        if (!currentGroupOnly && node.Data.TryGetValue(ReferencedFieldsKey, out object? allFieldsObject) && allFieldsObject is ISet<string> allFields)
             return allFields;
 
-        if (currentGroupOnly && node.Data.TryGetValue(CurrentGroupReferencedFieldsKey, out object immediateFieldsObject) && immediateFieldsObject is ISet<string> immediateFields)
+        if (currentGroupOnly && node.Data.TryGetValue(CurrentGroupReferencedFieldsKey, out object? immediateFieldsObject) && immediateFieldsObject is ISet<string> immediateFields)
             return immediateFields;
 
         var fields = new HashSet<string>();
@@ -255,7 +257,7 @@ public static class QueryNodeExtensions
         return fields;
     }
 
-    private static void GatherReferencedFields(IQueryVisitorContext context, IQueryNode node, HashSet<string> fields, int currentGroupDepth, int maxGroupDepth)
+    private static void GatherReferencedFields(IQueryVisitorContext? context, IQueryNode node, HashSet<string> fields, int currentGroupDepth, int maxGroupDepth)
     {
         if (maxGroupDepth >= 0 && currentGroupDepth >= 0 && currentGroupDepth > maxGroupDepth)
             return;
@@ -268,7 +270,7 @@ public static class QueryNodeExtensions
             }
             else if (fieldNode is not GroupNode)
             {
-                string[] defaultFields = node.GetDefaultFields(context?.DefaultFields);
+                string[]? defaultFields = node.GetDefaultFields(context?.DefaultFields);
                 if (defaultFields == null || defaultFields.Length == 0)
                     fields.Add("");
                 else

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryVisitorContextExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryVisitorContextExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -8,7 +9,7 @@ namespace Foundatio.Parsers.LuceneQueries.Extensions;
 
 public static class QueryVisitorContextExtensions
 {
-    public static QueryFieldResolver GetFieldResolver(this IQueryVisitorContext context)
+    public static QueryFieldResolver? GetFieldResolver(this IQueryVisitorContext context)
     {
         var resolverContext = context as IQueryVisitorContextWithFieldResolver;
         return resolverContext?.FieldResolver;
@@ -19,7 +20,7 @@ public static class QueryVisitorContextExtensions
         if (context is not IQueryVisitorContextWithFieldResolver resolverContext)
             throw new ArgumentException("Context must be of type IQueryVisitorContextWithFieldResolver", nameof(context));
 
-        resolverContext.FieldResolver = (field, _) => Task.FromResult(resolver(field));
+        resolverContext.FieldResolver = (field, _) => Task.FromResult<string?>(resolver(field));
 
         return context;
     }
@@ -34,7 +35,7 @@ public static class QueryVisitorContextExtensions
         return context;
     }
 
-    public static IncludeResolver GetIncludeResolver(this IQueryVisitorContext context)
+    public static IncludeResolver? GetIncludeResolver(this IQueryVisitorContext context)
     {
         if (context is not IQueryVisitorContextWithIncludeResolver includeContext)
             throw new ArgumentException("Context must be of type IQueryVisitorContextWithIncludeResolver", nameof(context));
@@ -173,9 +174,10 @@ public static class QueryVisitorContextExtensions
         return context;
     }
 
+    [return: MaybeNull]
     public static T GetValue<T>(this IQueryVisitorContext context, string key)
     {
-        if (context.Data.TryGetValue(key, out object value) && value is T typedValue)
+        if (context.Data.TryGetValue(key, out object? value) && value is T typedValue)
             return typedValue;
 
         return default;
@@ -183,7 +185,7 @@ public static class QueryVisitorContextExtensions
 
     public static ICollection<T> GetCollection<T>(this IQueryVisitorContext context, string key)
     {
-        if (context.Data.TryGetValue(key, out object value))
+        if (context.Data.TryGetValue(key, out object? value))
         {
             if (value is ICollection<T> typedValue)
                 return typedValue;
@@ -199,15 +201,15 @@ public static class QueryVisitorContextExtensions
 
     public static DateTime? GetDate(this IQueryVisitorContext context, string key)
     {
-        if (context.Data.TryGetValue(key, out object value) && value is DateTime date)
+        if (context.Data.TryGetValue(key, out object? value) && value is DateTime date)
             return date;
 
         return null;
     }
 
-    public static string GetString(this IQueryVisitorContext context, string key)
+    public static string? GetString(this IQueryVisitorContext context, string key)
     {
-        if (context.Data.TryGetValue(key, out object value) && value is string str)
+        if (context.Data.TryGetValue(key, out object? value) && value is string str)
             return str;
 
         return null;
@@ -215,7 +217,7 @@ public static class QueryVisitorContextExtensions
 
     public static bool GetBoolean(this IQueryVisitorContext context, string key, bool defaultValue = false)
     {
-        if (context.Data.TryGetValue(key, out object value) && value is bool b)
+        if (context.Data.TryGetValue(key, out object? value) && value is bool b)
             return b;
 
         return defaultValue;
@@ -229,7 +231,7 @@ public static class QueryVisitorContextExtensions
         return context;
     }
 
-    public static IQueryNode GetAlternateInvertedCriteria(this IQueryVisitorContext context)
+    public static IQueryNode? GetAlternateInvertedCriteria(this IQueryVisitorContext context)
     {
         return context.GetValue<IQueryNode>(AlternateInvertedCriteriaKey);
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryVisitorContextExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryVisitorContextExtensions.cs
@@ -15,7 +15,7 @@ public static class QueryVisitorContextExtensions
         return resolverContext?.FieldResolver;
     }
 
-    public static T SetFieldResolver<T>(this T context, Func<string, string> resolver) where T : IQueryVisitorContext
+    public static T SetFieldResolver<T>(this T context, Func<string, string?> resolver) where T : IQueryVisitorContext
     {
         if (context is not IQueryVisitorContextWithFieldResolver resolverContext)
             throw new ArgumentException("Context must be of type IQueryVisitorContextWithFieldResolver", nameof(context));

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/StringExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/StringExtensions.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Parsers.LuceneQueries.Extensions;
 
 public static class StringExtensions
 {
-    public static string Unescape(this string input)
+    public static string? Unescape(this string? input)
     {
         if (input == null)
             return null;

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/TextWriterExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/TextWriterExtensions.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Parsers.LuceneQueries.Extensions;
 
 public static class TextWriterExtensions
 {
-    public static void WriteIf(this TextWriter writer, bool condition, string content, params object[] arguments)
+    public static void WriteIf(this TextWriter writer, bool condition, string content, params object?[] arguments)
     {
         if (!condition)
             return;
@@ -15,7 +15,7 @@ public static class TextWriterExtensions
             writer.Write(content);
     }
 
-    public static void WriteLineIf(this TextWriter writer, bool condition, string content, params object[] arguments)
+    public static void WriteLineIf(this TextWriter writer, bool condition, string content, params object?[] arguments)
     {
         if (!condition)
             return;

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.cs
@@ -6,13 +6,13 @@ namespace Foundatio.Parsers.LuceneQueries;
 
 public partial class LuceneQueryParser : IQueryParser
 {
-    public virtual Task<IQueryNode> ParseAsync(string query, IQueryVisitorContext context = null)
+    public virtual Task<IQueryNode?> ParseAsync(string query, IQueryVisitorContext? context = null)
     {
         var result = Parse(query);
-        return Task.FromResult<IQueryNode>(result);
+        return Task.FromResult<IQueryNode?>(result);
     }
 
-    public IQueryNode Parse(string query, IQueryVisitorContext context)
+    public IQueryNode? Parse(string query, IQueryVisitorContext? context)
     {
         return ParseAsync(query, context).GetAwaiter().GetResult();
     }
@@ -28,6 +28,6 @@ public interface IQueryParser
     /// </summary>
     /// <param name="query">The query string to parse.</param>
     /// <param name="context">Optional visitor context for parsing configuration.</param>
-    /// <returns>The root node of the parsed query AST.</returns>
-    Task<IQueryNode> ParseAsync(string query, IQueryVisitorContext context = null);
+    /// <returns>The root node of the parsed query AST, or null if parsing failed (check context for validation errors).</returns>
+    Task<IQueryNode?> ParseAsync(string query, IQueryVisitorContext? context = null);
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/ExistsNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/ExistsNode.cs
@@ -7,9 +7,9 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 public class ExistsNode : QueryNodeBase, IFieldQueryNode
 {
     public bool? IsNegated { get; set; }
-    public string Prefix { get; set; }
-    public string Field { get; set; }
-    public string UnescapedField => Field?.Unescape();
+    public string? Prefix { get; set; }
+    public string? Field { get; set; }
+    public string? UnescapedField => Field?.Unescape();
 
     public ExistsNode CopyTo(ExistsNode target)
     {

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/GroupNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/GroupNode.cs
@@ -7,8 +7,8 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 
 public class GroupNode : QueryNodeBase, IFieldQueryWithProximityAndBoostNode
 {
-    private IQueryNode _left;
-    public IQueryNode Left
+    private IQueryNode? _left;
+    public IQueryNode? Left
     {
         get => _left;
         set
@@ -19,8 +19,8 @@ public class GroupNode : QueryNodeBase, IFieldQueryWithProximityAndBoostNode
         }
     }
 
-    private IQueryNode _right;
-    public IQueryNode Right
+    private IQueryNode? _right;
+    public IQueryNode? Right
     {
         get => _right;
         set
@@ -33,14 +33,14 @@ public class GroupNode : QueryNodeBase, IFieldQueryWithProximityAndBoostNode
 
     public GroupOperator Operator { get; set; } = GroupOperator.Default;
     public bool HasParens { get; set; }
-    public string Field { get; set; }
-    public string UnescapedField => Field?.Unescape();
+    public string? Field { get; set; }
+    public string? UnescapedField => Field?.Unescape();
     public bool? IsNegated { get; set; }
-    public string Prefix { get; set; }
-    public string Boost { get; set; }
-    public string UnescapedBoost => Boost?.Unescape();
-    public string Proximity { get; set; }
-    public string UnescapedProximity => Proximity?.Unescape();
+    public string? Prefix { get; set; }
+    public string? Boost { get; set; }
+    public string? UnescapedBoost => Boost?.Unescape();
+    public string? Proximity { get; set; }
+    public string? UnescapedProximity => Proximity?.Unescape();
 
     public GroupNode CopyTo(GroupNode target)
     {

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
@@ -16,7 +16,7 @@ public interface IQueryNode
     /// <summary>
     /// The parent node in the AST, or null for the root node.
     /// </summary>
-    IQueryNode Parent { get; set; }
+    IQueryNode? Parent { get; set; }
 
     /// <summary>
     /// The child nodes of this node.
@@ -57,17 +57,17 @@ public interface IFieldQueryNode : IQueryNode
     /// <summary>
     /// The prefix modifier (+, -, etc.) applied to this node.
     /// </summary>
-    string Prefix { get; set; }
+    string? Prefix { get; set; }
 
     /// <summary>
     /// The field name this query targets, or null for default field queries.
     /// </summary>
-    string Field { get; set; }
+    string? Field { get; set; }
 
     /// <summary>
     /// The field name with escape sequences resolved.
     /// </summary>
-    string UnescapedField { get; }
+    string? UnescapedField { get; }
 }
 
 /// <summary>
@@ -78,12 +78,12 @@ public interface IFieldQueryWithProximityAndBoostNode : IFieldQueryNode
     /// <summary>
     /// The boost factor (^) to increase or decrease relevance scoring.
     /// </summary>
-    string Boost { get; set; }
+    string? Boost { get; set; }
 
     /// <summary>
     /// The boost value with escape sequences resolved.
     /// </summary>
-    string UnescapedBoost { get; }
+    string? UnescapedBoost { get; }
 
     /// <summary>
     /// The proximity/slop factor (~) for fuzzy or phrase proximity searches.
@@ -94,10 +94,10 @@ public interface IFieldQueryWithProximityAndBoostNode : IFieldQueryNode
     /// For quoted terms (e.g., <c>"jakarta apache"~10</c>), this indicates a phrase proximity search with word slop.
     /// An empty string means the bare tilde was used with no explicit value (e.g., <c>term~</c>).
     /// </remarks>
-    string Proximity { get; set; }
+    string? Proximity { get; set; }
 
     /// <summary>
     /// The proximity value with escape sequences resolved.
     /// </summary>
-    string UnescapedProximity { get; }
+    string? UnescapedProximity { get; }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
@@ -31,7 +31,7 @@ public interface IQueryNode
     /// <summary>
     /// Accepts a visitor for tree traversal using the visitor pattern.
     /// </summary>
-    Task<IQueryNode> AcceptAsync(IQueryNodeVisitor visitor, IQueryVisitorContext context);
+    Task<IQueryNode?> AcceptAsync(IQueryNodeVisitor visitor, IQueryVisitorContext context);
 
     /// <summary>
     /// Returns the query string representation of this node.

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/MissingNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/MissingNode.cs
@@ -7,9 +7,9 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 public class MissingNode : QueryNodeBase, IFieldQueryNode
 {
     public bool? IsNegated { get; set; }
-    public string Prefix { get; set; }
-    public string Field { get; set; }
-    public string UnescapedField => Field?.Unescape();
+    public string? Prefix { get; set; }
+    public string? Field { get; set; }
+    public string? UnescapedField => Field?.Unescape();
 
     public MissingNode CopyTo(MissingNode target)
     {

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/QueryNodeBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/QueryNodeBase.cs
@@ -28,7 +28,7 @@ public abstract class QueryNodeBase : IQueryNode
 
     public IDictionary<string, object> Data { get; } = new Dictionary<string, object>();
     public abstract IEnumerable<IQueryNode> Children { get; }
-    public IQueryNode Parent { get; set; }
+    public IQueryNode? Parent { get; set; }
     public static readonly IList<IQueryNode> EmptyNodeList = new List<IQueryNode>().AsReadOnly();
 
     public abstract IQueryNode Clone();

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/QueryNodeBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/QueryNodeBase.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 
 public abstract class QueryNodeBase : IQueryNode
 {
-    public virtual Task<IQueryNode> AcceptAsync(IQueryNodeVisitor visitor, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> AcceptAsync(IQueryNodeVisitor visitor, IQueryVisitorContext context)
     {
         if (this is GroupNode groupNode)
             return visitor.VisitAsync(groupNode, context);
@@ -23,7 +23,7 @@ public abstract class QueryNodeBase : IQueryNode
         if (this is ExistsNode existsNode)
             return visitor.VisitAsync(existsNode, context);
 
-        return Task.FromResult<IQueryNode>(this);
+        return Task.FromResult<IQueryNode?>(this);
     }
 
     public IDictionary<string, object> Data { get; } = new Dictionary<string, object>();

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/TermNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/TermNode.cs
@@ -8,17 +8,17 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 public class TermNode : QueryNodeBase, IFieldQueryWithProximityAndBoostNode
 {
     public bool? IsNegated { get; set; }
-    public string Prefix { get; set; }
-    public string Field { get; set; }
-    public string UnescapedField => Field?.Unescape();
-    public string Term { get; set; }
-    public string UnescapedTerm => Term?.Unescape();
+    public string? Prefix { get; set; }
+    public string? Field { get; set; }
+    public string? UnescapedField => Field?.Unescape();
+    public string? Term { get; set; }
+    public string? UnescapedTerm => Term?.Unescape();
     public bool IsQuotedTerm { get; set; }
     public bool IsRegexTerm { get; set; }
-    public string Boost { get; set; }
-    public string UnescapedBoost => Boost?.Unescape();
-    public string Proximity { get; set; }
-    public string UnescapedProximity => Proximity?.Unescape();
+    public string? Boost { get; set; }
+    public string? UnescapedBoost => Boost?.Unescape();
+    public string? Proximity { get; set; }
+    public string? UnescapedProximity => Proximity?.Unescape();
 
     public TermNode CopyTo(TermNode target)
     {

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/TermRangeNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/TermRangeNode.cs
@@ -8,22 +8,22 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 public class TermRangeNode : QueryNodeBase, IFieldQueryNode
 {
     public bool? IsNegated { get; set; }
-    public string Field { get; set; }
-    public string UnescapedField => Field?.Unescape();
-    public string Prefix { get; set; }
-    public string Min { get; set; }
-    public string UnescapedMin => Min?.Unescape();
+    public string? Field { get; set; }
+    public string? UnescapedField => Field?.Unescape();
+    public string? Prefix { get; set; }
+    public string? Min { get; set; }
+    public string? UnescapedMin => Min?.Unescape();
     public bool IsMinQuotedTerm { get; set; }
-    public string Max { get; set; }
-    public string UnescapedMax => Max?.Unescape();
+    public string? Max { get; set; }
+    public string? UnescapedMax => Max?.Unescape();
     public bool IsMaxQuotedTerm { get; set; }
-    public string Operator { get; set; }
-    public string Delimiter { get; set; }
+    public string? Operator { get; set; }
+    public string? Delimiter { get; set; }
     public bool? MinInclusive { get; set; }
     public bool? MaxInclusive { get; set; }
-    public string Boost { get; set; }
-    public string UnescapedBoost => Boost?.Unescape();
-    public string Proximity { get; set; }
+    public string? Boost { get; set; }
+    public string? UnescapedBoost => Boost?.Unescape();
+    public string? Proximity { get; set; }
 
     public TermRangeNode CopyTo(TermRangeNode target)
     {

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
@@ -22,7 +22,7 @@ public class QueryValidationOptions
 [DebuggerDisplay("IsValid: {IsValid} Message: {Message} Type: {QueryType}")]
 public class QueryValidationResult
 {
-    private ConcurrentDictionary<string, ICollection<string>> _operations = new(StringComparer.OrdinalIgnoreCase);
+    private ConcurrentDictionary<string, ICollection<string?>> _operations = new(StringComparer.OrdinalIgnoreCase);
 
     public string? QueryType { get; set; }
     public bool IsValid => ValidationErrors.Count == 0;
@@ -45,7 +45,7 @@ public class QueryValidationResult
     public ICollection<string> UnresolvedFields { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     public ICollection<string> UnresolvedIncludes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     public int MaxNodeDepth { get; set; } = 1;
-    public IDictionary<string, ICollection<string>> Operations => _operations;
+    public IDictionary<string, ICollection<string?>> Operations => _operations;
 
     public static implicit operator bool(QueryValidationResult info) => info.IsValid;
 
@@ -61,10 +61,10 @@ public class QueryValidationResult
         }
     }
 
-    internal void AddOperation(string operation, string field)
+    internal void AddOperation(string operation, string? field)
     {
         _operations.AddOrUpdate(operation,
-            _ => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { field },
+            _ => new HashSet<string?>(StringComparer.OrdinalIgnoreCase) { field },
             (_, collection) =>
             {
                 collection.Add(field);

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
@@ -24,7 +24,7 @@ public class QueryValidationResult
 {
     private ConcurrentDictionary<string, ICollection<string>> _operations = new(StringComparer.OrdinalIgnoreCase);
 
-    public string QueryType { get; set; }
+    public string? QueryType { get; set; }
     public bool IsValid => ValidationErrors.Count == 0;
     public ICollection<QueryValidationError> ValidationErrors { get; } = new List<QueryValidationError>();
     public string Message
@@ -103,12 +103,12 @@ public class QueryValidationError
 
 public class QueryValidationException : Exception
 {
-    public QueryValidationException(string message, QueryValidationResult result = null,
-        Exception inner = null) : base(message, inner)
+    public QueryValidationException(string message, QueryValidationResult? result = null,
+        Exception? inner = null) : base(message, inner)
     {
         Result = result;
     }
 
-    public QueryValidationResult Result { get; }
-    public ICollection<QueryValidationError> Errors => Result.ValidationErrors;
+    public QueryValidationResult? Result { get; }
+    public ICollection<QueryValidationError>? Errors => Result?.ValidationErrors;
 }

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
@@ -22,7 +22,7 @@ public class QueryValidationOptions
 [DebuggerDisplay("IsValid: {IsValid} Message: {Message} Type: {QueryType}")]
 public class QueryValidationResult
 {
-    private ConcurrentDictionary<string, ICollection<string?>> _operations = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, ICollection<string?>> _operations = new(StringComparer.OrdinalIgnoreCase);
 
     public string? QueryType { get; set; }
     public bool IsValid => ValidationErrors.Count == 0;

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
@@ -64,13 +64,28 @@ public class QueryValidationResult
     internal void AddOperation(string operation, string? field)
     {
         _operations.AddOrUpdate(operation,
-            _ => new HashSet<string?>(StringComparer.OrdinalIgnoreCase) { field },
+            _ => new HashSet<string?>(NullSafeOrdinalIgnoreCaseComparer.Instance) { field },
             (_, collection) =>
             {
                 collection.Add(field);
                 return collection;
             }
         );
+    }
+
+    private sealed class NullSafeOrdinalIgnoreCaseComparer : IEqualityComparer<string?>
+    {
+        public static readonly NullSafeOrdinalIgnoreCaseComparer Instance = new();
+
+        public bool Equals(string? x, string? y)
+        {
+            if (x is null && y is null) return true;
+            if (x is null || y is null) return false;
+            return StringComparer.OrdinalIgnoreCase.Equals(x, y);
+        }
+
+        public int GetHashCode(string? obj) =>
+            obj is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj);
     }
 }
 

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
@@ -64,28 +64,13 @@ public class QueryValidationResult
     internal void AddOperation(string operation, string? field)
     {
         _operations.AddOrUpdate(operation,
-            _ => new HashSet<string?>(NullSafeOrdinalIgnoreCaseComparer.Instance) { field },
+            _ => new HashSet<string?>(StringComparer.OrdinalIgnoreCase) { field },
             (_, collection) =>
             {
                 collection.Add(field);
                 return collection;
             }
         );
-    }
-
-    private sealed class NullSafeOrdinalIgnoreCaseComparer : IEqualityComparer<string?>
-    {
-        public static readonly NullSafeOrdinalIgnoreCaseComparer Instance = new();
-
-        public bool Equals(string? x, string? y)
-        {
-            if (x is null && y is null) return true;
-            if (x is null || y is null) return false;
-            return StringComparer.OrdinalIgnoreCase.Equals(x, y);
-        }
-
-        public int GetHashCode(string? obj) =>
-            obj is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj);
     }
 }
 

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -8,7 +8,7 @@ namespace Foundatio.Parsers.LuceneQueries;
 
 public class QueryValidator
 {
-    public static Task<QueryValidationResult> ValidateQueryAsync(string query, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateQueryAsync(string query, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
         if (context == null)
             context = new QueryVisitorContext();
@@ -18,7 +18,7 @@ public class QueryValidator
         return InternalValidateAsync(query, context, options);
     }
 
-    public static Task<QueryValidationResult> ValidateAggregationsAsync(string aggregations, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateAggregationsAsync(string aggregations, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
         if (context == null)
             context = new QueryVisitorContext();
@@ -28,7 +28,7 @@ public class QueryValidator
         return InternalValidateAsync(aggregations, context, options);
     }
 
-    public static Task<QueryValidationResult> ValidateSortAsync(string sort, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateSortAsync(string sort, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
         if (context == null)
             context = new QueryVisitorContext();
@@ -38,7 +38,7 @@ public class QueryValidator
         return InternalValidateAsync(sort, context, options);
     }
 
-    private static async Task<QueryValidationResult> InternalValidateAsync(string query, IQueryVisitorContextWithValidation context, QueryValidationOptions options = null)
+    private static async Task<QueryValidationResult> InternalValidateAsync(string query, IQueryVisitorContextWithValidation context, QueryValidationOptions? options = null)
     {
         var parser = new LuceneQueryParser();
         try
@@ -46,6 +46,9 @@ public class QueryValidator
             var node = await parser.ParseAsync(query);
             if (context == null)
                 context = new QueryVisitorContext();
+
+            if (node is null)
+                return context.GetValidationResult();
 
             if (options != null)
                 context.SetValidationOptions(options);
@@ -58,18 +61,18 @@ public class QueryValidator
             if (includeResolver != null)
                 node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
 
-            return await ValidationVisitor.RunAsync(node, context);
+            return await ValidationVisitor.RunAsync(node!, context);
         }
         catch (FormatException ex)
         {
             var cursor = ex.Data["cursor"] as Cursor;
-            context.AddValidationError(ex.Message, cursor.Column);
+            context.AddValidationError(ex.Message, cursor?.Column ?? 0);
 
             return context.GetValidationResult();
         }
     }
 
-    public static Task<QueryValidationResult> ValidateQueryAndThrowAsync(string query, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateQueryAndThrowAsync(string query, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
         if (context == null)
             context = new QueryVisitorContext();
@@ -79,7 +82,7 @@ public class QueryValidator
         return InternalValidateAndThrowAsync(query, context, options);
     }
 
-    public static Task<QueryValidationResult> ValidateAggregationsAndThrowAsync(string aggregations, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateAggregationsAndThrowAsync(string aggregations, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
         if (context == null)
             context = new QueryVisitorContext();
@@ -89,7 +92,7 @@ public class QueryValidator
         return InternalValidateAndThrowAsync(aggregations, context, options);
     }
 
-    public static Task<QueryValidationResult> ValidateSortAndThrowAsync(string sort, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateSortAndThrowAsync(string sort, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
         if (context == null)
             context = new QueryVisitorContext();
@@ -99,7 +102,7 @@ public class QueryValidator
         return InternalValidateAndThrowAsync(sort, context, options);
     }
 
-    private static async Task<QueryValidationResult> InternalValidateAndThrowAsync(string query, IQueryVisitorContextWithValidation context, QueryValidationOptions options = null)
+    private static async Task<QueryValidationResult> InternalValidateAndThrowAsync(string query, IQueryVisitorContextWithValidation context, QueryValidationOptions? options = null)
     {
         var parser = new LuceneQueryParser();
         try
@@ -107,6 +110,12 @@ public class QueryValidator
             var node = await parser.ParseAsync(query);
             if (context == null)
                 context = new QueryVisitorContext();
+
+            if (node is null)
+            {
+                var earlyResult = context.GetValidationResult();
+                throw new QueryValidationException(earlyResult.Message, earlyResult);
+            }
 
             options ??= new QueryValidationOptions();
             options.ShouldThrow = true;
@@ -120,12 +129,12 @@ public class QueryValidator
             if (includeResolver != null)
                 node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
 
-            return await ValidationVisitor.RunAsync(node, context);
+            return await ValidationVisitor.RunAsync(node!, context);
         }
         catch (FormatException ex)
         {
             var cursor = ex.Data["cursor"] as Cursor;
-            context.AddValidationError(ex.Message, cursor.Column);
+            context.AddValidationError(ex.Message, cursor?.Column ?? 0);
 
             throw new QueryValidationException(ex.Message, context.GetValidationResult(), ex);
         }

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
@@ -10,7 +10,7 @@ public class QueryValidator
 {
     public static Task<QueryValidationResult> ValidateQueryAsync(string query, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Query;
@@ -20,7 +20,7 @@ public class QueryValidator
 
     public static Task<QueryValidationResult> ValidateAggregationsAsync(string aggregations, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Aggregation;
@@ -30,7 +30,7 @@ public class QueryValidator
 
     public static Task<QueryValidationResult> ValidateSortAsync(string sort, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Sort;
@@ -44,21 +44,21 @@ public class QueryValidator
         try
         {
             var node = await parser.ParseAsync(query);
-            if (context == null)
+            if (context is null)
                 context = new QueryVisitorContext();
 
             if (node is null)
                 return context.GetValidationResult();
 
-            if (options != null)
+            if (options is not null)
                 context.SetValidationOptions(options);
 
             var fieldResolver = context.GetFieldResolver();
-            if (fieldResolver != null)
+            if (fieldResolver is not null)
                 node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver);
 
             var includeResolver = context.GetIncludeResolver();
-            if (includeResolver != null)
+            if (includeResolver is not null)
                 node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
 
             return await ValidationVisitor.RunAsync(node!, context);
@@ -74,7 +74,7 @@ public class QueryValidator
 
     public static Task<QueryValidationResult> ValidateQueryAndThrowAsync(string query, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Query;
@@ -84,7 +84,7 @@ public class QueryValidator
 
     public static Task<QueryValidationResult> ValidateAggregationsAndThrowAsync(string aggregations, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Aggregation;
@@ -94,7 +94,7 @@ public class QueryValidator
 
     public static Task<QueryValidationResult> ValidateSortAndThrowAsync(string sort, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Sort;
@@ -108,7 +108,7 @@ public class QueryValidator
         try
         {
             var node = await parser.ParseAsync(query);
-            if (context == null)
+            if (context is null)
                 context = new QueryVisitorContext();
 
             if (node is null)

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
@@ -57,9 +57,15 @@ public class QueryValidator
             if (fieldResolver is not null)
                 node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver);
 
+            if (node is null)
+                return context.GetValidationResult();
+
             var includeResolver = context.GetIncludeResolver();
             if (includeResolver is not null)
                 node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
+
+            if (node is null)
+                return context.GetValidationResult();
 
             return await ValidationVisitor.RunAsync(node, context);
         }
@@ -111,23 +117,35 @@ public class QueryValidator
             if (context is null)
                 context = new QueryVisitorContext();
 
+            options ??= new QueryValidationOptions();
+            options.ShouldThrow = true;
+            context.SetValidationOptions(options);
+
             if (node is null)
             {
                 var earlyResult = context.GetValidationResult();
                 throw new QueryValidationException(earlyResult.Message, earlyResult);
             }
 
-            options ??= new QueryValidationOptions();
-            options.ShouldThrow = true;
-            context.SetValidationOptions(options);
-
             var fieldResolver = context.GetFieldResolver();
             if (fieldResolver != null)
                 node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver);
 
+            if (node is null)
+            {
+                var earlyResult2 = context.GetValidationResult();
+                throw new QueryValidationException(earlyResult2.Message, earlyResult2);
+            }
+
             var includeResolver = context.GetIncludeResolver();
             if (includeResolver != null)
                 node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
+
+            if (node is null)
+            {
+                var earlyResult3 = context.GetValidationResult();
+                throw new QueryValidationException(earlyResult3.Message, earlyResult3);
+            }
 
             return await ValidationVisitor.RunAsync(node, context);
         }

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
@@ -61,7 +61,7 @@ public class QueryValidator
             if (includeResolver is not null)
                 node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
 
-            return await ValidationVisitor.RunAsync(node!, context);
+            return await ValidationVisitor.RunAsync(node, context);
         }
         catch (FormatException ex)
         {
@@ -129,7 +129,7 @@ public class QueryValidator
             if (includeResolver != null)
                 node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
 
-            return await ValidationVisitor.RunAsync(node!, context);
+            return await ValidationVisitor.RunAsync(node, context);
         }
         catch (FormatException ex)
         {

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
+using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Parsers.LuceneQueries.Visitors;
 using Pegasus.Common;
 
@@ -55,17 +56,11 @@ public class QueryValidator
 
             var fieldResolver = context.GetFieldResolver();
             if (fieldResolver is not null)
-                node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver);
-
-            if (node is null)
-                return context.GetValidationResult();
+                node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver) ?? node;
 
             var includeResolver = context.GetIncludeResolver();
             if (includeResolver is not null)
-                node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
-
-            if (node is null)
-                return context.GetValidationResult();
+                node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver) ?? node;
 
             return await ValidationVisitor.RunAsync(node, context);
         }
@@ -121,31 +116,24 @@ public class QueryValidator
             options.ShouldThrow = true;
             context.SetValidationOptions(options);
 
-            if (node is null)
+            // Visitors never nullify a non-null root in practice; this guard satisfies NRT
+            // and produces a clear validation error if a visitor unexpectedly returns null.
+            IQueryNode EnsureNode(IQueryNode? n)
             {
-                var earlyResult = context.GetValidationResult();
-                throw new QueryValidationException(earlyResult.Message, earlyResult);
+                if (n is not null) return n;
+                var result = context.GetValidationResult();
+                throw new QueryValidationException(result.Message, result);
             }
+
+            node = EnsureNode(node);
 
             var fieldResolver = context.GetFieldResolver();
             if (fieldResolver != null)
-                node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver);
-
-            if (node is null)
-            {
-                var earlyResult2 = context.GetValidationResult();
-                throw new QueryValidationException(earlyResult2.Message, earlyResult2);
-            }
+                node = EnsureNode(await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver));
 
             var includeResolver = context.GetIncludeResolver();
             if (includeResolver != null)
-                node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
-
-            if (node is null)
-            {
-                var earlyResult3 = context.GetValidationResult();
-                throw new QueryValidationException(earlyResult3.Message, earlyResult3);
-            }
+                node = EnsureNode(await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver));
 
             return await ValidationVisitor.RunAsync(node, context);
         }

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
@@ -118,11 +118,13 @@ public class QueryValidator
 
             // Visitors never nullify a non-null root in practice; this guard satisfies NRT
             // and produces a clear validation error if a visitor unexpectedly returns null.
-            IQueryNode EnsureNode(IQueryNode? n)
+            IQueryNode EnsureNode(IQueryNode? node)
             {
-                if (n is not null) return n;
-                var result = context.GetValidationResult();
-                throw new QueryValidationException(result.Message, result);
+                if (node is not null)
+                    return node;
+
+                var validationResult = context.GetValidationResult();
+                throw new QueryValidationException(validationResult.Message, validationResult);
             }
 
             node = EnsureNode(node);

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
@@ -78,7 +78,10 @@ public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, 
     public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
         if (_isDirty)
+        {
             _frozenVisitors = _visitors.OrderBy(v => v.Priority).ToArray();
+            _isDirty = false;
+        }
 
         IQueryNode? current = node;
         foreach (var visitor in _frozenVisitors!)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
@@ -5,13 +5,13 @@ using Foundatio.Parsers.LuceneQueries.Nodes;
 
 namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
-public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode>, IChainableQueryVisitor
+public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, IChainableQueryVisitor
 {
     private readonly List<QueryVisitorWithPriority> _visitors = new();
     private QueryVisitorWithPriority[]? _frozenVisitors;
     private bool _isDirty = true;
 
-    public void AddVisitor(IQueryNodeVisitorWithResult<IQueryNode> visitor, int priority = 0)
+    public void AddVisitor(IQueryNodeVisitorWithResult<IQueryNode?> visitor, int priority = 0)
     {
         AddVisitor(new QueryVisitorWithPriority
         {
@@ -75,14 +75,19 @@ public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode>, I
         _isDirty = true;
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
         if (_isDirty)
             _frozenVisitors = _visitors.OrderBy(v => v.Priority).ToArray();
 
+        IQueryNode? current = node;
         foreach (var visitor in _frozenVisitors!)
-            node = await visitor.AcceptAsync(node, context).ConfigureAwait(false);
+        {
+            if (current is null)
+                break;
+            current = await visitor.AcceptAsync(current, context).ConfigureAwait(false);
+        }
 
-        return node;
+        return current;
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
@@ -8,7 +8,7 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, IChainableQueryVisitor
 {
     private readonly List<QueryVisitorWithPriority> _visitors = new();
-    private QueryVisitorWithPriority[]? _frozenVisitors;
+    private QueryVisitorWithPriority[] _frozenVisitors = [];
     private bool _isDirty = true;
 
     public void AddVisitor(IQueryNodeVisitorWithResult<IQueryNode?> visitor, int priority = 0)
@@ -84,7 +84,7 @@ public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, 
         }
 
         IQueryNode? current = node;
-        foreach (var visitor in _frozenVisitors!)
+        foreach (var visitor in _frozenVisitors)
         {
             if (current is null)
                 break;

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
@@ -75,7 +75,7 @@ public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode>, I
         _isDirty = true;
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
         if (_isDirty)
             _frozenVisitors = _visitors.OrderBy(v => v.Priority).ToArray();

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
@@ -88,6 +88,7 @@ public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, 
         {
             if (current is null)
                 break;
+
             current = await visitor.AcceptAsync(current, context).ConfigureAwait(false);
         }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
@@ -8,7 +8,7 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode>, IChainableQueryVisitor
 {
     private readonly List<QueryVisitorWithPriority> _visitors = new();
-    private QueryVisitorWithPriority[] _frozenVisitors;
+    private QueryVisitorWithPriority[]? _frozenVisitors;
     private bool _isDirty = true;
 
     public void AddVisitor(IQueryNodeVisitorWithResult<IQueryNode> visitor, int priority = 0)
@@ -80,7 +80,7 @@ public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode>, I
         if (_isDirty)
             _frozenVisitors = _visitors.OrderBy(v => v.Priority).ToArray();
 
-        foreach (var visitor in _frozenVisitors)
+        foreach (var visitor in _frozenVisitors!)
             node = await visitor.AcceptAsync(node, context).ConfigureAwait(false);
 
         return node;

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
@@ -75,7 +75,7 @@ public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, 
         _isDirty = true;
     }
 
-    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
         if (_isDirty)
         {

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
@@ -10,6 +10,9 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
     public override async Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         var result = CleanNode(node);
+        if (result is null)
+            return null!;
+
         result = await base.VisitAsync(result, context).ConfigureAwait(false);
 
         return CleanNode(result);
@@ -125,7 +128,7 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
 
     public static async Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        var result = await new CleanupQueryVisitor().AcceptAsync(node, context).ConfigureAwait(false);
+        var result = await new CleanupQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return result.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
@@ -130,6 +130,7 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
 
     public static async Task<string?> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext();
         var result = await new CleanupQueryVisitor().AcceptAsync(node, context).ConfigureAwait(false);
         return result?.ToString();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
 using Foundatio.Parsers.LuceneQueries.Nodes;
@@ -10,10 +10,7 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
     public override async Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         var result = CleanNode(node);
-        if (result == null)
-            return null;
-
-        result = await base.VisitAsync(result, context);
+        result = await base.VisitAsync(result, context).ConfigureAwait(false);
 
         return CleanNode(result);
     }
@@ -126,13 +123,13 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
         return node;
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static async Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        var result = await new CleanupQueryVisitor().AcceptAsync(node, context);
+        var result = await new CleanupQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return result.ToString();
     }
 
-    public static string Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static string Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
@@ -128,13 +128,13 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
         return node;
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
+    public static async Task<string?> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
         var result = await new CleanupQueryVisitor().AcceptAsync(node, context).ConfigureAwait(false);
-        return result?.ToString() ?? string.Empty;
+        return result?.ToString();
     }
 
-    public static string Run(IQueryNode node, IQueryVisitorContext? context = null)
+    public static string? Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
@@ -7,13 +7,15 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public class CleanupQueryVisitor : ChainableQueryVisitor
 {
-    public override async Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         var result = CleanNode(node);
         if (result is null)
-            return null!;
+            return null;
 
         result = await base.VisitAsync(result, context).ConfigureAwait(false);
+        if (result is null)
+            return null;
 
         return CleanNode(result);
     }
@@ -129,7 +131,7 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
     public static async Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
         var result = await new CleanupQueryVisitor().AcceptAsync(node, context).ConfigureAwait(false);
-        return result.ToString();
+        return result?.ToString() ?? string.Empty;
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
@@ -128,7 +128,7 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
 
     public static async Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        var result = await new CleanupQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        var result = await new CleanupQueryVisitor().AcceptAsync(node, context).ConfigureAwait(false);
         return result.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
@@ -125,7 +125,7 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
 
     public static async Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        var result = await new CleanupQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        var result = await new CleanupQueryVisitor().AcceptAsync(node, context).ConfigureAwait(false);
         return result.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
@@ -129,15 +129,15 @@ public class DebugQueryVisitor : QueryNodeVisitorWithResultBase<string>
         _writer.Indent--;
     }
 
-    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context);
+        await node.AcceptAsync(this, context ?? new QueryVisitorContext());
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new DebugQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
+        return new DebugQueryVisitor().AcceptAsync(node, context);
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
@@ -130,14 +130,15 @@ public class DebugQueryVisitor : QueryNodeVisitorWithResultBase<string>
         _writer.Indent--;
     }
 
-    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        await node.AcceptAsync(this, context ?? new QueryVisitorContext { DefaultOperator = GroupOperator.Default });
+        await node.AcceptAsync(this, context);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext { DefaultOperator = GroupOperator.Default };
         return new DebugQueryVisitor().AcceptAsync(node, context);
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
@@ -1,4 +1,5 @@
-﻿using System.CodeDom.Compiler;
+﻿using System;
+using System.CodeDom.Compiler;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -131,13 +132,14 @@ public class DebugQueryVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context ?? new QueryVisitorContext());
+        ArgumentNullException.ThrowIfNull(context);
+        await node.AcceptAsync(this, context);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new DebugQueryVisitor().AcceptAsync(node, context);
+        return new DebugQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
@@ -132,7 +132,7 @@ public class DebugQueryVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context!);
+        await node.AcceptAsync(this, context ?? new QueryVisitorContext { DefaultOperator = GroupOperator.Default });
         return _builder.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
@@ -135,12 +135,12 @@ public class DebugQueryVisitor : QueryNodeVisitorWithResultBase<string>
         return _builder.ToString();
     }
 
-    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new DebugQueryVisitor().AcceptAsync(node, context);
+        return new DebugQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
     }
 
-    public static string Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static string Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
@@ -132,14 +132,13 @@ public class DebugQueryVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        await node.AcceptAsync(this, context);
+        await node.AcceptAsync(this, context!);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new DebugQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
+        return new DebugQueryVisitor().AcceptAsync(node, context);
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
@@ -80,11 +80,6 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
         }
     }
 
-    public override Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
-    {
-        return node.AcceptAsync(this, context ?? new QueryVisitorContext());
-    }
-
     public static Task<IQueryNode?> RunAsync(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
@@ -8,9 +8,9 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public class FieldResolverQueryVisitor : ChainableQueryVisitor
 {
-    private readonly QueryFieldResolver _globalResolver;
+    private readonly QueryFieldResolver? _globalResolver;
 
-    public FieldResolverQueryVisitor(QueryFieldResolver globalResolver = null)
+    public FieldResolverQueryVisitor(QueryFieldResolver? globalResolver = null)
     {
         _globalResolver = globalResolver;
     }
@@ -52,7 +52,7 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
 
         try
         {
-            string resolvedField = null;
+            string? resolvedField = null;
             if (contextResolver != null)
                 resolvedField = await contextResolver(node.Field, context).ConfigureAwait(false);
             if (resolvedField == null && _globalResolver != null)
@@ -86,82 +86,82 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
         return node;
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver context = null)
+    public static Task<IQueryNode> RunAsync(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();
         context.SetFieldResolver(resolver);
         return new FieldResolverQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, Func<string, string> resolver, IQueryVisitorContextWithFieldResolver context = null)
+    public static Task<IQueryNode> RunAsync(IQueryNode node, Func<string, string> resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();
-        context.SetFieldResolver((field, _) => Task.FromResult(resolver(field)));
+        context.SetFieldResolver((field, _) => Task.FromResult<string?>(resolver(field)));
         return new FieldResolverQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static IQueryNode Run(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver context = null)
+    public static IQueryNode Run(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         return RunAsync(node, resolver, context).GetAwaiter().GetResult();
     }
 
-    public static IQueryNode Run(IQueryNode node, Func<string, string> resolver, IQueryVisitorContextWithFieldResolver context = null)
+    public static IQueryNode Run(IQueryNode node, Func<string, string> resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         return RunAsync(node, resolver, context).GetAwaiter().GetResult();
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver context = null)
+    public static Task<IQueryNode> RunAsync(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();
         context.SetFieldResolver(map.ToHierarchicalFieldResolver());
         return new FieldResolverQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static IQueryNode Run(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver context = null)
+    public static IQueryNode Run(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver? context = null)
     {
         return RunAsync(node, map, context).GetAwaiter().GetResult();
     }
 }
 
-public delegate Task<string> QueryFieldResolver(string field, IQueryVisitorContext context);
+public delegate Task<string?> QueryFieldResolver(string field, IQueryVisitorContext context);
 
 public class FieldMap : Dictionary<string, string> { }
 
 public static class FieldMapExtensions
 {
-    public static string GetValueOrNull(this IDictionary<string, string> map, string field)
+    public static string? GetValueOrNull(this IDictionary<string, string> map, string? field)
     {
         if (map == null || field == null)
             return null;
 
-        if (map.TryGetValue(field, out string value))
+        if (map.TryGetValue(field, out string? value))
             return value;
 
         return null;
     }
 
-    public static QueryFieldResolver ToHierarchicalFieldResolver(this IDictionary<string, string> map, string resultPrefix = null)
+    public static QueryFieldResolver ToHierarchicalFieldResolver(this IDictionary<string, string> map, string? resultPrefix = null)
     {
         return (field, _) =>
         {
             if (field == null)
-                return null;
+                return Task.FromResult<string?>(null);
 
-            if (map.TryGetValue(field, out string result))
-                return Task.FromResult($"{resultPrefix}{result}");
+            if (map.TryGetValue(field, out string? result))
+                return Task.FromResult<string?>($"{resultPrefix}{result}");
 
             // start at the longest path and go backwards until we find a match in the map
             int currentPart = field.LastIndexOf('.');
             while (currentPart > 0)
             {
                 string currentName = field.Substring(0, currentPart);
-                if (map.TryGetValue(currentName, out string currentResult))
-                    return Task.FromResult($"{resultPrefix}{currentResult}{field.Substring(currentPart)}");
+                if (map.TryGetValue(currentName, out string? currentResult))
+                    return Task.FromResult<string?>($"{resultPrefix}{currentResult}{field.Substring(currentPart)}");
 
                 currentPart = field.LastIndexOf('.', currentPart - 1);
             }
 
-            return Task.FromResult(field);
+            return Task.FromResult<string?>(field);
         };
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
@@ -80,8 +80,9 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
         }
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
+        context ??= new QueryVisitorContext();
         await node.AcceptAsync(this, context).ConfigureAwait(false);
         return node;
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
@@ -94,7 +94,7 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
         return new FieldResolverQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, Func<string, string> resolver, IQueryVisitorContextWithFieldResolver? context = null)
+    public static Task<IQueryNode> RunAsync(IQueryNode node, Func<string, string?> resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();
         context.SetFieldResolver((field, _) => Task.FromResult<string?>(resolver(field)));
@@ -106,7 +106,7 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
         return RunAsync(node, resolver, context).GetAwaiter().GetResult();
     }
 
-    public static IQueryNode Run(IQueryNode node, Func<string, string> resolver, IQueryVisitorContextWithFieldResolver? context = null)
+    public static IQueryNode Run(IQueryNode node, Func<string, string?> resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         return RunAsync(node, resolver, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
@@ -80,44 +80,44 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
         }
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
         await node.AcceptAsync(this, context!).ConfigureAwait(false);
         return node;
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver? context = null)
+    public static Task<IQueryNode?> RunAsync(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();
         context.SetFieldResolver(resolver);
         return new FieldResolverQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, Func<string, string?> resolver, IQueryVisitorContextWithFieldResolver? context = null)
+    public static Task<IQueryNode?> RunAsync(IQueryNode node, Func<string, string?> resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();
         context.SetFieldResolver((field, _) => Task.FromResult<string?>(resolver(field)));
         return new FieldResolverQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static IQueryNode Run(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver? context = null)
+    public static IQueryNode? Run(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         return RunAsync(node, resolver, context).GetAwaiter().GetResult();
     }
 
-    public static IQueryNode Run(IQueryNode node, Func<string, string?> resolver, IQueryVisitorContextWithFieldResolver? context = null)
+    public static IQueryNode? Run(IQueryNode node, Func<string, string?> resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         return RunAsync(node, resolver, context).GetAwaiter().GetResult();
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver? context = null)
+    public static Task<IQueryNode?> RunAsync(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();
         context.SetFieldResolver(map.ToHierarchicalFieldResolver());
         return new FieldResolverQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static IQueryNode Run(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver? context = null)
+    public static IQueryNode? Run(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver? context = null)
     {
         return RunAsync(node, map, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
@@ -82,8 +82,7 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
 
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        context ??= new QueryVisitorContext();
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
+        await node.AcceptAsync(this, context!).ConfigureAwait(false);
         return node;
     }
 
@@ -124,7 +123,7 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
     }
 }
 
-public delegate Task<string?> QueryFieldResolver(string field, IQueryVisitorContext context);
+public delegate Task<string?> QueryFieldResolver(string field, IQueryVisitorContext? context);
 
 public class FieldMap : Dictionary<string, string> { }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
@@ -80,10 +80,9 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
         }
     }
 
-    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context!).ConfigureAwait(false);
-        return node;
+        return node.AcceptAsync(this, context ?? new QueryVisitorContext());
     }
 
     public static Task<IQueryNode?> RunAsync(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
@@ -36,14 +36,15 @@ public class GenerateQueryVisitor : QueryNodeVisitorWithResultBase<string>
         _builder.Append(node);
     }
 
-    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        await node.AcceptAsync(this, context ?? new QueryVisitorContext { DefaultOperator = GroupOperator.Default }).ConfigureAwait(false);
+        await node.AcceptAsync(this, context).ConfigureAwait(false);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext { DefaultOperator = GroupOperator.Default };
         return new GenerateQueryVisitor().AcceptAsync(node, context);
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 
@@ -41,12 +41,12 @@ public class GenerateQueryVisitor : QueryNodeVisitorWithResultBase<string>
         return _builder.ToString();
     }
 
-    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GenerateQueryVisitor().AcceptAsync(node, context);
+        return new GenerateQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext { DefaultOperator = GroupOperator.Default });
     }
 
-    public static string Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static string Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
@@ -38,7 +38,7 @@ public class GenerateQueryVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context!).ConfigureAwait(false);
+        await node.AcceptAsync(this, context ?? new QueryVisitorContext { DefaultOperator = GroupOperator.Default }).ConfigureAwait(false);
         return _builder.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
@@ -35,15 +35,15 @@ public class GenerateQueryVisitor : QueryNodeVisitorWithResultBase<string>
         _builder.Append(node);
     }
 
-    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
+        await node.AcceptAsync(this, context ?? new QueryVisitorContext { DefaultOperator = GroupOperator.Default }).ConfigureAwait(false);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GenerateQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext { DefaultOperator = GroupOperator.Default });
+        return new GenerateQueryVisitor().AcceptAsync(node, context);
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
@@ -38,14 +38,13 @@ public class GenerateQueryVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
+        await node.AcceptAsync(this, context!).ConfigureAwait(false);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GenerateQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
+        return new GenerateQueryVisitor().AcceptAsync(node, context);
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
@@ -10,7 +11,7 @@ public class GenerateQueryVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override Task VisitAsync(GroupNode node, IQueryVisitorContext context)
     {
-        _builder.Append(node.ToString(context != null ? context.DefaultOperator : GroupOperator.Default));
+        _builder.Append(node.ToString(context?.DefaultOperator ?? GroupOperator.Default));
 
         return Task.CompletedTask;
     }
@@ -37,13 +38,14 @@ public class GenerateQueryVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context ?? new QueryVisitorContext { DefaultOperator = GroupOperator.Default }).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(context);
+        await node.AcceptAsync(this, context).ConfigureAwait(false);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GenerateQueryVisitor().AcceptAsync(node, context);
+        return new GenerateQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GetReferencedFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GetReferencedFieldsQueryVisitor.cs
@@ -9,14 +9,14 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 [Obsolete("Use QueryNodeExtensions.GetReferencedFields() extension method instead.")]
 public class GetReferencedFieldsQueryVisitor : QueryNodeVisitorWithResultBase<ISet<string>>
 {
-    public override Task<ISet<string>> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override Task<ISet<string>> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
         return Task.FromResult(node.GetReferencedFields(context));
     }
 
     public static Task<ISet<string>> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GetReferencedFieldsQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
+        return new GetReferencedFieldsQueryVisitor().AcceptAsync(node, context);
     }
 
     public static ISet<string> Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GetReferencedFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GetReferencedFieldsQueryVisitor.cs
@@ -9,13 +9,14 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 [Obsolete("Use QueryNodeExtensions.GetReferencedFields() extension method instead.")]
 public class GetReferencedFieldsQueryVisitor : QueryNodeVisitorWithResultBase<ISet<string>>
 {
-    public override Task<ISet<string>> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override Task<ISet<string>> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
         return Task.FromResult(node.GetReferencedFields(context));
     }
 
     public static Task<ISet<string>> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext();
         return new GetReferencedFieldsQueryVisitor().AcceptAsync(node, context);
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GetReferencedFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GetReferencedFieldsQueryVisitor.cs
@@ -14,12 +14,12 @@ public class GetReferencedFieldsQueryVisitor : QueryNodeVisitorWithResultBase<IS
         return Task.FromResult(node.GetReferencedFields(context));
     }
 
-    public static Task<ISet<string>> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task<ISet<string>> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GetReferencedFieldsQueryVisitor().AcceptAsync(node, context);
+        return new GetReferencedFieldsQueryVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
     }
 
-    public static ISet<string> Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static ISet<string> Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IChainableQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IChainableQueryVisitor.cs
@@ -8,4 +8,4 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 /// <remarks>
 /// Use <see cref="ChainedQueryVisitor"/> to combine multiple chainable visitors.
 /// </remarks>
-public interface IChainableQueryVisitor : IQueryNodeVisitorWithResult<IQueryNode> { }
+public interface IChainableQueryVisitor : IQueryNodeVisitorWithResult<IQueryNode?> { }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryNodeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryNodeVisitor.cs
@@ -16,6 +16,6 @@ public interface IQueryNodeVisitor
     /// </summary>
     /// <param name="node">The node to visit.</param>
     /// <param name="context">The visitor context containing traversal state.</param>
-    /// <returns>The visited node, potentially transformed.</returns>
-    Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context);
+    /// <returns>The visited node, potentially transformed. Returns null to signal node removal.</returns>
+    Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context);
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryNodeVisitorWithResult.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryNodeVisitorWithResult.cs
@@ -15,5 +15,5 @@ public interface IQueryNodeVisitorWithResult<T> : IQueryNodeVisitor
     /// <param name="node">The root node to start traversal from.</param>
     /// <param name="context">The visitor context containing traversal state.</param>
     /// <returns>The result of visiting the AST.</returns>
-    Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext? context);
+    Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext context);
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryNodeVisitorWithResult.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryNodeVisitorWithResult.cs
@@ -15,5 +15,5 @@ public interface IQueryNodeVisitorWithResult<T> : IQueryNodeVisitor
     /// <param name="node">The root node to start traversal from.</param>
     /// <param name="context">The visitor context containing traversal state.</param>
     /// <returns>The result of visiting the AST.</returns>
-    Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext context);
+    Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext? context);
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContext.cs
@@ -16,7 +16,7 @@ public interface IQueryVisitorContext
     /// <summary>
     /// The default fields to search when no field is specified in a term.
     /// </summary>
-    string[] DefaultFields { get; set; }
+    string[]? DefaultFields { get; set; }
 
     /// <summary>
     /// The type of query being processed (query, aggregation, sort).

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithFieldResolver.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithFieldResolver.cs
@@ -11,5 +11,5 @@ public interface IQueryVisitorContextWithFieldResolver : IQueryVisitorContext
     /// <summary>
     /// Resolves field names to their actual storage names or aliases.
     /// </summary>
-    QueryFieldResolver FieldResolver { get; set; }
+    QueryFieldResolver? FieldResolver { get; set; }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithIncludeResolver.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithIncludeResolver.cs
@@ -11,5 +11,5 @@ public interface IQueryVisitorContextWithIncludeResolver : IQueryVisitorContext
     /// <summary>
     /// Resolves include names to their query string definitions.
     /// </summary>
-    IncludeResolver IncludeResolver { get; set; }
+    IncludeResolver? IncludeResolver { get; set; }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithValidation.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithValidation.cs
@@ -8,10 +8,10 @@ public interface IQueryVisitorContextWithValidation : IQueryVisitorContext
     /// <summary>
     /// Configuration options controlling validation behavior.
     /// </summary>
-    QueryValidationOptions ValidationOptions { get; set; }
+    QueryValidationOptions? ValidationOptions { get; set; }
 
     /// <summary>
     /// The validation results populated after validation completes.
     /// </summary>
-    QueryValidationResult ValidationResult { get; set; }
+    QueryValidationResult? ValidationResult { get; set; }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
@@ -21,7 +21,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
         _includeName = includeName;
     }
 
-    public override async Task<IQueryNode> VisitAsync(TermNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode?> VisitAsync(TermNode node, IQueryVisitorContext context)
     {
         if (String.IsNullOrEmpty(node.Term))
             return node;
@@ -77,7 +77,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
         }
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
+    public static Task<IQueryNode?> RunAsync(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         context ??= new QueryVisitorContext();
         context.SetIncludeResolver(includeResolver);
@@ -85,22 +85,22 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
         return new IncludeVisitor(shouldSkipInclude).AcceptAsync(node, context);
     }
 
-    public static IQueryNode Run(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
+    public static IQueryNode? Run(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         return RunAsync(node, includeResolver, context, shouldSkipInclude).GetAwaiter().GetResult();
     }
 
-    public static IQueryNode Run(IQueryNode node, Func<string, string?> includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
+    public static IQueryNode? Run(IQueryNode node, Func<string, string?> includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         return RunAsync(node, name => Task.FromResult<string?>(includeResolver(name)), context, shouldSkipInclude).GetAwaiter().GetResult();
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
+    public static Task<IQueryNode?> RunAsync(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         return RunAsync(node, name => Task.FromResult<string?>(includes.TryGetValue(name, out var include) ? include : null), context, shouldSkipInclude);
     }
 
-    public static IQueryNode Run(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
+    public static IQueryNode? Run(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         return RunAsync(node, includes, context, shouldSkipInclude).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
@@ -57,10 +57,9 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
 
             includeStack.Push(node.Term);
 
-            var parsed = await _parser.ParseAsync(includedQuery).ConfigureAwait(false);
-            if (parsed is not GroupNode result)
-                return node;
-
+            var parsed = await _parser.ParseAsync(includedQuery).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Parser returned null for included query: {includedQuery}");
+            var result = (GroupNode)parsed;
             result.HasParens = true;
             await VisitAsync(result, context).ConfigureAwait(false);
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
@@ -90,7 +90,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
         return RunAsync(node, includeResolver, context, shouldSkipInclude).GetAwaiter().GetResult();
     }
 
-    public static IQueryNode Run(IQueryNode node, Func<string, string> includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
+    public static IQueryNode Run(IQueryNode node, Func<string, string?> includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         return RunAsync(node, name => Task.FromResult<string?>(includeResolver(name)), context, shouldSkipInclude).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
@@ -7,15 +7,15 @@ using Foundatio.Parsers.LuceneQueries.Nodes;
 namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public delegate bool ShouldSkipIncludeFunc(TermNode node, IQueryVisitorContext context);
-public delegate Task<string> IncludeResolver(string name);
+public delegate Task<string?> IncludeResolver(string name);
 
 public class IncludeVisitor : ChainableMutatingQueryVisitor
 {
     private readonly LuceneQueryParser _parser = new();
-    private readonly ShouldSkipIncludeFunc _shouldSkipInclude;
+    private readonly ShouldSkipIncludeFunc? _shouldSkipInclude;
     private readonly string _includeName;
 
-    public IncludeVisitor(ShouldSkipIncludeFunc shouldSkipInclude = null, string includeName = "include")
+    public IncludeVisitor(ShouldSkipIncludeFunc? shouldSkipInclude = null, string includeName = "include")
     {
         _shouldSkipInclude = shouldSkipInclude;
         _includeName = includeName;
@@ -23,6 +23,9 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
 
     public override async Task<IQueryNode> VisitAsync(TermNode node, IQueryVisitorContext context)
     {
+        if (String.IsNullOrEmpty(node.Term))
+            return node;
+
         if (node.Field != "@" + _includeName || (_shouldSkipInclude != null && _shouldSkipInclude(node, context)))
             return node;
 
@@ -42,7 +45,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
 
         try
         {
-            string includedQuery = await includeResolver(node.Term).ConfigureAwait(false);
+            string? includedQuery = await includeResolver(node.Term).ConfigureAwait(false);
             if (includedQuery == null)
             {
                 context.AddValidationError($"Unresolved {_includeName} ({node.Term})");
@@ -54,7 +57,9 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
 
             includeStack.Push(node.Term);
 
-            var result = (GroupNode)await _parser.ParseAsync(includedQuery).ConfigureAwait(false);
+            var parsed = await _parser.ParseAsync(includedQuery).ConfigureAwait(false);
+            if (parsed is not GroupNode result)
+                return node;
             result.HasParens = true;
             await VisitAsync(result, context).ConfigureAwait(false);
 
@@ -71,7 +76,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
         }
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver context = null, ShouldSkipIncludeFunc shouldSkipInclude = null)
+    public static Task<IQueryNode> RunAsync(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         context ??= new QueryVisitorContext();
         context.SetIncludeResolver(includeResolver);
@@ -79,22 +84,22 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
         return new IncludeVisitor(shouldSkipInclude).AcceptAsync(node, context);
     }
 
-    public static IQueryNode Run(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver context = null, ShouldSkipIncludeFunc shouldSkipInclude = null)
+    public static IQueryNode Run(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         return RunAsync(node, includeResolver, context, shouldSkipInclude).GetAwaiter().GetResult();
     }
 
-    public static IQueryNode Run(IQueryNode node, Func<string, string> includeResolver, IQueryVisitorContextWithIncludeResolver context = null, ShouldSkipIncludeFunc shouldSkipInclude = null)
+    public static IQueryNode Run(IQueryNode node, Func<string, string> includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
-        return RunAsync(node, name => Task.FromResult(includeResolver(name)), context, shouldSkipInclude).GetAwaiter().GetResult();
+        return RunAsync(node, name => Task.FromResult<string?>(includeResolver(name)), context, shouldSkipInclude).GetAwaiter().GetResult();
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver context = null, ShouldSkipIncludeFunc shouldSkipInclude = null)
+    public static Task<IQueryNode> RunAsync(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
-        return RunAsync(node, name => Task.FromResult(includes.ContainsKey(name) ? includes[name] : null), context, shouldSkipInclude);
+        return RunAsync(node, name => Task.FromResult<string?>(includes.ContainsKey(name) ? includes[name] : null), context, shouldSkipInclude);
     }
 
-    public static IQueryNode Run(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver context = null, ShouldSkipIncludeFunc shouldSkipInclude = null)
+    public static IQueryNode Run(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         return RunAsync(node, includes, context, shouldSkipInclude).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
@@ -96,7 +96,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
 
     public static Task<IQueryNode> RunAsync(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
-        return RunAsync(node, name => Task.FromResult<string?>(includes.ContainsKey(name) ? includes[name] : null), context, shouldSkipInclude);
+        return RunAsync(node, name => Task.FromResult<string?>(includes.TryGetValue(name, out var include) ? include : null), context, shouldSkipInclude);
     }
 
     public static IQueryNode Run(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
@@ -60,6 +60,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
             var parsed = await _parser.ParseAsync(includedQuery).ConfigureAwait(false);
             if (parsed is not GroupNode result)
                 return node;
+
             result.HasParens = true;
             await VisitAsync(result, context).ConfigureAwait(false);
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -75,14 +75,14 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
         return Task.FromResult(node);
     }
 
-    public override Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        return node.AcceptAsync(this, context);
+        return node.AcceptAsync(this, context ?? new QueryVisitorContext());
     }
 
     public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context ?? new QueryVisitorContext());
+        var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
         return result.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -17,7 +17,7 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
 
     public List<string> NonInvertedFields { get; } = new List<string>();
 
-    public override Task<IQueryNode> VisitAsync(GroupNode node, IQueryVisitorContext context)
+    public override Task<IQueryNode?> VisitAsync(GroupNode node, IQueryVisitorContext context)
     {
         bool onlyNonInvertedFields = node.GetReferencedFields().All(f => NonInvertedFields.Contains(f, StringComparer.OrdinalIgnoreCase));
         bool hasNonInvertedFields = node.GetReferencedFields().Any(f => NonInvertedFields.Contains(f, StringComparer.OrdinalIgnoreCase));
@@ -25,12 +25,12 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
 
         // don't invert groups that only contain non-inverted fields
         if (onlyNonInvertedFields)
-            return Task.FromResult<IQueryNode>(node);
+            return Task.FromResult<IQueryNode?>(node);
 
         if (onlyInvertedFields)
         {
             // invert, don't visit children
-            node = (node.InvertNegation() as GroupNode)!;
+            node = (GroupNode)node.InvertNegation();
 
             var alternateInvertedCriteria = context.GetAlternateInvertedCriteria();
             if (alternateInvertedCriteria != null)
@@ -42,14 +42,14 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
                     HasParens = true
                 });
 
-            return Task.FromResult<IQueryNode>(node);
+            return Task.FromResult<IQueryNode?>(node);
         }
 
         // otherwise, continue visiting children and invert them
         return base.VisitAsync(node, context);
     }
 
-    public override Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public override Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         if (context.DefaultOperator == GroupOperator.Or)
             throw new ArgumentException("Queries using OR as the default operator can not be inverted.");
@@ -58,7 +58,7 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
             return VisitAsync(groupNode, context);
 
         if (node is IFieldQueryNode fieldNode && NonInvertedFields.Contains(fieldNode.Field, StringComparer.OrdinalIgnoreCase))
-            return Task.FromResult(node);
+            return Task.FromResult<IQueryNode?>(node);
 
         node = node.InvertNegation();
 
@@ -72,10 +72,10 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
                 HasParens = true
             });
 
-        return Task.FromResult(node);
+        return Task.FromResult<IQueryNode?>(node);
     }
 
-    public override Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
         return node.AcceptAsync(this, context!);
     }
@@ -83,7 +83,7 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
     public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
         var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
-        return result.ToString();
+        return result?.ToString() ?? string.Empty;
     }
 
     public static string Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -9,7 +9,7 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public class InvertQueryVisitor : ChainableMutatingQueryVisitor
 {
-    public InvertQueryVisitor(IEnumerable<string> nonInvertedFields = null)
+    public InvertQueryVisitor(IEnumerable<string>? nonInvertedFields = null)
     {
         if (nonInvertedFields != null)
             NonInvertedFields.AddRange(nonInvertedFields);
@@ -30,7 +30,7 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
         if (onlyInvertedFields)
         {
             // invert, don't visit children
-            node = node.InvertNegation() as GroupNode;
+            node = (node.InvertNegation() as GroupNode)!;
 
             var alternateInvertedCriteria = context.GetAlternateInvertedCriteria();
             if (alternateInvertedCriteria != null)
@@ -80,13 +80,13 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
         return node.AcceptAsync(this, context);
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string> nonInvertedFields = null, IQueryVisitorContext context = null)
+    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
+        var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context ?? new QueryVisitorContext());
         return result.ToString();
     }
 
-    public static string Run(IQueryNode node, IEnumerable<string> nonInvertedFields = null, IQueryVisitorContext context = null)
+    public static string Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, nonInvertedFields, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -77,12 +77,13 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
 
     public override Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        return node.AcceptAsync(this, context ?? new QueryVisitorContext());
+        ArgumentNullException.ThrowIfNull(context);
+        return node.AcceptAsync(this, context);
     }
 
     public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
+        var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context ?? new QueryVisitorContext());
         return result.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -75,18 +75,13 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
         return Task.FromResult<IQueryNode?>(node);
     }
 
-    public override Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
-    {
-        return node.AcceptAsync(this, context ?? new QueryVisitorContext());
-    }
-
-    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
+    public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
         var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
-        return result?.ToString() ?? string.Empty;
+        return result?.ToString();
     }
 
-    public static string Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
+    public static string? Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, nonInvertedFields, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -77,13 +77,12 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
 
     public override Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        return node.AcceptAsync(this, context);
+        return node.AcceptAsync(this, context!);
     }
 
     public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context ?? new QueryVisitorContext());
+        var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
         return result.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -77,6 +77,7 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
 
     public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext();
         var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
         return result?.ToString();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -30,7 +30,8 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
         if (onlyInvertedFields)
         {
             // invert, don't visit children
-            node = (GroupNode)node.InvertNegation();
+            if (node.InvertNegation() is GroupNode inverted)
+                node = inverted;
 
             var alternateInvertedCriteria = context.GetAlternateInvertedCriteria();
             if (alternateInvertedCriteria != null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -77,7 +77,7 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
 
     public override Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        return node.AcceptAsync(this, context!);
+        return node.AcceptAsync(this, context ?? new QueryVisitorContext());
     }
 
     public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -32,6 +32,8 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
             // invert, don't visit children
             if (node.InvertNegation() is GroupNode inverted)
                 node = inverted;
+            else
+                throw new InvalidOperationException($"InvertNegation on a GroupNode returned an unexpected type: {node.GetType().Name}");
 
             var alternateInvertedCriteria = context.GetAlternateInvertedCriteria();
             if (alternateInvertedCriteria != null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorBase.cs
@@ -43,7 +43,7 @@ public abstract class QueryNodeVisitorBase : IQueryNodeVisitor
         return Task.CompletedTask;
     }
 
-    public virtual async Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public virtual async Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         if (node is GroupNode groupNode)
         {
@@ -81,7 +81,7 @@ public abstract class QueryNodeVisitorBase : IQueryNodeVisitor
 
 public abstract class MutatingQueryNodeVisitorBase : IQueryNodeVisitor
 {
-    public virtual async Task<IQueryNode> VisitAsync(GroupNode node, IQueryVisitorContext context)
+    public virtual async Task<IQueryNode?> VisitAsync(GroupNode node, IQueryVisitorContext context)
     {
         foreach (var child in node.Children)
             await VisitAsync(child, context).ConfigureAwait(false);
@@ -91,33 +91,33 @@ public abstract class MutatingQueryNodeVisitorBase : IQueryNodeVisitor
 
     public virtual IQueryNode Visit(TermNode node, IQueryVisitorContext context) => node;
 
-    public virtual Task<IQueryNode> VisitAsync(TermNode node, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> VisitAsync(TermNode node, IQueryVisitorContext context)
     {
-        return Task.FromResult(Visit(node, context));
+        return Task.FromResult<IQueryNode?>(Visit(node, context));
     }
 
     public virtual IQueryNode Visit(TermRangeNode node, IQueryVisitorContext context) => node;
 
-    public virtual Task<IQueryNode> VisitAsync(TermRangeNode node, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> VisitAsync(TermRangeNode node, IQueryVisitorContext context)
     {
-        return Task.FromResult(Visit(node, context));
+        return Task.FromResult<IQueryNode?>(Visit(node, context));
     }
 
     public virtual IQueryNode Visit(ExistsNode node, IQueryVisitorContext context) => node;
 
-    public virtual Task<IQueryNode> VisitAsync(ExistsNode node, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> VisitAsync(ExistsNode node, IQueryVisitorContext context)
     {
-        return Task.FromResult(Visit(node, context));
+        return Task.FromResult<IQueryNode?>(Visit(node, context));
     }
 
     public virtual IQueryNode Visit(MissingNode node, IQueryVisitorContext context) => node;
 
-    public virtual Task<IQueryNode> VisitAsync(MissingNode node, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> VisitAsync(MissingNode node, IQueryVisitorContext context)
     {
-        return Task.FromResult(Visit(node, context));
+        return Task.FromResult<IQueryNode?>(Visit(node, context));
     }
 
-    public virtual Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         if (node is GroupNode groupNode)
             return VisitAsync(groupNode, context);
@@ -134,6 +134,6 @@ public abstract class MutatingQueryNodeVisitorBase : IQueryNodeVisitor
         if (node is ExistsNode existsNode)
             return VisitAsync(existsNode, context);
 
-        return Task.FromResult(node);
+        return Task.FromResult<IQueryNode?>(node);
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
@@ -5,18 +5,19 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public abstract class QueryNodeVisitorWithResultBase<T> : QueryNodeVisitorBase, IQueryNodeVisitorWithResult<T>
 {
-    public abstract Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext context);
+    public abstract Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext? context);
 }
 
 public abstract class MutatingQueryNodeVisitorWithResultBase<T> : MutatingQueryNodeVisitorBase, IQueryNodeVisitorWithResult<T>
 {
-    public abstract Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext context);
+    public abstract Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext? context);
 }
 
 public abstract class ChainableQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode>, IChainableQueryVisitor
 {
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
+        context ??= new QueryVisitorContext();
         var result = await node.AcceptAsync(this, context).ConfigureAwait(false);
         return result;
     }
@@ -24,8 +25,9 @@ public abstract class ChainableQueryVisitor : QueryNodeVisitorWithResultBase<IQu
 
 public abstract class ChainableMutatingQueryVisitor : MutatingQueryNodeVisitorWithResultBase<IQueryNode>, IChainableQueryVisitor
 {
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
+        context ??= new QueryVisitorContext();
         var result = await node.AcceptAsync(this, context).ConfigureAwait(false);
         return result;
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
@@ -13,20 +13,20 @@ public abstract class MutatingQueryNodeVisitorWithResultBase<T> : MutatingQueryN
     public abstract Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext? context);
 }
 
-public abstract class ChainableQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode>, IChainableQueryVisitor
+public abstract class ChainableQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, IChainableQueryVisitor
 {
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        var result = await node.AcceptAsync(this, context!).ConfigureAwait(false);
+        var result = await node.AcceptAsync(this, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return result;
     }
 }
 
-public abstract class ChainableMutatingQueryVisitor : MutatingQueryNodeVisitorWithResultBase<IQueryNode>, IChainableQueryVisitor
+public abstract class ChainableMutatingQueryVisitor : MutatingQueryNodeVisitorWithResultBase<IQueryNode?>, IChainableQueryVisitor
 {
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        var result = await node.AcceptAsync(this, context!).ConfigureAwait(false);
+        var result = await node.AcceptAsync(this, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return result;
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
@@ -5,28 +5,28 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public abstract class QueryNodeVisitorWithResultBase<T> : QueryNodeVisitorBase, IQueryNodeVisitorWithResult<T>
 {
-    public abstract Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext? context);
+    public abstract Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext context);
 }
 
 public abstract class MutatingQueryNodeVisitorWithResultBase<T> : MutatingQueryNodeVisitorBase, IQueryNodeVisitorWithResult<T>
 {
-    public abstract Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext? context);
+    public abstract Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext context);
 }
 
 public abstract class ChainableQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, IChainableQueryVisitor
 {
-    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        var result = await node.AcceptAsync(this, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        var result = await node.AcceptAsync(this, context).ConfigureAwait(false);
         return result;
     }
 }
 
 public abstract class ChainableMutatingQueryVisitor : MutatingQueryNodeVisitorWithResultBase<IQueryNode?>, IChainableQueryVisitor
 {
-    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        var result = await node.AcceptAsync(this, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        var result = await node.AcceptAsync(this, context).ConfigureAwait(false);
         return result;
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 
 namespace Foundatio.Parsers.LuceneQueries.Visitors;
@@ -17,7 +18,7 @@ public abstract class ChainableQueryVisitor : QueryNodeVisitorWithResultBase<IQu
 {
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        context ??= new QueryVisitorContext();
+        ArgumentNullException.ThrowIfNull(context);
         var result = await node.AcceptAsync(this, context).ConfigureAwait(false);
         return result;
     }
@@ -27,7 +28,7 @@ public abstract class ChainableMutatingQueryVisitor : MutatingQueryNodeVisitorWi
 {
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        context ??= new QueryVisitorContext();
+        ArgumentNullException.ThrowIfNull(context);
         var result = await node.AcceptAsync(this, context).ConfigureAwait(false);
         return result;
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 
 namespace Foundatio.Parsers.LuceneQueries.Visitors;
@@ -18,8 +17,7 @@ public abstract class ChainableQueryVisitor : QueryNodeVisitorWithResultBase<IQu
 {
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        var result = await node.AcceptAsync(this, context).ConfigureAwait(false);
+        var result = await node.AcceptAsync(this, context!).ConfigureAwait(false);
         return result;
     }
 }
@@ -28,8 +26,7 @@ public abstract class ChainableMutatingQueryVisitor : MutatingQueryNodeVisitorWi
 {
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        var result = await node.AcceptAsync(this, context).ConfigureAwait(false);
+        var result = await node.AcceptAsync(this, context!).ConfigureAwait(false);
         return result;
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryVisitorContext.cs
@@ -6,11 +6,11 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 public class QueryVisitorContext : IQueryVisitorContext, IQueryVisitorContextWithFieldResolver, IQueryVisitorContextWithIncludeResolver, IQueryVisitorContextWithValidation
 {
     public GroupOperator DefaultOperator { get; set; } = GroupOperator.And;
-    public string[] DefaultFields { get; set; }
+    public string[]? DefaultFields { get; set; }
     public string QueryType { get; set; } = QueryTypes.Query;
     public IDictionary<string, object> Data { get; } = new Dictionary<string, object>();
-    public QueryFieldResolver FieldResolver { get; set; }
-    public IncludeResolver IncludeResolver { get; set; }
-    public QueryValidationOptions ValidationOptions { get; set; }
-    public QueryValidationResult ValidationResult { get; set; }
+    public QueryFieldResolver? FieldResolver { get; set; }
+    public IncludeResolver? IncludeResolver { get; set; }
+    public QueryValidationOptions? ValidationOptions { get; set; }
+    public QueryValidationResult? ValidationResult { get; set; }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -26,18 +26,18 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
 
     public Func<string, bool> ShouldRemoveField { get; }
 
-    public override Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public override Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         if (node is IFieldQueryNode fieldNode && fieldNode.Field is not null && ShouldRemoveField(fieldNode.Field))
         {
             node.RemoveSelf();
-            return Task.FromResult<IQueryNode>(null!);
+            return Task.FromResult<IQueryNode?>(null);
         }
 
         return base.VisitAsync(node, context);
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
         await node.AcceptAsync(this, context!).ConfigureAwait(false);
         return node;
@@ -46,13 +46,13 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
     public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
         var result = await new RemoveFieldsQueryVisitor(nonInvertedFields ?? []).AcceptAsync(node, context).ConfigureAwait(false);
-        return result.ToString();
+        return result?.ToString() ?? string.Empty;
     }
 
     public static async Task<string> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
         var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context).ConfigureAwait(false);
-        return result.ToString();
+        return result?.ToString() ?? string.Empty;
     }
 
     public static string Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -33,7 +33,7 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         if (node is IFieldQueryNode fieldNode && fieldNode.Field != null && ShouldRemoveField(fieldNode.Field))
         {
             node.RemoveSelf();
-            return Task.FromResult<IQueryNode>(null);
+            return Task.FromResult(node);
         }
 
         return base.VisitAsync(node, context);
@@ -41,28 +41,29 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
 
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        await node.AcceptAsync(this, context);
+        await node.AcceptAsync(this, context).ConfigureAwait(false);
         return node;
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string> nonInvertedFields = null, IQueryVisitorContext context = null)
+    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
     {
-        var result = await new RemoveFieldsQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
+        ArgumentNullException.ThrowIfNull(fieldsToRemove);
+        var result = await new RemoveFieldsQueryVisitor(fieldsToRemove).AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return result.ToString();
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext context = null)
+    public static async Task<string> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
-        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context);
+        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return result.ToString();
     }
 
-    public static string Run(IQueryNode node, IEnumerable<string> nonInvertedFields = null, IQueryVisitorContext context = null)
+    public static string Run(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
     {
-        return RunAsync(node, nonInvertedFields, context).GetAwaiter().GetResult();
+        return RunAsync(node, fieldsToRemove, context).GetAwaiter().GetResult();
     }
 
-    public static string Run(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext context = null)
+    public static string Run(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, shouldRemoveFieldFunc, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -9,11 +9,11 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
 {
-    public RemoveFieldsQueryVisitor(IEnumerable<string> nonInvertedFields)
+    public RemoveFieldsQueryVisitor(IEnumerable<string> fieldsToRemove)
     {
-        ArgumentNullException.ThrowIfNull(nonInvertedFields);
+        ArgumentNullException.ThrowIfNull(fieldsToRemove);
 
-        string[] fieldsToRemoveList = nonInvertedFields.ToArray();
+        string[] fieldsToRemoveList = fieldsToRemove.ToArray();
         ShouldRemoveField = f => fieldsToRemoveList.Contains(f, StringComparer.OrdinalIgnoreCase);
     }
 
@@ -39,20 +39,19 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
 
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
+        await node.AcceptAsync(this, context!).ConfigureAwait(false);
         return node;
     }
 
     public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        var result = await new RemoveFieldsQueryVisitor(nonInvertedFields ?? []).AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        var result = await new RemoveFieldsQueryVisitor(nonInvertedFields ?? []).AcceptAsync(node, context).ConfigureAwait(false);
         return result.ToString();
     }
 
     public static async Task<string> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
-        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context).ConfigureAwait(false);
         return result.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -37,29 +37,24 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return base.VisitAsync(node, context);
     }
 
-    public override Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
-    {
-        return node.AcceptAsync(this, context ?? new QueryVisitorContext());
-    }
-
-    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
+    public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
         var result = await new RemoveFieldsQueryVisitor(nonInvertedFields ?? []).AcceptAsync(node, context).ConfigureAwait(false);
-        return result?.ToString() ?? string.Empty;
+        return result?.ToString();
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
+    public static async Task<string?> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
         var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context).ConfigureAwait(false);
-        return result?.ToString() ?? string.Empty;
+        return result?.ToString();
     }
 
-    public static string Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
+    public static string? Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, nonInvertedFields ?? [], context).GetAwaiter().GetResult();
     }
 
-    public static string Run(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
+    public static string? Run(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, shouldRemoveFieldFunc, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -37,10 +37,9 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return base.VisitAsync(node, context);
     }
 
-    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context!).ConfigureAwait(false);
-        return node;
+        return node.AcceptAsync(this, context ?? new QueryVisitorContext());
     }
 
     public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -9,19 +9,17 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
 {
-    public RemoveFieldsQueryVisitor(IEnumerable<string> fieldsToRemove)
+    public RemoveFieldsQueryVisitor(IEnumerable<string> nonInvertedFields)
     {
-        if (fieldsToRemove == null)
-            throw new ArgumentNullException(nameof(fieldsToRemove));
+        ArgumentNullException.ThrowIfNull(nonInvertedFields);
 
-        string[] fieldsToRemoveList = fieldsToRemove.ToArray();
+        string[] fieldsToRemoveList = nonInvertedFields.ToArray();
         ShouldRemoveField = f => fieldsToRemoveList.Contains(f, StringComparer.OrdinalIgnoreCase);
     }
 
     public RemoveFieldsQueryVisitor(Func<string, bool> shouldRemoveFieldFunc)
     {
-        if (shouldRemoveFieldFunc == null)
-            throw new ArgumentNullException(nameof(shouldRemoveFieldFunc));
+        ArgumentNullException.ThrowIfNull(shouldRemoveFieldFunc);
 
         ShouldRemoveField = shouldRemoveFieldFunc;
     }
@@ -30,10 +28,10 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
 
     public override Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        if (node is IFieldQueryNode fieldNode && fieldNode.Field != null && ShouldRemoveField(fieldNode.Field))
+        if (node is IFieldQueryNode fieldNode && fieldNode.Field is not null && ShouldRemoveField(fieldNode.Field))
         {
             node.RemoveSelf();
-            return Task.FromResult(node);
+            return Task.FromResult<IQueryNode>(null!);
         }
 
         return base.VisitAsync(node, context);
@@ -41,25 +39,26 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
 
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(context);
+        await node.AcceptAsync(this, context).ConfigureAwait(false);
         return node;
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string> fieldsToRemove, IQueryVisitorContext? context = null)
+    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        var result = await new RemoveFieldsQueryVisitor(fieldsToRemove).AcceptAsync(node, context).ConfigureAwait(false);
+        var result = await new RemoveFieldsQueryVisitor(nonInvertedFields ?? []).AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return result.ToString();
     }
 
     public static async Task<string> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
-        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context).ConfigureAwait(false);
+        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return result.ToString();
     }
 
-    public static string Run(IQueryNode node, IEnumerable<string> fieldsToRemove, IQueryVisitorContext? context = null)
+    public static string Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        return RunAsync(node, fieldsToRemove, context).GetAwaiter().GetResult();
+        return RunAsync(node, nonInvertedFields ?? [], context).GetAwaiter().GetResult();
     }
 
     public static string Run(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -39,12 +39,14 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
 
     public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext();
         var result = await new RemoveFieldsQueryVisitor(nonInvertedFields ?? []).AcceptAsync(node, context).ConfigureAwait(false);
         return result?.ToString();
     }
 
     public static async Task<string?> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext();
         var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context).ConfigureAwait(false);
         return result?.ToString();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -39,21 +39,21 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return base.VisitAsync(node, context);
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
+        await node.AcceptAsync(this, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return node;
     }
 
     public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string> fieldsToRemove, IQueryVisitorContext? context = null)
     {
-        var result = await new RemoveFieldsQueryVisitor(fieldsToRemove).AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        var result = await new RemoveFieldsQueryVisitor(fieldsToRemove).AcceptAsync(node, context).ConfigureAwait(false);
         return result.ToString();
     }
 
     public static async Task<string> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
-        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
+        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context).ConfigureAwait(false);
         return result.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -45,9 +45,8 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return node;
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
+    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string> fieldsToRemove, IQueryVisitorContext? context = null)
     {
-        ArgumentNullException.ThrowIfNull(fieldsToRemove);
         var result = await new RemoveFieldsQueryVisitor(fieldsToRemove).AcceptAsync(node, context ?? new QueryVisitorContext()).ConfigureAwait(false);
         return result.ToString();
     }
@@ -58,7 +57,7 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return result.ToString();
     }
 
-    public static string Run(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
+    public static string Run(IQueryNode node, IEnumerable<string> fieldsToRemove, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, fieldsToRemove, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/TermToFieldVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/TermToFieldVisitor.cs
@@ -15,12 +15,12 @@ public class TermToFieldVisitor : ChainableQueryVisitor
         node.Term = null;
     }
 
-    public static Task RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new TermToFieldVisitor().AcceptAsync(node, context);
+        return new TermToFieldVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
     }
 
-    public static void Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static void Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/TermToFieldVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/TermToFieldVisitor.cs
@@ -17,6 +17,7 @@ public class TermToFieldVisitor : ChainableQueryVisitor
 
     public static Task RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext();
         return new TermToFieldVisitor().AcceptAsync(node, context);
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/TermToFieldVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/TermToFieldVisitor.cs
@@ -17,7 +17,7 @@ public class TermToFieldVisitor : ChainableQueryVisitor
 
     public static Task RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new TermToFieldVisitor().AcceptAsync(node, context);
+        return new TermToFieldVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
     }
 
     public static void Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/TermToFieldVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/TermToFieldVisitor.cs
@@ -17,7 +17,7 @@ public class TermToFieldVisitor : ChainableQueryVisitor
 
     public static Task RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new TermToFieldVisitor().AcceptAsync(node, context ?? new QueryVisitorContext());
+        return new TermToFieldVisitor().AcceptAsync(node, context);
     }
 
     public static void Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
@@ -91,10 +91,8 @@ public class ValidationVisitor : ChainableQueryVisitor
         info.AddOperation(operation, field);
     }
 
-    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        ArgumentNullException.ThrowIfNull(context);
-
         await node.AcceptAsync(this, context).ConfigureAwait(false);
         var validationResult = context.GetValidationResult();
         validationResult.QueryType = context.QueryType;

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
@@ -86,7 +86,7 @@ public class ValidationVisitor : ChainableQueryVisitor
         if (String.IsNullOrEmpty(operation))
             return;
 
-        info.AddOperation(operation, field ?? "");
+        info.AddOperation(operation, field);
     }
 
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
@@ -93,7 +93,8 @@ public class ValidationVisitor : ChainableQueryVisitor
 
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        context ??= new QueryVisitorContext();
+        ArgumentNullException.ThrowIfNull(context);
+
         await node.AcceptAsync(this, context).ConfigureAwait(false);
         var validationResult = context.GetValidationResult();
         validationResult.QueryType = context.QueryType;
@@ -114,7 +115,7 @@ public class ValidationVisitor : ChainableQueryVisitor
             foreach (string field in options.RestrictedFields)
             {
                 string? resolvedField = fieldResolver is null ? field : await fieldResolver(field, context);
-                if (result.ReferencedFields.Any(f => !String.IsNullOrEmpty(f) && (resolvedField?.Equals(f) == true || field.Equals(f))))
+                if (result.ReferencedFields.Any(f => !String.IsNullOrEmpty(f) && (resolvedField?.Equals(f) is true || field.Equals(f))))
                     restrictedFields.Add(field);
             }
             if (restrictedFields.Count > 0)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -68,11 +68,11 @@ public class ValidationVisitor : ChainableQueryVisitor
             if (node.Field.StartsWith("@"))
                 return;
 
-            validationResult.ReferencedFields.Add(node.GetOriginalField());
+            validationResult.ReferencedFields.Add(node.GetOriginalField() ?? node.Field ?? "");
         }
         else
         {
-            string[] fields = node.GetDefaultFields(context.DefaultFields);
+            string[]? fields = node.GetDefaultFields(context.DefaultFields);
             if (fields == null || fields.Length == 0)
                 validationResult.ReferencedFields.Add("");
             else
@@ -81,12 +81,12 @@ public class ValidationVisitor : ChainableQueryVisitor
         }
     }
 
-    private void AddOperation(QueryValidationResult info, string operation, string field)
+    private void AddOperation(QueryValidationResult info, string? operation, string? field)
     {
         if (String.IsNullOrEmpty(operation))
             return;
 
-        info.AddOperation(operation, field);
+        info.AddOperation(operation, field ?? "");
     }
 
     public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
@@ -110,8 +110,8 @@ public class ValidationVisitor : ChainableQueryVisitor
             var restrictedFields = new List<string>();
             foreach (string field in options.RestrictedFields)
             {
-                string resolvedField = fieldResolver == null ? field : await fieldResolver(field, context);
-                if (result.ReferencedFields.Any(f => !String.IsNullOrEmpty(f) && (resolvedField.Equals(f) || field.Equals(f))))
+                string? resolvedField = fieldResolver == null ? field : await fieldResolver(field, context);
+                if (result.ReferencedFields.Any(f => !String.IsNullOrEmpty(f) && (resolvedField?.Equals(f) == true || field.Equals(f))))
                     restrictedFields.Add(field);
             }
             if (restrictedFields.Count > 0)
@@ -160,7 +160,7 @@ public class ValidationVisitor : ChainableQueryVisitor
             throw new QueryValidationException($"Invalid query: {result.Message}", result);
     }
 
-    public static async Task<QueryValidationResult> RunAsync(IQueryNode node, IQueryVisitorContextWithValidation context = null)
+    public static async Task<QueryValidationResult> RunAsync(IQueryNode node, IQueryVisitorContextWithValidation? context = null)
     {
         context ??= new QueryVisitorContext();
 
@@ -175,12 +175,12 @@ public class ValidationVisitor : ChainableQueryVisitor
         return context.GetValidationResult();
     }
 
-    public static QueryValidationResult Run(IQueryNode node, IQueryVisitorContextWithValidation context = null)
+    public static QueryValidationResult Run(IQueryNode node, IQueryVisitorContextWithValidation? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }
 
-    public static async Task<QueryValidationResult> RunAsync(IQueryNode node, QueryValidationOptions options, IQueryVisitorContextWithValidation context = null)
+    public static async Task<QueryValidationResult> RunAsync(IQueryNode node, QueryValidationOptions options, IQueryVisitorContextWithValidation? context = null)
     {
         context ??= new QueryVisitorContext();
 
@@ -192,7 +192,7 @@ public class ValidationVisitor : ChainableQueryVisitor
         return validationResult;
     }
 
-    public static Task<QueryValidationResult> RunAsync(IQueryNode node, IEnumerable<string> allowedFields, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> RunAsync(IQueryNode node, IEnumerable<string> allowedFields, IQueryVisitorContextWithValidation? context = null)
     {
         var options = new QueryValidationOptions();
         foreach (string field in allowedFields)
@@ -200,7 +200,7 @@ public class ValidationVisitor : ChainableQueryVisitor
         return RunAsync(node, options, context);
     }
 
-    public static QueryValidationResult Run(IQueryNode node, IEnumerable<string> allowedFields, IQueryVisitorContextWithValidation context = null)
+    public static QueryValidationResult Run(IQueryNode node, IEnumerable<string> allowedFields, IQueryVisitorContextWithValidation? context = null)
     {
         return RunAsync(node, allowedFields, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
@@ -68,7 +68,9 @@ public class ValidationVisitor : ChainableQueryVisitor
             if (node.Field.StartsWith("@"))
                 return;
 
-            validationResult.ReferencedFields.Add(node.GetOriginalField() ?? node.Field ?? "");
+            var originalField = node.GetOriginalField();
+            if (originalField is not null)
+                validationResult.ReferencedFields.Add(originalField);
         }
         else
         {
@@ -89,8 +91,9 @@ public class ValidationVisitor : ChainableQueryVisitor
         info.AddOperation(operation, field);
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
+        context ??= new QueryVisitorContext();
         await node.AcceptAsync(this, context).ConfigureAwait(false);
         var validationResult = context.GetValidationResult();
         validationResult.QueryType = context.QueryType;
@@ -110,7 +113,7 @@ public class ValidationVisitor : ChainableQueryVisitor
             var restrictedFields = new List<string>();
             foreach (string field in options.RestrictedFields)
             {
-                string? resolvedField = fieldResolver == null ? field : await fieldResolver(field, context);
+                string? resolvedField = fieldResolver is null ? field : await fieldResolver(field, context);
                 if (result.ReferencedFields.Any(f => !String.IsNullOrEmpty(f) && (resolvedField?.Equals(f) == true || field.Equals(f))))
                     restrictedFields.Add(field);
             }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
@@ -91,7 +91,7 @@ public class ValidationVisitor : ChainableQueryVisitor
         info.AddOperation(operation, field);
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
         ArgumentNullException.ThrowIfNull(context);
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
@@ -25,7 +25,10 @@ public class QueryVisitorWithPriority : IChainableQueryVisitor
     {
         public int Compare(QueryVisitorWithPriority? x, QueryVisitorWithPriority? y)
         {
-            return x!.Priority.CompareTo(y!.Priority);
+            if (ReferenceEquals(x, y)) return 0;
+            if (x is null) return -1;
+            if (y is null) return 1;
+            return x.Priority.CompareTo(y.Priority);
         }
 
         public static readonly PriorityComparer Instance = new();

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
@@ -9,7 +9,7 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 public class QueryVisitorWithPriority : IChainableQueryVisitor
 {
     public int Priority { get; set; }
-    public IQueryNodeVisitorWithResult<IQueryNode> Visitor { get; set; }
+    public required IQueryNodeVisitorWithResult<IQueryNode> Visitor { get; set; }
 
     public Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
@@ -23,9 +23,9 @@ public class QueryVisitorWithPriority : IChainableQueryVisitor
 
     public class PriorityComparer : IComparer<QueryVisitorWithPriority>
     {
-        public int Compare(QueryVisitorWithPriority x, QueryVisitorWithPriority y)
+        public int Compare(QueryVisitorWithPriority? x, QueryVisitorWithPriority? y)
         {
-            return x.Priority.CompareTo(y.Priority);
+            return x!.Priority.CompareTo(y!.Priority);
         }
 
         public static readonly PriorityComparer Instance = new();

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
@@ -9,14 +9,14 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 public class QueryVisitorWithPriority : IChainableQueryVisitor
 {
     public int Priority { get; set; }
-    public required IQueryNodeVisitorWithResult<IQueryNode> Visitor { get; set; }
+    public required IQueryNodeVisitorWithResult<IQueryNode?> Visitor { get; set; }
 
-    public Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
         return Visitor.AcceptAsync(node, context);
     }
 
-    public Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         return Visitor.VisitAsync(node, context);
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
@@ -11,7 +11,7 @@ public class QueryVisitorWithPriority : IChainableQueryVisitor
     public int Priority { get; set; }
     public required IQueryNodeVisitorWithResult<IQueryNode> Visitor { get; set; }
 
-    public Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
         return Visitor.AcceptAsync(node, context);
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
@@ -25,9 +25,15 @@ public class QueryVisitorWithPriority : IChainableQueryVisitor
     {
         public int Compare(QueryVisitorWithPriority? x, QueryVisitorWithPriority? y)
         {
-            if (ReferenceEquals(x, y)) return 0;
-            if (x is null) return -1;
-            if (y is null) return 1;
+            if (ReferenceEquals(x, y))
+                return 0;
+
+            if (x is null)
+                return -1;
+
+            if (y is null)
+                return 1;
+
             return x.Priority.CompareTo(y.Priority);
         }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
@@ -11,7 +11,7 @@ public class QueryVisitorWithPriority : IChainableQueryVisitor
     public int Priority { get; set; }
     public required IQueryNodeVisitorWithResult<IQueryNode?> Visitor { get; set; }
 
-    public Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
         return Visitor.AcceptAsync(node, context);
     }

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -194,7 +194,7 @@ public static class SqlNodeExtensions
 
                         builder.Append(scopePrefix);
 
-                        if (context.FullTextFields.Contains(kvp.Key.FullName, StringComparer.OrdinalIgnoreCase))
+                        if (context.FullTextFields?.Contains(kvp.Key.FullName, StringComparer.OrdinalIgnoreCase) is true)
                         {
                             builder.Append("FTS.Contains(");
                             builder.Append(argumentPrefix);
@@ -224,7 +224,7 @@ public static class SqlNodeExtensions
                         builder.Append(i.IsFirst ? "(" : " OR ");
                         builder.Append(scopePrefix);
 
-                        if (context.FullTextFields.Contains(kvp.Key.FullName, StringComparer.OrdinalIgnoreCase))
+                        if (context.FullTextFields?.Contains(kvp.Key.FullName, StringComparer.OrdinalIgnoreCase) is true)
                         {
                             builder.Append("FTS.Contains(");
                             builder.Append(argumentPrefix);
@@ -280,7 +280,7 @@ public static class SqlNodeExtensions
         {
             builder.Append(scopePrefix);
 
-            if (context.FullTextFields.Contains(field.FullName, StringComparer.OrdinalIgnoreCase))
+            if (context.FullTextFields?.Contains(field.FullName, StringComparer.OrdinalIgnoreCase) is true)
             {
                 builder.Append("FTS.Contains(");
                 builder.Append(argumentPrefix);
@@ -304,7 +304,7 @@ public static class SqlNodeExtensions
         {
             builder.Append(scopePrefix);
 
-            if (context.FullTextFields.Contains(field.FullName, StringComparer.OrdinalIgnoreCase))
+            if (context.FullTextFields?.Contains(field.FullName, StringComparer.OrdinalIgnoreCase) is true)
             {
                 builder.Append("FTS.Contains(");
                 builder.Append(argumentPrefix);

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Foundatio.Parsers.LuceneQueries.Extensions;
@@ -13,7 +14,7 @@ public static class SqlNodeExtensions
     public static string ToDynamicLinqString(this GroupNode node, ISqlQueryVisitorContext context)
     {
         // support overriding the generated query
-        if (node.TryGetQuery(out string query))
+        if (node.TryGetQuery(out var query))
             return query;
 
         if (node.Left == null && node.Right == null)
@@ -67,7 +68,7 @@ public static class SqlNodeExtensions
             context.AddValidationError("Field is required for exists node queries.");
 
         // support overriding the generated query
-        if (node.TryGetQuery(out string query))
+        if (node.TryGetQuery(out var query))
             return query;
 
         var field = GetFieldInfo(context.Fields, node.Field);
@@ -95,7 +96,7 @@ public static class SqlNodeExtensions
             context.AddValidationError("Prefix is not supported for term range queries.");
 
         // support overriding the generated query
-        if (node.TryGetQuery(out string query))
+        if (node.TryGetQuery(out var query))
             return query;
 
         var field = GetFieldInfo(context.Fields, node.Field);
@@ -119,7 +120,7 @@ public static class SqlNodeExtensions
             context.AddValidationError("Prefix is not supported for term range queries.");
 
         // support overriding the generated query
-        if (node.TryGetQuery(out string query))
+        if (node.TryGetQuery(out var query))
             return query;
 
         var builder = new StringBuilder();
@@ -141,7 +142,7 @@ public static class SqlNodeExtensions
                     searchTerm = new SearchTerm
                     {
                         FieldInfo = fieldInfo,
-                        Term = node.Term,
+                        Term = node.Term!,
                         Operator = context.DefaultSearchOperator
                     };
                     fieldTerms[fieldInfo] = searchTerm;
@@ -149,7 +150,7 @@ public static class SqlNodeExtensions
 
                 context.SearchTokenizer.Invoke(searchTerm);
                 if (searchTerm.Tokens == null)
-                    searchTerm.Tokens = [searchTerm.Term];
+                    searchTerm.Tokens = [searchTerm.Term!];
                 else
                     searchTerm.Tokens = searchTerm.Tokens.Select(t => !String.IsNullOrWhiteSpace(t) ? t : "@__NOMATCH__").ToList();
             }
@@ -255,7 +256,7 @@ public static class SqlNodeExtensions
         var (fieldPrefix, fieldSuffix) = field.GetFieldPrefixAndSuffix();
         var (scopePrefix, argumentPrefix) = SplitFieldPrefix(field, fieldPrefix);
         var searchOperator = SqlSearchOperator.Equals;
-        if (node.Term.StartsWith("*") && node.Term.EndsWith("*"))
+        if (node.Term!.StartsWith("*") && node.Term.EndsWith("*"))
             searchOperator = SqlSearchOperator.Contains;
         else if (node.Term.EndsWith("*"))
             searchOperator = SqlSearchOperator.StartsWith;
@@ -334,7 +335,7 @@ public static class SqlNodeExtensions
             context.AddValidationError("Proximity is not supported for term range queries.");
 
         // support overriding the generated query
-        if (node.TryGetQuery(out string query))
+        if (node.TryGetQuery(out var query))
             return query;
 
         var field = GetFieldInfo(context.Fields, node.Field);
@@ -394,9 +395,11 @@ public static class SqlNodeExtensions
         };
     }
 
-    public static EntityFieldInfo GetFieldInfo(List<EntityFieldInfo> fields, string field)
+    public static EntityFieldInfo GetFieldInfo(List<EntityFieldInfo>? fields, string? field)
     {
-        if (fields == null)
+        field ??= String.Empty;
+
+        if (fields is null)
             return new EntityFieldInfo { Name = field, FullName = field };
 
         return fields.FirstOrDefault(f => f.FullName.Equals(field, StringComparison.OrdinalIgnoreCase)) ??
@@ -516,15 +519,15 @@ public static class SqlNodeExtensions
         node.Data[QueryKey] = query;
     }
 
-    public static string GetQuery(this IQueryNode node)
+    public static string? GetQuery(this IQueryNode node)
     {
-        return node.Data.TryGetValue(QueryKey, out object query) ? query as string : null;
+        return node.Data.TryGetValue(QueryKey, out object? query) ? query as string : null;
     }
 
-    public static bool TryGetQuery(this IQueryNode node, out string query)
+    public static bool TryGetQuery(this IQueryNode node, [NotNullWhen(true)] out string? query)
     {
         query = null;
-        return node.Data.TryGetValue(QueryKey, out object value) && (query = value as string) != null;
+        return node.Data.TryGetValue(QueryKey, out object? value) && (query = value as string) != null;
     }
 
     public static void RemoveQuery(this IQueryNode node)

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -114,13 +114,13 @@ public static class SqlNodeExtensions
         return builder.ToString();
     }
 
-    public static string ToDynamicLinqString(this TermNode node, ISqlQueryVisitorContext context)
+    public static string? ToDynamicLinqString(this TermNode node, ISqlQueryVisitorContext context)
     {
         if (!String.IsNullOrEmpty(node.Prefix))
             context.AddValidationError("Prefix is not supported for term range queries.");
 
         if (node.Term is null)
-            return String.Empty;
+            return null;
 
         // support overriding the generated query
         if (node.TryGetQuery(out string? query))
@@ -385,7 +385,7 @@ public static class SqlNodeExtensions
         return builder.ToString();
     }
 
-    public static string ToDynamicLinqString(this IQueryNode node, ISqlQueryVisitorContext context)
+    public static string? ToDynamicLinqString(this IQueryNode node, ISqlQueryVisitorContext context)
     {
         return node switch
         {

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -401,10 +401,10 @@ public static class SqlNodeExtensions
     public static EntityFieldInfo GetFieldInfo(List<EntityFieldInfo>? fields, string? field)
     {
         if (fields is null)
-            return new EntityFieldInfo { Name = field, FullName = field };
+            return new EntityFieldInfo { Name = field ?? string.Empty, FullName = field ?? string.Empty };
 
         return fields.FirstOrDefault(f => String.Equals(f.FullName, field, StringComparison.OrdinalIgnoreCase)) ??
-               new EntityFieldInfo { Name = field, FullName = field };
+               new EntityFieldInfo { Name = field ?? string.Empty, FullName = field ?? string.Empty };
     }
 
     private static (string scopePrefix, string argumentPrefix) SplitFieldPrefix(EntityFieldInfo field, string fieldPrefix)

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -401,10 +401,10 @@ public static class SqlNodeExtensions
     public static EntityFieldInfo GetFieldInfo(List<EntityFieldInfo>? fields, string? field)
     {
         if (fields is null)
-            return new EntityFieldInfo { Name = field ?? string.Empty, FullName = field ?? string.Empty };
+            return new EntityFieldInfo { Name = field, FullName = field };
 
         return fields.FirstOrDefault(f => String.Equals(f.FullName, field, StringComparison.OrdinalIgnoreCase)) ??
-               new EntityFieldInfo { Name = field ?? string.Empty, FullName = field ?? string.Empty };
+               new EntityFieldInfo { Name = field, FullName = field };
     }
 
     private static (string scopePrefix, string argumentPrefix) SplitFieldPrefix(EntityFieldInfo field, string fieldPrefix)

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -14,7 +14,7 @@ public static class SqlNodeExtensions
     public static string ToDynamicLinqString(this GroupNode node, ISqlQueryVisitorContext context)
     {
         // support overriding the generated query
-        if (node.TryGetQuery(out var query))
+        if (node.TryGetQuery(out string? query))
             return query;
 
         if (node.Left == null && node.Right == null)
@@ -68,7 +68,7 @@ public static class SqlNodeExtensions
             context.AddValidationError("Field is required for exists node queries.");
 
         // support overriding the generated query
-        if (node.TryGetQuery(out var query))
+        if (node.TryGetQuery(out string? query))
             return query;
 
         var field = GetFieldInfo(context.Fields, node.Field);
@@ -96,7 +96,7 @@ public static class SqlNodeExtensions
             context.AddValidationError("Prefix is not supported for term range queries.");
 
         // support overriding the generated query
-        if (node.TryGetQuery(out var query))
+        if (node.TryGetQuery(out string? query))
             return query;
 
         var field = GetFieldInfo(context.Fields, node.Field);
@@ -119,8 +119,11 @@ public static class SqlNodeExtensions
         if (!String.IsNullOrEmpty(node.Prefix))
             context.AddValidationError("Prefix is not supported for term range queries.");
 
+        if (String.IsNullOrEmpty(node.Term))
+            return String.Empty;
+
         // support overriding the generated query
-        if (node.TryGetQuery(out var query))
+        if (node.TryGetQuery(out string? query))
             return query;
 
         var builder = new StringBuilder();
@@ -142,7 +145,7 @@ public static class SqlNodeExtensions
                     searchTerm = new SearchTerm
                     {
                         FieldInfo = fieldInfo,
-                        Term = node.Term!,
+                        Term = node.Term,
                         Operator = context.DefaultSearchOperator
                     };
                     fieldTerms[fieldInfo] = searchTerm;
@@ -150,7 +153,7 @@ public static class SqlNodeExtensions
 
                 context.SearchTokenizer.Invoke(searchTerm);
                 if (searchTerm.Tokens == null)
-                    searchTerm.Tokens = [searchTerm.Term!];
+                    searchTerm.Tokens = [searchTerm.Term];
                 else
                     searchTerm.Tokens = searchTerm.Tokens.Select(t => !String.IsNullOrWhiteSpace(t) ? t : "@__NOMATCH__").ToList();
             }
@@ -256,7 +259,7 @@ public static class SqlNodeExtensions
         var (fieldPrefix, fieldSuffix) = field.GetFieldPrefixAndSuffix();
         var (scopePrefix, argumentPrefix) = SplitFieldPrefix(field, fieldPrefix);
         var searchOperator = SqlSearchOperator.Equals;
-        if (node.Term!.StartsWith("*") && node.Term.EndsWith("*"))
+        if (node.Term.StartsWith("*") && node.Term.EndsWith("*"))
             searchOperator = SqlSearchOperator.Contains;
         else if (node.Term.EndsWith("*"))
             searchOperator = SqlSearchOperator.StartsWith;
@@ -335,7 +338,7 @@ public static class SqlNodeExtensions
             context.AddValidationError("Proximity is not supported for term range queries.");
 
         // support overriding the generated query
-        if (node.TryGetQuery(out var query))
+        if (node.TryGetQuery(out string? query))
             return query;
 
         var field = GetFieldInfo(context.Fields, node.Field);
@@ -397,13 +400,11 @@ public static class SqlNodeExtensions
 
     public static EntityFieldInfo GetFieldInfo(List<EntityFieldInfo>? fields, string? field)
     {
-        field ??= String.Empty;
-
         if (fields is null)
-            return new EntityFieldInfo { Name = field, FullName = field };
+            return new EntityFieldInfo { Name = field ?? String.Empty, FullName = field ?? String.Empty };
 
         return fields.FirstOrDefault(f => f.FullName.Equals(field, StringComparison.OrdinalIgnoreCase)) ??
-               new EntityFieldInfo { Name = field, FullName = field };
+               new EntityFieldInfo { Name = field ?? String.Empty, FullName = field ?? String.Empty };
     }
 
     private static (string scopePrefix, string argumentPrefix) SplitFieldPrefix(EntityFieldInfo field, string fieldPrefix)
@@ -526,8 +527,14 @@ public static class SqlNodeExtensions
 
     public static bool TryGetQuery(this IQueryNode node, [NotNullWhen(true)] out string? query)
     {
+        if (node.Data.TryGetValue(QueryKey, out object? value) && value is string s)
+        {
+            query = s;
+            return true;
+        }
+
         query = null;
-        return node.Data.TryGetValue(QueryKey, out object? value) && (query = value as string) != null;
+        return false;
     }
 
     public static void RemoveQuery(this IQueryNode node)

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -151,7 +151,7 @@ public static class SqlNodeExtensions
                     fieldTerms[fieldInfo] = searchTerm;
                 }
 
-                context.SearchTokenizer.Invoke(searchTerm);
+                context.SearchTokenizer?.Invoke(searchTerm);
                 if (searchTerm.Tokens == null)
                     searchTerm.Tokens = [searchTerm.Term];
                 else
@@ -361,7 +361,7 @@ public static class SqlNodeExtensions
             builder.Append(scopePrefix);
             builder.Append(argumentPrefix);
             builder.Append(field.Name);
-            builder.Append(node.MinInclusive == true ? " >= " : " > ");
+            builder.Append(node.MinInclusive is true ? " >= " : " > ");
             AppendField(builder, field, node.Min, context);
             builder.Append(fieldSuffix);
         }
@@ -374,7 +374,7 @@ public static class SqlNodeExtensions
             builder.Append(scopePrefix);
             builder.Append(argumentPrefix);
             builder.Append(field.Name);
-            builder.Append(node.MaxInclusive == true ? " <= " : " < ");
+            builder.Append(node.MaxInclusive is true ? " <= " : " < ");
             AppendField(builder, field, node.Max, context);
             builder.Append(fieldSuffix);
         }
@@ -401,10 +401,10 @@ public static class SqlNodeExtensions
     public static EntityFieldInfo GetFieldInfo(List<EntityFieldInfo>? fields, string? field)
     {
         if (fields is null)
-            return new EntityFieldInfo { Name = field ?? String.Empty, FullName = field ?? String.Empty };
+            return new EntityFieldInfo { Name = field, FullName = field };
 
-        return fields.FirstOrDefault(f => f.FullName.Equals(field, StringComparison.OrdinalIgnoreCase)) ??
-               new EntityFieldInfo { Name = field ?? String.Empty, FullName = field ?? String.Empty };
+        return fields.FirstOrDefault(f => String.Equals(f.FullName, field, StringComparison.OrdinalIgnoreCase)) ??
+               new EntityFieldInfo { Name = field, FullName = field };
     }
 
     private static (string scopePrefix, string argumentPrefix) SplitFieldPrefix(EntityFieldInfo field, string fieldPrefix)

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -119,7 +119,7 @@ public static class SqlNodeExtensions
         if (!String.IsNullOrEmpty(node.Prefix))
             context.AddValidationError("Prefix is not supported for term range queries.");
 
-        if (String.IsNullOrEmpty(node.Term))
+        if (node.Term is null)
             return String.Empty;
 
         // support overriding the generated query

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/TypeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/TypeExtensions.cs
@@ -25,10 +25,10 @@ public static class TypeExtensions
         typeof (ulong?)
     };
 
-    public static Type UnwrapNullable(this Type type)
+    public static Type? UnwrapNullable(this Type type)
     {
         if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-            return Nullable.GetUnderlyingType(type)!;
+            return Nullable.GetUnderlyingType(type);
 
         return type;
     }

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/TypeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/TypeExtensions.cs
@@ -28,7 +28,7 @@ public static class TypeExtensions
     public static Type UnwrapNullable(this Type type)
     {
         if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-            return Nullable.GetUnderlyingType(type);
+            return Nullable.GetUnderlyingType(type)!;
 
         return type;
     }

--- a/src/Foundatio.Parsers.SqlQueries/Foundatio.Parsers.SqlQueries.csproj
+++ b/src/Foundatio.Parsers.SqlQueries/Foundatio.Parsers.SqlQueries.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
     <PackageReference Include="Exceptionless.DateTimeExtensions" Version="6.0.1" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
   </ItemGroup>
   <ItemGroup>
       <ProjectReference Include="..\..\src\Foundatio.Parsers.LuceneQueries\Foundatio.Parsers.LuceneQueries.csproj" />

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
@@ -199,7 +199,7 @@ public class SqlQueryParser : LuceneQueryParser
         context.SetFieldResolver(async (field, context) =>
         {
             string? resolvedField = null;
-            if (context.Data.TryGetValue("@OriginalContextResolver", out object? data) && data is QueryFieldResolver resolver)
+            if (context?.Data.TryGetValue("@OriginalContextResolver", out object? data) is true && data is QueryFieldResolver resolver)
             {
                 string? contextResolvedField = await resolver(field, context).ConfigureAwait(false);
                 if (contextResolvedField != null)

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
@@ -104,7 +104,7 @@ public class SqlQueryParser : LuceneQueryParser
         fields = fields.ToList();
 
         var validationOptions = new QueryValidationOptions();
-        foreach (string field in fields.Where(f => !f.IsNavigation).Select(f => f.FullName))
+        foreach (string field in fields.Where(f => !f.IsNavigation && f.FullName is not null).Select(f => f.FullName!))
             validationOptions.AllowedFields.Add(field);
 
         Configuration.SetValidationOptions(validationOptions);
@@ -139,10 +139,10 @@ public class SqlQueryParser : LuceneQueryParser
             {
                 Name = property.Name,
                 FullName = propertyPath,
-                IsNumber = property.ClrType.UnwrapNullable().IsNumeric(),
-                IsDate = property.ClrType.UnwrapNullable().IsDateTime(),
-                IsDateOnly = property.ClrType.UnwrapNullable().IsDateOnly(),
-                IsBoolean = property.ClrType.UnwrapNullable().IsBoolean(),
+                IsNumber = property.ClrType.UnwrapNullable()?.IsNumeric() ?? false,
+                IsDate = property.ClrType.UnwrapNullable()?.IsDateTime() ?? false,
+                IsDateOnly = property.ClrType.UnwrapNullable()?.IsDateOnly() ?? false,
+                IsBoolean = property.ClrType.UnwrapNullable()?.IsBoolean() ?? false,
                 Parent = parent
             });
         }

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
@@ -104,7 +104,7 @@ public class SqlQueryParser : LuceneQueryParser
         fields = fields.ToList();
 
         var validationOptions = new QueryValidationOptions();
-        foreach (string field in fields.Where(f => !f.IsNavigation).Select(f => f.FullName))
+        foreach (string field in fields.Where(f => !f.IsNavigation && f.FullName is not null).Select(f => f.FullName!))
             validationOptions.AllowedFields.Add(field);
 
         Configuration.SetValidationOptions(validationOptions);

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
@@ -104,7 +104,7 @@ public class SqlQueryParser : LuceneQueryParser
         fields = fields.ToList();
 
         var validationOptions = new QueryValidationOptions();
-        foreach (string field in fields.Where(f => !f.IsNavigation && f.FullName is not null).Select(f => f.FullName!))
+        foreach (string field in fields.Where(f => !f.IsNavigation).Select(f => f.FullName))
             validationOptions.AllowedFields.Add(field);
 
         Configuration.SetValidationOptions(validationOptions);

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -20,7 +20,7 @@ namespace Foundatio.Parsers.SqlQueries;
 
 public class SqlQueryParser : LuceneQueryParser
 {
-    public SqlQueryParser(Action<SqlQueryParserConfiguration> configure = null)
+    public SqlQueryParser(Action<SqlQueryParserConfiguration>? configure = null)
     {
         var config = new SqlQueryParserConfiguration();
         configure?.Invoke(config);
@@ -33,7 +33,7 @@ public class SqlQueryParser : LuceneQueryParser
         CustomTypeProvider = new DynamicLinqTypeProvider()
     };
 
-    public override async Task<IQueryNode> ParseAsync(string query, IQueryVisitorContext context = null)
+    public override async Task<IQueryNode?> ParseAsync(string query, IQueryVisitorContext? context = null)
     {
         query ??= String.Empty;
         context ??= new SqlQueryVisitorContext();
@@ -42,6 +42,9 @@ public class SqlQueryParser : LuceneQueryParser
         try
         {
             var result = await base.ParseAsync(query, context).ConfigureAwait(false);
+            if (result is null)
+                return null;
+
             switch (context.QueryType)
             {
                 case QueryTypes.Aggregation:
@@ -61,7 +64,7 @@ public class SqlQueryParser : LuceneQueryParser
         {
             var cursor = ex.Data["cursor"] as Cursor;
             context.GetValidationResult().QueryType = context.QueryType;
-            context.AddValidationError(ex.Message, cursor.Column);
+            context.AddValidationError(ex.Message, cursor?.Column ?? 0);
 
             return null;
         }
@@ -70,18 +73,22 @@ public class SqlQueryParser : LuceneQueryParser
     private static readonly ConcurrentDictionary<IEntityType, List<EntityFieldInfo>> _entityFieldCache = new();
     public async Task<QueryValidationResult> ValidateAsync(string query, SqlQueryVisitorContext context)
     {
-        var node = await ParseAsync(query, context);
-        return await ValidationVisitor.RunAsync(node, context);
+        var node = await ParseAsync(query, context).ConfigureAwait(false);
+        var validationResult = context.GetValidationResult();
+        if (!validationResult.IsValid || node is null)
+            return validationResult;
+
+        return await ValidationVisitor.RunAsync(node, context).ConfigureAwait(false);
     }
 
     public async Task<string> ToDynamicLinqAsync(string query, SqlQueryVisitorContext context)
     {
-        var node = await ParseAsync(query, context);
+        var node = await ParseAsync(query, context).ConfigureAwait(false);
         var result = context.GetValidationResult();
-        if (!result.IsValid)
+        if (!result.IsValid || node is null)
             throw new ValidationException("Invalid query: " + result.Message);
 
-        return await GenerateSqlVisitor.RunAsync(node, context);
+        return await GenerateSqlVisitor.RunAsync(node, context).ConfigureAwait(false);
     }
 
     public SqlQueryVisitorContext GetContext(IEntityType entityType)
@@ -108,7 +115,7 @@ public class SqlQueryParser : LuceneQueryParser
         };
     }
 
-    private void AddEntityFields(List<EntityFieldInfo> fields, EntityFieldInfo parent, IEntityType entityType, Stack<IEntityType> entityTypeStack = null, string prefix = null, int depth = 0)
+    private void AddEntityFields(List<EntityFieldInfo> fields, EntityFieldInfo? parent, IEntityType entityType, Stack<IEntityType>? entityTypeStack = null, string? prefix = null, int depth = 0)
     {
         entityTypeStack ??= new Stack<IEntityType>();
 
@@ -187,21 +194,21 @@ public class SqlQueryParser : LuceneQueryParser
     private void SetupQueryVisitorContextDefaults(IQueryVisitorContext context)
     {
         if (!context.Data.ContainsKey("@OriginalContextResolver"))
-            context.SetValue("@OriginalContextResolver", context.GetFieldResolver());
+            context.SetValue("@OriginalContextResolver", context.GetFieldResolver()!);
 
         context.SetFieldResolver(async (field, context) =>
         {
-            string resolvedField = null;
-            if (context.Data.TryGetValue("@OriginalContextResolver", out object data) && data is QueryFieldResolver resolver)
+            string? resolvedField = null;
+            if (context.Data.TryGetValue("@OriginalContextResolver", out object? data) && data is QueryFieldResolver resolver)
             {
-                string contextResolvedField = await resolver(field, context).ConfigureAwait(false);
+                string? contextResolvedField = await resolver(field, context).ConfigureAwait(false);
                 if (contextResolvedField != null)
                     resolvedField = contextResolvedField;
             }
 
             if (Configuration.FieldResolver != null)
             {
-                string configResolvedField = await Configuration.FieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
+                string? configResolvedField = await Configuration.FieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
                 if (configResolvedField != null)
                     resolvedField = configResolvedField;
             }
@@ -214,7 +221,8 @@ public class SqlQueryParser : LuceneQueryParser
 
         if (context.QueryType == QueryTypes.Query)
         {
-            context.SetDefaultFields(Configuration.DefaultFields);
+            if (Configuration.DefaultFields is not null)
+                context.SetDefaultFields(Configuration.DefaultFields);
             if (Configuration.IncludeResolver != null && context.GetIncludeResolver() == null)
                 context.SetIncludeResolver(Configuration.IncludeResolver);
         }
@@ -225,7 +233,7 @@ public class SqlQueryParser : LuceneQueryParser
             sqlContext.DateTimeParser = Configuration.DateTimeParser;
             sqlContext.DateOnlyParser = Configuration.DateOnlyParser;
             sqlContext.DefaultSearchOperator = Configuration.DefaultFieldsSearchOperator;
-            sqlContext.FullTextFields = Configuration.FullTextFields;
+            sqlContext.FullTextFields = Configuration.FullTextFields ?? [];
         }
     }
 }

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParserConfiguration.cs
@@ -17,24 +17,24 @@ public class SqlQueryParserConfiguration
     public SqlQueryParserConfiguration()
     {
         AddSortVisitor(new TermToFieldVisitor(), 0);
-        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver != null ? FieldResolver(field, context) : Task.FromResult<string>(null)), 10);
+        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver != null ? FieldResolver(field, context) : Task.FromResult<string?>(null)), 10);
         AddVisitor(new ValidationVisitor(), 30);
     }
 
     public ILoggerFactory LoggerFactory { get; private set; } = NullLoggerFactory.Instance;
-    public string[] DefaultFields { get; private set; }
+    public string[]? DefaultFields { get; private set; }
     public SqlSearchOperator DefaultFieldsSearchOperator { get; private set; } = SqlSearchOperator.StartsWith;
-    public string[] FullTextFields { get; private set; }
+    public string[]? FullTextFields { get; private set; }
     public int MaxFieldDepth { get; private set; } = 10;
-    public QueryFieldResolver FieldResolver { get; private set; }
+    public QueryFieldResolver? FieldResolver { get; private set; }
     public Action<SearchTerm> SearchTokenizer { get; set; } = static _ => { };
     public Func<string, string> DateTimeParser { get; set; } = DefaultTimeParser;
     public Func<string, string> DateOnlyParser { get; set; } = DefaultOnlyParser;
     public EntityTypePropertyFilter EntityTypePropertyFilter { get; private set; } = static _ => true;
     public EntityTypeNavigationFilter EntityTypeNavigationFilter { get; private set; } = static _ => true;
     public EntityTypeSkipNavigationFilter EntityTypeSkipNavigationFilter { get; private set; } = static _ => true;
-    public IncludeResolver IncludeResolver { get; private set; }
-    public QueryValidationOptions ValidationOptions { get; private set; }
+    public IncludeResolver? IncludeResolver { get; private set; }
+    public QueryValidationOptions? ValidationOptions { get; private set; }
     public ChainedQueryVisitor SortVisitor { get; } = new();
     public ChainedQueryVisitor QueryVisitor { get; } = new();
     public ChainedQueryVisitor AggregationVisitor { get; } = new();
@@ -102,7 +102,7 @@ public class SqlQueryParserConfiguration
         return this;
     }
 
-    public SqlQueryParserConfiguration UseFieldResolver(QueryFieldResolver resolver, int priority = 10)
+    public SqlQueryParserConfiguration UseFieldResolver(QueryFieldResolver? resolver, int priority = 10)
     {
         FieldResolver = resolver;
         ReplaceVisitor<FieldResolverQueryVisitor>(new FieldResolverQueryVisitor(resolver), priority);
@@ -118,19 +118,19 @@ public class SqlQueryParserConfiguration
         return UseFieldResolver(null);
     }
 
-    public SqlQueryParserConfiguration UseIncludes(IncludeResolver includeResolver, ShouldSkipIncludeFunc shouldSkipInclude = null, string includeName = "include", int priority = 0)
+    public SqlQueryParserConfiguration UseIncludes(IncludeResolver includeResolver, ShouldSkipIncludeFunc? shouldSkipInclude = null, string includeName = "include", int priority = 0)
     {
         IncludeResolver = includeResolver;
 
         return AddVisitor(new IncludeVisitor(shouldSkipInclude, includeName), priority);
     }
 
-    public SqlQueryParserConfiguration UseIncludes(Func<string, string> resolveInclude, ShouldSkipIncludeFunc shouldSkipInclude = null, string includeName = "include", int priority = 0)
+    public SqlQueryParserConfiguration UseIncludes(Func<string, string?> resolveInclude, ShouldSkipIncludeFunc? shouldSkipInclude = null, string includeName = "include", int priority = 0)
     {
         return UseIncludes(name => Task.FromResult(resolveInclude(name)), shouldSkipInclude, includeName, priority);
     }
 
-    public SqlQueryParserConfiguration UseIncludes(IDictionary<string, string> includes, ShouldSkipIncludeFunc shouldSkipInclude = null, string includeName = "include", int priority = 0)
+    public SqlQueryParserConfiguration UseIncludes(IDictionary<string, string> includes, ShouldSkipIncludeFunc? shouldSkipInclude = null, string includeName = "include", int priority = 0)
     {
         return UseIncludes(name => includes.ContainsKey(name) ? includes[name] : null, shouldSkipInclude, includeName, priority);
     }

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParserConfiguration.cs
@@ -17,7 +17,7 @@ public class SqlQueryParserConfiguration
     public SqlQueryParserConfiguration()
     {
         AddSortVisitor(new TermToFieldVisitor(), 0);
-        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver != null ? FieldResolver(field, context) : Task.FromResult<string?>(null)), 10);
+        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver is not null ? FieldResolver(field, context) : Task.FromResult<string?>(null)), 10);
         AddVisitor(new ValidationVisitor(), 30);
     }
 
@@ -42,7 +42,7 @@ public class SqlQueryParserConfiguration
     public SqlQueryParserConfiguration SetLoggerFactory(ILoggerFactory loggerFactory)
     {
         LoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
-        _logger = loggerFactory!.CreateLogger<SqlQueryParserConfiguration>();
+        _logger = LoggerFactory.CreateLogger<SqlQueryParserConfiguration>();
 
         return this;
     }

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
@@ -53,15 +53,15 @@ public class GenerateSqlVisitor : QueryNodeVisitorWithResultBase<string>
         _builder.Append(node.ToDynamicLinqString(sqlContext));
     }
 
-    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
+        await node.AcceptAsync(this, context ?? new SqlQueryVisitorContext()).ConfigureAwait(false);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GenerateSqlVisitor().AcceptAsync(node, context ?? new SqlQueryVisitorContext());
+        return new GenerateSqlVisitor().AcceptAsync(node, context);
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
@@ -55,7 +55,7 @@ public class GenerateSqlVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context!).ConfigureAwait(false);
+        await node.AcceptAsync(this, context ?? new SqlQueryVisitorContext()).ConfigureAwait(false);
         return _builder.ToString();
     }
 

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
@@ -53,14 +53,15 @@ public class GenerateSqlVisitor : QueryNodeVisitorWithResultBase<string>
         _builder.Append(node.ToDynamicLinqString(sqlContext));
     }
 
-    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        await node.AcceptAsync(this, context ?? new SqlQueryVisitorContext()).ConfigureAwait(false);
+        await node.AcceptAsync(this, context).ConfigureAwait(false);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new SqlQueryVisitorContext();
         return new GenerateSqlVisitor().AcceptAsync(node, context);
     }
 

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
@@ -53,18 +53,18 @@ public class GenerateSqlVisitor : QueryNodeVisitorWithResultBase<string>
         _builder.Append(node.ToDynamicLinqString(sqlContext));
     }
 
-    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
+        await node.AcceptAsync(this, context!).ConfigureAwait(false);
         return _builder.ToString();
     }
 
-    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return new GenerateSqlVisitor().AcceptAsync(node, context);
     }
 
-    public static string Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static string Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
@@ -53,15 +53,15 @@ public class GenerateSqlVisitor : QueryNodeVisitorWithResultBase<string>
         _builder.Append(node.ToDynamicLinqString(sqlContext));
     }
 
-    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
+    public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        await node.AcceptAsync(this, context!).ConfigureAwait(false);
+        await node.AcceptAsync(this, context).ConfigureAwait(false);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GenerateSqlVisitor().AcceptAsync(node, context);
+        return new GenerateSqlVisitor().AcceptAsync(node, context ?? new SqlQueryVisitorContext());
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
@@ -55,14 +55,13 @@ public class GenerateSqlVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        ArgumentNullException.ThrowIfNull(context);
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
+        await node.AcceptAsync(this, context!).ConfigureAwait(false);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GenerateSqlVisitor().AcceptAsync(node, context ?? new SqlQueryVisitorContext());
+        return new GenerateSqlVisitor().AcceptAsync(node, context);
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
@@ -55,13 +55,14 @@ public class GenerateSqlVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override async Task<string> AcceptAsync(IQueryNode node, IQueryVisitorContext? context)
     {
-        await node.AcceptAsync(this, context ?? new SqlQueryVisitorContext()).ConfigureAwait(false);
+        ArgumentNullException.ThrowIfNull(context);
+        await node.AcceptAsync(this, context).ConfigureAwait(false);
         return _builder.ToString();
     }
 
     public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return new GenerateSqlVisitor().AcceptAsync(node, context);
+        return new GenerateSqlVisitor().AcceptAsync(node, context ?? new SqlQueryVisitorContext());
     }
 
     public static string Run(IQueryNode node, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/ISqlQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/ISqlQueryVisitorContext.cs
@@ -12,7 +12,7 @@ public interface ISqlQueryVisitorContext : IQueryVisitorContext
     /// <summary>
     /// Metadata about available entity fields for query generation.
     /// </summary>
-    List<EntityFieldInfo> Fields { get; set; }
+    List<EntityFieldInfo>? Fields { get; set; }
 
     /// <summary>
     /// The default operator for text searches (Equals, Contains, StartsWith).
@@ -22,20 +22,20 @@ public interface ISqlQueryVisitorContext : IQueryVisitorContext
     /// <summary>
     /// Fields that support full-text search operations.
     /// </summary>
-    string[] FullTextFields { get; set; }
+    string[]? FullTextFields { get; set; }
 
     /// <summary>
     /// Tokenizes search terms for full-text search processing.
     /// </summary>
-    Action<SearchTerm> SearchTokenizer { get; set; }
+    Action<SearchTerm>? SearchTokenizer { get; set; }
 
     /// <summary>
     /// Converts date/time strings to SQL-compatible format.
     /// </summary>
-    Func<string, string> DateTimeParser { get; set; }
+    Func<string, string>? DateTimeParser { get; set; }
 
     /// <summary>
     /// Converts date-only strings to SQL-compatible format.
     /// </summary>
-    Func<string, string> DateOnlyParser { get; set; }
+    Func<string, string>? DateOnlyParser { get; set; }
 }

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/SqlQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/SqlQueryVisitorContext.cs
@@ -9,13 +9,13 @@ namespace Foundatio.Parsers.SqlQueries.Visitors;
 
 public class SqlQueryVisitorContext : QueryVisitorContext, ISqlQueryVisitorContext
 {
-    public List<EntityFieldInfo> Fields { get; set; }
+    public List<EntityFieldInfo> Fields { get; set; } = [];
     public SqlSearchOperator DefaultSearchOperator { get; set; } = SqlSearchOperator.StartsWith;
     public string[] FullTextFields { get; set; } = [];
     public Action<SearchTerm> SearchTokenizer { get; set; } = static _ => { };
-    public Func<string, string> DateTimeParser { get; set; }
-    public Func<string, string> DateOnlyParser { get; set; }
-    public IEntityType EntityType { get; set; }
+    public Func<string, string> DateTimeParser { get; set; } = static s => s;
+    public Func<string, string> DateOnlyParser { get; set; } = static s => s;
+    public IEntityType? EntityType { get; set; }
 }
 
 [DebuggerDisplay("{FullName} IsNumber: {IsNumber} IsMoney: {IsMoney} IsDate: {IsDate} IsBoolean: {IsBoolean} IsCollection: {IsCollection}")]
@@ -30,12 +30,12 @@ public class EntityFieldInfo
     public bool IsBoolean { get; set; }
     public bool IsCollection { get; set; }
     public bool IsNavigation { get; set; }
-    public EntityFieldInfo Parent { get; set; }
+    public EntityFieldInfo? Parent { get; set; }
     public IDictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
 
     protected bool Equals(EntityFieldInfo other) => Name == other.Name;
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (obj is null)
         {
@@ -60,7 +60,7 @@ public class EntityFieldInfo
     public (string fieldPrefix, string fieldSuffix) GetFieldPrefixAndSuffix()
     {
         var fieldTree = new List<EntityFieldInfo>();
-        EntityFieldInfo current = Parent;
+        EntityFieldInfo? current = Parent;
         while (current != null)
         {
             fieldTree.Add(current);
@@ -116,9 +116,9 @@ public class EntityFieldInfo
 
 public class SearchTerm
 {
-    public EntityFieldInfo FieldInfo { get; set; }
-    public string Term { get; set; }
-    public List<string> Tokens { get; set; }
+    public required EntityFieldInfo FieldInfo { get; set; }
+    public required string Term { get; set; }
+    public List<string>? Tokens { get; set; }
     public SqlSearchOperator Operator { get; set; } = SqlSearchOperator.Contains;
 }
 

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/SqlQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/SqlQueryVisitorContext.cs
@@ -21,8 +21,8 @@ public class SqlQueryVisitorContext : QueryVisitorContext, ISqlQueryVisitorConte
 [DebuggerDisplay("{FullName} IsNumber: {IsNumber} IsMoney: {IsMoney} IsDate: {IsDate} IsBoolean: {IsBoolean} IsCollection: {IsCollection}")]
 public class EntityFieldInfo
 {
-    public string? Name { get; init; }
-    public string? FullName { get; init; }
+    public required string Name { get; init; }
+    public required string FullName { get; init; }
     public bool IsNumber { get; set; }
     public bool IsMoney { get; set; }
     public bool IsDate { get; set; }

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/SqlQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/SqlQueryVisitorContext.cs
@@ -9,20 +9,20 @@ namespace Foundatio.Parsers.SqlQueries.Visitors;
 
 public class SqlQueryVisitorContext : QueryVisitorContext, ISqlQueryVisitorContext
 {
-    public List<EntityFieldInfo> Fields { get; set; } = [];
+    public List<EntityFieldInfo>? Fields { get; set; }
     public SqlSearchOperator DefaultSearchOperator { get; set; } = SqlSearchOperator.StartsWith;
-    public string[] FullTextFields { get; set; } = [];
-    public Action<SearchTerm> SearchTokenizer { get; set; } = static _ => { };
-    public Func<string, string> DateTimeParser { get; set; } = static s => s;
-    public Func<string, string> DateOnlyParser { get; set; } = static s => s;
+    public string[]? FullTextFields { get; set; }
+    public Action<SearchTerm>? SearchTokenizer { get; set; }
+    public Func<string, string>? DateTimeParser { get; set; }
+    public Func<string, string>? DateOnlyParser { get; set; }
     public IEntityType? EntityType { get; set; }
 }
 
 [DebuggerDisplay("{FullName} IsNumber: {IsNumber} IsMoney: {IsMoney} IsDate: {IsDate} IsBoolean: {IsBoolean} IsCollection: {IsCollection}")]
 public class EntityFieldInfo
 {
-    public required string Name { get; init; }
-    public required string FullName { get; init; }
+    public string? Name { get; init; }
+    public string? FullName { get; init; }
     public bool IsNumber { get; set; }
     public bool IsMoney { get; set; }
     public bool IsDate { get; set; }

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/SqlQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/SqlQueryVisitorContext.cs
@@ -21,8 +21,8 @@ public class SqlQueryVisitorContext : QueryVisitorContext, ISqlQueryVisitorConte
 [DebuggerDisplay("{FullName} IsNumber: {IsNumber} IsMoney: {IsMoney} IsDate: {IsDate} IsBoolean: {IsBoolean} IsCollection: {IsCollection}")]
 public class EntityFieldInfo
 {
-    public required string Name { get; init; }
-    public required string FullName { get; init; }
+    public string? Name { get; init; }
+    public string? FullName { get; init; }
     public bool IsNumber { get; set; }
     public bool IsMoney { get; set; }
     public bool IsDate { get; set; }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/AggregationParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/AggregationParserTests.cs
@@ -497,40 +497,40 @@ public class AggregationParserTests : ElasticsearchTestBase
 
     public static IEnumerable<object[]> AggregationTestCases =>
     [
-        [null!, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string>>()],
-        [String.Empty, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string>>()],
+        [null!, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string?>>()],
+        [String.Empty, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string?>>()],
         ["avg",
             false,
             1,
             new HashSet<string> { "" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { null! } } }
+            new Dictionary<string, ICollection<string?>> { { "avg", new HashSet<string?> { null } } }
         ],
-        ["avg:", false, 1, new HashSet<string>(), new Dictionary<string, ICollection<string>>()],
+        ["avg:", false, 1, new HashSet<string>(), new Dictionary<string, ICollection<string?>>()],
         [
             "avg:value",
             true,
             1,
             new HashSet<string> { "value" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { "value" } } }
+            new Dictionary<string, ICollection<string?>> { { "avg", new HashSet<string?> { "value" } } }
         ],
         [
             "    avg    :    value",
             true,
             1,
             new HashSet<string> { "value" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { "value" } } }
+            new Dictionary<string, ICollection<string?>> { { "avg", new HashSet<string?> { "value" } } }
         ],
         [
             "avg:value cardinality:value sum:value min:value max:value",
             true,
             1,
             new HashSet<string> { "value" },
-            new Dictionary<string, ICollection<string>> {
-                    { "avg", new HashSet<string> { "value" } },
-                    { "cardinality", new HashSet<string> { "value" } },
-                    { "sum", new HashSet<string> { "value" } },
-                    { "min", new HashSet<string> { "value" } },
-                    { "max", new HashSet<string> { "value" } }
+            new Dictionary<string, ICollection<string?>> {
+                    { "avg", new HashSet<string?> { "value" } },
+                    { "cardinality", new HashSet<string?> { "value" } },
+                    { "sum", new HashSet<string?> { "value" } },
+                    { "min", new HashSet<string?> { "value" } },
+                    { "max", new HashSet<string?> { "value" } }
                 }
         ],
         [
@@ -538,26 +538,26 @@ public class AggregationParserTests : ElasticsearchTestBase
             true,
             1,
             new HashSet<string> { "value", "value2" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { "value", "value2" } } }
+            new Dictionary<string, ICollection<string?>> { { "avg", new HashSet<string?> { "value", "value2" } } }
         ],
         [
             "avg:value avg:value",
             true,
             1,
             new HashSet<string> { "value" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { "value" } } }
+            new Dictionary<string, ICollection<string?>> { { "avg", new HashSet<string?> { "value" } } }
         ]
     ];
 
     [Theory]
     [MemberData(nameof(AggregationTestCases))]
-    public Task GetElasticAggregationQueryInfoAsync(string query, bool isValid, int maxNodeDepth, HashSet<string> fields, Dictionary<string, ICollection<string>> operations)
+    public Task GetElasticAggregationQueryInfoAsync(string query, bool isValid, int maxNodeDepth, HashSet<string> fields, Dictionary<string, ICollection<string?>> operations)
     {
         var parser = new ElasticQueryParser(c => c.SetLoggerFactory(Log));
         return GetAggregationQueryInfoAsync(parser, query, isValid, maxNodeDepth, fields, operations);
     }
 
-    private async Task GetAggregationQueryInfoAsync(IQueryParser parser, string query, bool isValid, int maxNodeDepth = -1, HashSet<string>? fields = null, Dictionary<string, ICollection<string>>? operations = null)
+    private async Task GetAggregationQueryInfoAsync(IQueryParser parser, string query, bool isValid, int maxNodeDepth = -1, HashSet<string>? fields = null, Dictionary<string, ICollection<string?>>? operations = null)
     {
         var context = new ElasticQueryVisitorContext { QueryType = QueryTypes.Aggregation };
         var queryNode = await parser.ParseAsync(query, context);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/AggregationParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/AggregationParserTests.cs
@@ -33,7 +33,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseGeo(_ => "51.5032520,-0.1278990"));
         var aggregations = await processor.BuildAggregationsAsync("min:field4");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -65,7 +65,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseFieldMap(fieldMap).UseGeo(_ => "51.5032520,-0.1278990"));
         var aggregations = await processor.BuildAggregationsAsync("min:heynow");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -101,7 +101,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseFieldMap(fieldMap));
         var aggregations = await processor.BuildAggregationsAsync("terms:heynow");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -132,7 +132,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseGeo(_ => "51.5032520,-0.1278990"));
         var aggregations = await processor.BuildAggregationsAsync("min:field4 max:field4 avg:field4 sum:field4 percentiles:field4~50,100 cardinality:field4 missing:field2 date:field5 histogram:field4 geogrid:field3 terms:field1");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -175,7 +175,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseFieldMap(aliasMap));
         var aggregations = await processor.BuildAggregationsAsync("terms:(alias1 cardinality:user)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -205,7 +205,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseFieldMap(aliasMap));
         var aggregations = await processor.BuildAggregationsAsync("missing:alias2");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -239,7 +239,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseGeo(_ => "51.5032520,-0.1278990").UseFieldMap(aliasMap));
         var aggregations = await processor.BuildAggregationsAsync("min:alias4 max:alias4 avg:alias4 sum:alias4 percentiles:alias4 cardinality:user missing:alias2 date:alias5 histogram:alias4 geogrid:alias3 terms:alias1");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -275,7 +275,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("terms:(field1 @exclude:myexclude @include:myinclude @include:otherinclude @missing:mymissing @exclude:otherexclude @min:1)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -304,7 +304,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("terms:(field1 @exclude:/A.*/ @include:/B.*/)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -331,7 +331,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("histogram:(field1~0.1)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -358,7 +358,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("terms:(field1~1000^2 tophits:(_~1000 @include:myinclude))");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -386,7 +386,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("terms:(field1 -cardinality:field4)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -416,7 +416,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("date:(field5^1h @missing:\"0001-01-01T00:00:00\" min:field5^1h max:field5^1h)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -450,7 +450,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("min:field4~0 max:field4~0 avg:field4~0 sum:field4~0 cardinality:field4~0");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -497,13 +497,13 @@ public class AggregationParserTests : ElasticsearchTestBase
 
     public static IEnumerable<object[]> AggregationTestCases =>
     [
-        [null, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string>>()],
+        [null!, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string>>()],
         [String.Empty, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string>>()],
         ["avg",
             false,
             1,
             new HashSet<string> { "" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { null } } }
+            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { null! } } }
         ],
         ["avg:", false, 1, new HashSet<string>(), new Dictionary<string, ICollection<string>>()],
         [
@@ -557,7 +557,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         return GetAggregationQueryInfoAsync(parser, query, isValid, maxNodeDepth, fields, operations);
     }
 
-    private async Task GetAggregationQueryInfoAsync(IQueryParser parser, string query, bool isValid, int maxNodeDepth = -1, HashSet<string> fields = null, Dictionary<string, ICollection<string>> operations = null)
+    private async Task GetAggregationQueryInfoAsync(IQueryParser parser, string query, bool isValid, int maxNodeDepth = -1, HashSet<string>? fields = null, Dictionary<string, ICollection<string>>? operations = null)
     {
         var context = new ElasticQueryVisitorContext { QueryType = QueryTypes.Aggregation };
         var queryNode = await parser.ParseAsync(query, context);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/CustomVisitorTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/CustomVisitorTests.cs
@@ -110,10 +110,10 @@ public class CustomVisitorTests : ElasticsearchTestBase
         return false;
     }
 
-    private static Task<string> ResolveIncludeAsync(string expected, string actual, string resolvedFilterIfMatch)
+    private static Task<string?> ResolveIncludeAsync(string expected, string actual, string resolvedFilterIfMatch)
     {
         if (String.Equals(expected, actual))
-            return Task.FromResult(resolvedFilterIfMatch);
+            return Task.FromResult<string?>(resolvedFilterIfMatch);
 
         throw new ArgumentException(nameof(actual), $"Unable to resolve filter with id: {actual}");
     }
@@ -175,9 +175,9 @@ public sealed class CustomFilterVisitor : ChainableQueryVisitor
             string term = ToTerm(node);
             var ids = await GetIdsAsync(term);
             if (ids != null && ids.Count > 0)
-                node.Parent.SetQuery(new TermsQuery { Field = "id", Terms = ids });
+                node.Parent!.SetQuery(new TermsQuery { Field = "id", Terms = ids });
             else
-                node.Parent.SetQuery(new TermQuery { Field = "id", Value = "none" });
+                node.Parent!.SetQuery(new TermQuery { Field = "id", Value = "none" });
 
             node.Left = null;
             node.Right = null;

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
@@ -94,10 +94,12 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         string dynamicTextAggregation = resolver.GetAggregationsFieldName("nested.data.text-0001")!;
         Assert.Equal("nested.data.text-0001.keyword", dynamicTextAggregation);
 
-        string dynamicSpacedAggregation = resolver.GetAggregationsFieldName("nested.data.spaced field")!;
+        string? dynamicSpacedAggregation = resolver.GetAggregationsFieldName("nested.data.spaced field");
+        Assert.NotNull(dynamicSpacedAggregation);
         Assert.Equal("nested.data.spaced field.keyword", dynamicSpacedAggregation);
 
-        string dynamicSpacedSort = resolver.GetSortFieldName("nested.data.spaced field")!;
+        string? dynamicSpacedSort = resolver.GetSortFieldName("nested.data.spaced field");
+        Assert.NotNull(dynamicSpacedSort);
         Assert.Equal("nested.data.spaced field.keyword", dynamicSpacedSort);
 
         string? dynamicSpacedField = resolver.GetResolvedField("nested.data.spaced field");
@@ -106,7 +108,8 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         var field1Property = resolver.GetMappingProperty("Field1");
         Assert.IsType<TextProperty>(field1Property);
 
-        string field5Property = resolver.GetAggregationsFieldName("Field5")!;
+        string? field5Property = resolver.GetAggregationsFieldName("Field5");
+        Assert.NotNull(field5Property);
         Assert.Equal("field5.keyword", field5Property);
 
         var unknownProperty = resolver.GetMappingProperty("UnknowN.test.doesNotExist");

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
@@ -100,7 +100,7 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         string dynamicSpacedSort = resolver.GetSortFieldName("nested.data.spaced field")!;
         Assert.Equal("nested.data.spaced field.keyword", dynamicSpacedSort);
 
-        string dynamicSpacedField = resolver.GetResolvedField("nested.data.spaced field");
+        string? dynamicSpacedField = resolver.GetResolvedField("nested.data.spaced field");
         Assert.Equal("nested.data.spaced field", dynamicSpacedField);
 
         var field1Property = resolver.GetMappingProperty("Field1");
@@ -112,19 +112,19 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         var unknownProperty = resolver.GetMappingProperty("UnknowN.test.doesNotExist");
         Assert.Null(unknownProperty);
 
-        string field1 = resolver.GetResolvedField("FielD1");
+        string? field1 = resolver.GetResolvedField("FielD1");
         Assert.Equal("field1", field1);
 
-        string emptyField = resolver.GetResolvedField(" ");
+        string? emptyField = resolver.GetResolvedField(" ");
         Assert.Equal(" ", emptyField);
 
-        string unknownField = resolver.GetResolvedField("UnknowN.test.doesNotExist");
+        string? unknownField = resolver.GetResolvedField("UnknowN.test.doesNotExist");
         Assert.Equal("UnknowN.test.doesNotExist", unknownField);
 
-        string unknownField2 = resolver.GetResolvedField("unknown.test.doesnotexist");
+        string? unknownField2 = resolver.GetResolvedField("unknown.test.doesnotexist");
         Assert.Equal("unknown.test.doesnotexist", unknownField2);
 
-        string unknownField3 = resolver.GetResolvedField("unknown");
+        string? unknownField3 = resolver.GetResolvedField("unknown");
         Assert.Equal("unknown", unknownField3);
 
         var field4Property = resolver.GetMappingProperty("Field4");
@@ -137,7 +137,8 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         Assert.IsType<TextProperty>(field4ExpressionProperty);
 
         var field4AliasMapping = resolver.GetMapping("Field4Alias", true);
-        Assert.IsType<TextProperty>(field4AliasMapping!.Property);
+        Assert.NotNull(field4AliasMapping);
+        Assert.IsType<TextProperty>(field4AliasMapping.Property);
         Assert.Same(field4Property, field4AliasMapping.Property);
 
         string field4sort = resolver.GetSortFieldName("Field4Alias")!;
@@ -149,7 +150,7 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         var nestedIdProperty = resolver.GetMappingProperty("Nested.Id");
         Assert.IsType<TextProperty>(nestedIdProperty);
 
-        string nestedId = resolver.GetResolvedField("Nested.Id");
+        string? nestedId = resolver.GetResolvedField("Nested.Id");
         Assert.Equal("nested.id", nestedId);
 
         nestedIdProperty = resolver.GetMappingProperty("nested.id");

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
@@ -91,7 +91,8 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
 
         var resolver = ElasticMappingResolver.Create<ElasticNestedQueryParserTests.MyNestedType>(MapMyNestedType, Client, index, _logger);
 
-        string dynamicTextAggregation = resolver.GetAggregationsFieldName("nested.data.text-0001")!;
+        string? dynamicTextAggregation = resolver.GetAggregationsFieldName("nested.data.text-0001");
+        Assert.NotNull(dynamicTextAggregation);
         Assert.Equal("nested.data.text-0001.keyword", dynamicTextAggregation);
 
         string? dynamicSpacedAggregation = resolver.GetAggregationsFieldName("nested.data.spaced field");
@@ -144,10 +145,12 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         Assert.IsType<TextProperty>(field4AliasMapping.Property);
         Assert.Same(field4Property, field4AliasMapping.Property);
 
-        string field4sort = resolver.GetSortFieldName("Field4Alias")!;
+        string? field4sort = resolver.GetSortFieldName("Field4Alias");
+        Assert.NotNull(field4sort);
         Assert.Equal("field4.sort", field4sort);
 
-        string field4aggs = resolver.GetAggregationsFieldName("Field4Alias")!;
+        string? field4aggs = resolver.GetAggregationsFieldName("Field4Alias");
+        Assert.NotNull(field4aggs);
         Assert.Equal("field4.keyword", field4aggs);
 
         var nestedIdProperty = resolver.GetMappingProperty("Nested.Id");

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
@@ -91,13 +91,13 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
 
         var resolver = ElasticMappingResolver.Create<ElasticNestedQueryParserTests.MyNestedType>(MapMyNestedType, Client, index, _logger);
 
-        string dynamicTextAggregation = resolver.GetAggregationsFieldName("nested.data.text-0001");
+        string dynamicTextAggregation = resolver.GetAggregationsFieldName("nested.data.text-0001")!;
         Assert.Equal("nested.data.text-0001.keyword", dynamicTextAggregation);
 
-        string dynamicSpacedAggregation = resolver.GetAggregationsFieldName("nested.data.spaced field");
+        string dynamicSpacedAggregation = resolver.GetAggregationsFieldName("nested.data.spaced field")!;
         Assert.Equal("nested.data.spaced field.keyword", dynamicSpacedAggregation);
 
-        string dynamicSpacedSort = resolver.GetSortFieldName("nested.data.spaced field");
+        string dynamicSpacedSort = resolver.GetSortFieldName("nested.data.spaced field")!;
         Assert.Equal("nested.data.spaced field.keyword", dynamicSpacedSort);
 
         string dynamicSpacedField = resolver.GetResolvedField("nested.data.spaced field");
@@ -106,7 +106,7 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         var field1Property = resolver.GetMappingProperty("Field1");
         Assert.IsType<TextProperty>(field1Property);
 
-        string field5Property = resolver.GetAggregationsFieldName("Field5");
+        string field5Property = resolver.GetAggregationsFieldName("Field5")!;
         Assert.Equal("field5.keyword", field5Property);
 
         var unknownProperty = resolver.GetMappingProperty("UnknowN.test.doesNotExist");
@@ -130,20 +130,20 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         var field4Property = resolver.GetMappingProperty("Field4");
         Assert.IsType<TextProperty>(field4Property);
 
-        var field4ReflectionProperty = resolver.GetMappingProperty(new Field(typeof(ElasticNestedQueryParserTests.MyNestedType).GetProperty("Field4")));
+        var field4ReflectionProperty = resolver.GetMappingProperty(new Field(typeof(ElasticNestedQueryParserTests.MyNestedType).GetProperty("Field4")!));
         Assert.IsType<TextProperty>(field4ReflectionProperty);
 
         var field4ExpressionProperty = resolver.GetMappingProperty(new Field(GetObjectPath(p => p.Field4)));
         Assert.IsType<TextProperty>(field4ExpressionProperty);
 
         var field4AliasMapping = resolver.GetMapping("Field4Alias", true);
-        Assert.IsType<TextProperty>(field4AliasMapping.Property);
+        Assert.IsType<TextProperty>(field4AliasMapping!.Property);
         Assert.Same(field4Property, field4AliasMapping.Property);
 
-        string field4sort = resolver.GetSortFieldName("Field4Alias");
+        string field4sort = resolver.GetSortFieldName("Field4Alias")!;
         Assert.Equal("field4.sort", field4sort);
 
-        string field4aggs = resolver.GetAggregationsFieldName("Field4Alias");
+        string field4aggs = resolver.GetAggregationsFieldName("Field4Alias")!;
         Assert.Equal("field4.keyword", field4aggs);
 
         var nestedIdProperty = resolver.GetMappingProperty("Nested.Id");

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -33,7 +33,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextWithKeywordMapping("title"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("title", "keyword");
+        string result = resolver.GetNonAnalyzedFieldName("title", "keyword")!;
 
         // Assert
         Assert.Equal("title.keyword", result);
@@ -47,7 +47,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextWithKeywordMapping("title"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetAggregationsFieldName("title");
+        string result = resolver.GetAggregationsFieldName("title")!;
 
         // Assert
         Assert.Equal("title.keyword", result);
@@ -61,7 +61,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextWithKeywordAndSortMapping("title"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetSortFieldName("title");
+        string result = resolver.GetSortFieldName("title")!;
 
         // Assert
         Assert.Equal("title.sort", result);
@@ -81,7 +81,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var resolver = new ElasticMappingResolver(codeMapping, _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("status", "keyword");
+        string result = resolver.GetNonAnalyzedFieldName("status", "keyword")!;
 
         // Assert
         Assert.Equal("status", result);
@@ -95,7 +95,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextOnlyMapping("body"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("body", "keyword");
+        string result = resolver.GetNonAnalyzedFieldName("body", "keyword")!;
 
         // Assert
         Assert.Equal("body", result);
@@ -115,9 +115,9 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         }, _inferrer, logger: _logger);
 
         // Act
-        string beforeRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string beforeRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
         resolver.RefreshMapping();
-        string afterRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string afterRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
 
         // Assert
         Assert.Equal("name", beforeRefresh);
@@ -139,9 +139,9 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         }, _inferrer, logger: _logger);
 
         // Act
-        string first = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string first = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
         resolver.RefreshMapping();
-        string second = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string second = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
 
         // Assert
         Assert.Equal("name", first);
@@ -158,7 +158,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         resolver.RefreshMapping();
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string result = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
 
         // Assert
         Assert.Equal("name.keyword", result);
@@ -177,9 +177,9 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             }, logger: _logger);
 
         // Act
-        string initial = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string initial = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
         resolver.RefreshMapping();
-        string updated = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string updated = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
 
         // Assert
         Assert.Equal("name", initial);
@@ -205,7 +205,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             barrier.SignalAndWait(TestCancellationToken);
             for (int i = 0; i < iterations; i++)
             {
-                string result = resolver.GetNonAnalyzedFieldName("name", "keyword");
+                string result = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
                 Assert.Equal("name.keyword", result);
             }
         }, TestCancellationToken);
@@ -215,7 +215,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             barrier.SignalAndWait(TestCancellationToken);
             for (int i = 0; i < iterations; i++)
             {
-                string result = resolver.GetAggregationsFieldName("name");
+                string result = resolver.GetAggregationsFieldName("name")!;
                 Assert.Equal("name.keyword", result);
             }
         }, TestCancellationToken);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
@@ -388,7 +388,8 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:nested.field4");
 
         // Assert
-        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result!));
+        Assert.NotNull(result);
+        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -454,7 +455,8 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:nested.field1 terms:nested.field4 max:nested.field4");
 
         // Assert
-        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result!));
+        Assert.NotNull(result);
+        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -509,7 +511,8 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:(nested.field1 @include:apple @include:banana @include:cherry)");
 
         // Assert
-        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result!));
+        Assert.NotNull(result);
+        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -554,7 +557,8 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:(nested.field1 @exclude:myexclude @include:myinclude @include:otherinclude @missing:mymissing @exclude:otherexclude @min:1)");
 
         // Assert
-        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result!));
+        Assert.NotNull(result);
+        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -1520,7 +1524,8 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("max:resellers.price");
 
         // Assert
-        var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result!));
+        Assert.NotNull(result);
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -1797,7 +1802,8 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("max:resellers.price terms:resellers.name");
 
         // Assert
-        var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result!));
+        Assert.NotNull(result);
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
@@ -432,7 +432,8 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         // Parse and examine the result after visitors have run
         var context = new ElasticQueryVisitorContext { QueryType = QueryTypes.Aggregation };
         var parsedNode = await processor.ParseAsync("terms:nested.field1 terms:nested.field4 max:nested.field4", context);
-        _logger.LogInformation("Parsed node (after visitors): {Node}", await DebugQueryVisitor.RunAsync(parsedNode!));
+        Assert.NotNull(parsedNode);
+        _logger.LogInformation("Parsed node (after visitors): {Node}", await DebugQueryVisitor.RunAsync(parsedNode));
 
         // Check nested paths on term nodes
         void LogNestedPaths(IQueryNode node, string indent = "")
@@ -449,7 +450,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
                     LogNestedPaths(child, indent + "  ");
             }
         }
-        LogNestedPaths(parsedNode!);
+        LogNestedPaths(parsedNode);
 
         // Act
         var result = await processor.BuildAggregationsAsync("terms:nested.field1 terms:nested.field4 max:nested.field4");
@@ -787,9 +788,10 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         // Act
         var queryResult = await processor.BuildQueryAsync("nested.field4:>=5", new ElasticQueryVisitorContext { UseScoring = true });
         var aggResult = await processor.BuildAggregationsAsync("terms:nested.field1 max:nested.field4");
+        Assert.NotNull(aggResult);
 
         // Assert
-        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Query(_ => queryResult).Aggregations(aggResult!));
+        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Query(_ => queryResult).Aggregations(aggResult));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
@@ -1683,7 +1683,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c
             .SetLoggerFactory(Log)
             .UseMappings<Product>(Client)
-            .UseNestedFilter((path, orig, resolved, ctx) => (QueryContainer)null!)
+            .UseNestedFilter((path, orig, resolved, ctx) => (QueryContainer?)null)
             .UseNested());
 
         // Act

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
@@ -388,7 +388,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:nested.field4");
 
         // Assert
-        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
+        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -431,7 +431,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         // Parse and examine the result after visitors have run
         var context = new ElasticQueryVisitorContext { QueryType = QueryTypes.Aggregation };
         var parsedNode = await processor.ParseAsync("terms:nested.field1 terms:nested.field4 max:nested.field4", context);
-        _logger.LogInformation("Parsed node (after visitors): {Node}", await DebugQueryVisitor.RunAsync(parsedNode));
+        _logger.LogInformation("Parsed node (after visitors): {Node}", await DebugQueryVisitor.RunAsync(parsedNode!));
 
         // Check nested paths on term nodes
         void LogNestedPaths(IQueryNode node, string indent = "")
@@ -448,13 +448,13 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
                     LogNestedPaths(child, indent + "  ");
             }
         }
-        LogNestedPaths(parsedNode);
+        LogNestedPaths(parsedNode!);
 
         // Act
         var result = await processor.BuildAggregationsAsync("terms:nested.field1 terms:nested.field4 max:nested.field4");
 
         // Assert
-        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
+        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -509,7 +509,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:(nested.field1 @include:apple @include:banana @include:cherry)");
 
         // Assert
-        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
+        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -554,7 +554,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:(nested.field1 @exclude:myexclude @include:myinclude @include:otherinclude @missing:mymissing @exclude:otherexclude @min:1)");
 
         // Assert
-        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
+        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -785,7 +785,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var aggResult = await processor.BuildAggregationsAsync("terms:nested.field1 max:nested.field4");
 
         // Assert
-        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Query(_ => queryResult).Aggregations(aggResult));
+        var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Query(_ => queryResult).Aggregations(aggResult!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -1355,24 +1355,24 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
 
     public class MyDeeplyNestedType
     {
-        public string Field1 { get; set; }
+        public string Field1 { get; set; } = null!;
         public IList<MyMiddleNestedType> Parent { get; set; } = new List<MyMiddleNestedType>();
     }
 
     public class MyMiddleNestedType
     {
-        public string Field1 { get; set; }
+        public string Field1 { get; set; } = null!;
         public IList<MyType> Child { get; set; } = new List<MyType>();
     }
 
     public class MyNestedType
     {
-        public string Field1 { get; set; }
-        public string Field2 { get; set; }
-        public string Field3 { get; set; }
+        public string Field1 { get; set; } = null!;
+        public string Field2 { get; set; } = null!;
+        public string Field3 { get; set; } = null!;
         public int Field4 { get; set; }
-        public string Field5 { get; set; }
-        public string Payload { get; set; }
+        public string Field5 { get; set; } = null!;
+        public string Payload { get; set; } = null!;
         public IList<MyType> Nested { get; set; } = new List<MyType>();
     }
 
@@ -1520,7 +1520,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("max:resellers.price");
 
         // Assert
-        var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result));
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -1676,7 +1676,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c
             .SetLoggerFactory(Log)
             .UseMappings<Product>(Client)
-            .UseNestedFilter((path, orig, resolved, ctx) => (QueryContainer)null)
+            .UseNestedFilter((path, orig, resolved, ctx) => (QueryContainer)null!)
             .UseNested());
 
         // Act
@@ -1797,7 +1797,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("max:resellers.price terms:resellers.name");
 
         // Assert
-        var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result));
+        var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -1827,26 +1827,26 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
 
     public class Product
     {
-        public string Name { get; set; }
-        public string Category { get; set; }
+        public string Name { get; set; } = null!;
+        public string Category { get; set; } = null!;
         public IList<Reseller> Resellers { get; set; } = new List<Reseller>();
     }
 
     public class MultiNestedProduct
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public IList<Reseller> Resellers { get; set; } = new List<Reseller>();
         public IList<Tag> Tags { get; set; } = new List<Tag>();
     }
 
     public class Reseller
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public double Price { get; set; }
     }
 
     public class Tag
     {
-        public string Label { get; set; }
+        public string Label { get; set; } = null!;
     }
 }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -289,10 +289,26 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var parser = new ElasticQueryParser(c => c.SetDefaultFields(["field1"]).UseMappings<MyType>(GetCodeMappings, Client, index));
 
-        var dynamicServerMappingProperty = parser.Configuration.MappingResolver!.GetMapping("field5")!.Property!;
-        var serverMappingProperty = parser.Configuration.MappingResolver.GetMapping("field2")!.Property!;
-        var codeMappingProperty = parser.Configuration.MappingResolver.GetMapping("field1")!.Property!;
-        var codeAndServerMappingProperty = parser.Configuration.MappingResolver.GetMapping("field3")!.Property!;
+        Assert.NotNull(parser.Configuration.MappingResolver);
+        var field5Mapping = parser.Configuration.MappingResolver.GetMapping("field5");
+        Assert.NotNull(field5Mapping);
+        Assert.NotNull(field5Mapping.Property);
+        var dynamicServerMappingProperty = field5Mapping.Property;
+
+        var field2Mapping = parser.Configuration.MappingResolver.GetMapping("field2");
+        Assert.NotNull(field2Mapping);
+        Assert.NotNull(field2Mapping.Property);
+        var serverMappingProperty = field2Mapping.Property;
+
+        var field1Mapping = parser.Configuration.MappingResolver.GetMapping("field1");
+        Assert.NotNull(field1Mapping);
+        Assert.NotNull(field1Mapping.Property);
+        var codeMappingProperty = field1Mapping.Property;
+
+        var field3Mapping = parser.Configuration.MappingResolver.GetMapping("field3");
+        Assert.NotNull(field3Mapping);
+        Assert.NotNull(field3Mapping.Property);
+        var codeAndServerMappingProperty = field3Mapping.Property;
 
         Assert.Equal("date", dynamicServerMappingProperty.Type);
         Assert.Equal("keyword", serverMappingProperty.Type);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -63,10 +63,10 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var sut = new ElasticQueryParser(c => c.AddQueryVisitor(testQueryVisitor));
         var context = new ElasticQueryVisitorContext();
 
-        var result = sut.Parse("NOT (dog parrot)", context) as GroupNode;
+        var result = Assert.IsType<GroupNode>(sut.Parse("NOT (dog parrot)", context));
         Assert.Equal(2, testQueryVisitor.GroupNodeCount);
 
-        Assert.IsType<GroupNode>(result!.Left);
+        Assert.IsType<GroupNode>(result.Left);
         Assert.True((result.Left as GroupNode)!.HasParens);
         Assert.True((result.Left as GroupNode)!.IsNegated);
     }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -51,9 +51,9 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var result = sut.Parse("NOT (dog parrot)");
 
-        Assert.IsType<GroupNode>(result.Left);
-        Assert.True((result.Left as GroupNode)!.HasParens);
-        Assert.True((result.Left as GroupNode)!.IsNegated);
+        var leftGroup = Assert.IsType<GroupNode>(result.Left);
+        Assert.True(leftGroup.HasParens);
+        Assert.True(leftGroup.IsNegated);
     }
 
     [Fact]
@@ -66,9 +66,9 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var result = Assert.IsType<GroupNode>(sut.Parse("NOT (dog parrot)", context));
         Assert.Equal(2, testQueryVisitor.GroupNodeCount);
 
-        Assert.IsType<GroupNode>(result.Left);
-        Assert.True((result.Left as GroupNode)!.HasParens);
-        Assert.True((result.Left as GroupNode)!.IsNegated);
+        var leftGroup2 = Assert.IsType<GroupNode>(result.Left);
+        Assert.True(leftGroup2.HasParens);
+        Assert.True(leftGroup2.IsNegated);
     }
 
     [Fact]
@@ -454,7 +454,8 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var result = await processor.BuildAggregationsAsync("min:field2 max:field2 date:(field5~1d^\"America/Chicago\" min:field2 max:field2 min:field1 @offset:-6h)");
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result!));
+        Assert.NotNull(result);
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -522,7 +523,8 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
 
         var result = await processor.BuildAggregationsAsync($"date:(field5~{interval})");
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result!));
+        Assert.NotNull(result);
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -578,7 +580,8 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log));
         var result = await processor.BuildAggregationsAsync("date:field5");
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result!));
+        Assert.NotNull(result);
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -40,7 +40,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var sortResult = await sut.BuildSortAsync("");
         Assert.NotNull(sortResult);
 
-        sortResult = await sut.BuildSortAsync((string)null!);
+        sortResult = await sut.BuildSortAsync((string?)null);
         Assert.NotNull(sortResult);
     }
 

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -28,19 +28,19 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var queryResult = await sut.BuildQueryAsync("");
         Assert.NotNull(queryResult);
 
-        queryResult = await sut.BuildQueryAsync((string)null);
+        queryResult = await sut.BuildQueryAsync((string)null!);
         Assert.NotNull(queryResult);
 
         var aggResult = await sut.BuildAggregationsAsync("");
         Assert.NotNull(aggResult);
 
-        aggResult = await sut.BuildAggregationsAsync((string)null);
+        aggResult = await sut.BuildAggregationsAsync((string)null!);
         Assert.NotNull(aggResult);
 
         var sortResult = await sut.BuildSortAsync("");
         Assert.NotNull(sortResult);
 
-        sortResult = await sut.BuildSortAsync((string)null);
+        sortResult = await sut.BuildSortAsync((string)null!);
         Assert.NotNull(sortResult);
     }
 
@@ -52,8 +52,8 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var result = sut.Parse("NOT (dog parrot)");
 
         Assert.IsType<GroupNode>(result.Left);
-        Assert.True((result.Left as GroupNode).HasParens);
-        Assert.True((result.Left as GroupNode).IsNegated);
+        Assert.True((result.Left as GroupNode)!.HasParens);
+        Assert.True((result.Left as GroupNode)!.IsNegated);
     }
 
     [Fact]
@@ -66,9 +66,9 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var result = sut.Parse("NOT (dog parrot)", context) as GroupNode;
         Assert.Equal(2, testQueryVisitor.GroupNodeCount);
 
-        Assert.IsType<GroupNode>(result.Left);
-        Assert.True((result.Left as GroupNode).HasParens);
-        Assert.True((result.Left as GroupNode).IsNegated);
+        Assert.IsType<GroupNode>(result!.Left);
+        Assert.True((result.Left as GroupNode)!.HasParens);
+        Assert.True((result.Left as GroupNode)!.IsNegated);
     }
 
     [Fact]
@@ -289,10 +289,10 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var parser = new ElasticQueryParser(c => c.SetDefaultFields(["field1"]).UseMappings<MyType>(GetCodeMappings, Client, index));
 
-        var dynamicServerMappingProperty = parser.Configuration.MappingResolver.GetMapping("field5").Property;
-        var serverMappingProperty = parser.Configuration.MappingResolver.GetMapping("field2").Property;
-        var codeMappingProperty = parser.Configuration.MappingResolver.GetMapping("field1").Property;
-        var codeAndServerMappingProperty = parser.Configuration.MappingResolver.GetMapping("field3").Property;
+        var dynamicServerMappingProperty = parser.Configuration.MappingResolver!.GetMapping("field5")!.Property!;
+        var serverMappingProperty = parser.Configuration.MappingResolver.GetMapping("field2")!.Property!;
+        var codeMappingProperty = parser.Configuration.MappingResolver.GetMapping("field1")!.Property!;
+        var codeAndServerMappingProperty = parser.Configuration.MappingResolver.GetMapping("field3")!.Property!;
 
         Assert.Equal("date", dynamicServerMappingProperty.Type);
         Assert.Equal("keyword", serverMappingProperty.Type);
@@ -454,7 +454,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var result = await processor.BuildAggregationsAsync("min:field2 max:field2 date:(field5~1d^\"America/Chicago\" min:field2 max:field2 min:field1 @offset:-6h)");
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -513,7 +513,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
     [InlineData("1y", DateInterval.Year)]
     [InlineData("year", DateInterval.Year)]
     [Theory]
-    public async Task CanUseDateHistogramAggregationInterval(string interval, object expectedInterval = null)
+    public async Task CanUseDateHistogramAggregationInterval(string interval, object? expectedInterval = null)
     {
         string index = CreateRandomIndex<MyType>();
         await Client.IndexManyAsync([new MyType { Field5 = DateTime.Now }], index, TestCancellationToken);
@@ -522,7 +522,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
 
         var result = await processor.BuildAggregationsAsync($"date:(field5~{interval})");
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -578,7 +578,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log));
         var result = await processor.BuildAggregationsAsync("date:field5");
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -1196,7 +1196,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         parser = new ElasticQueryParser(c => c.UseMappings(Client, index).SetValidationOptions(new QueryValidationOptions { AllowUnresolvedFields = false }));
         var ex = await Assert.ThrowsAsync<QueryValidationException>(() => parser.BuildQueryAsync("field2:value", context));
         Assert.Contains("resolved", ex.Message);
-        Assert.Contains("field2", ex.Result.ReferencedFields);
+        Assert.Contains("field2", ex.Result!.ReferencedFields);
         Assert.Contains("field2", ex.Result.UnresolvedFields);
         Assert.False(ex.Result.IsValid);
         Assert.NotNull(ex.Result.Message);
@@ -1426,7 +1426,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         Assert.Equal(expectedResponse.Total, actualResponse.Total);
     }
 
-    private async Task<string> GetIncludeAsync(string name)
+    private async Task<string?> GetIncludeAsync(string name)
     {
         await Task.Delay(150);
         return "included:value";
@@ -1443,7 +1443,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var parser = new ElasticQueryParser(c => c.UseMappings(Client, index).SetLoggerFactory(Log));
         var node = await parser.ParseAsync(aggregation, context);
 
-        var result = await ValidationVisitor.RunAsync(node, context);
+        var result = await ValidationVisitor.RunAsync(node!, context);
         Assert.True(result.IsValid, result.Message);
         Assert.Single(result.ReferencedFields, "field1");
         Assert.Empty(result.UnresolvedFields);
@@ -1452,13 +1452,13 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
 public class MyType
 {
-    public string Id { get; set; }
-    public string Field1 { get; set; }
-    public string Field2 { get; set; }
-    public string Field3 { get; set; }
+    public string Id { get; set; } = null!;
+    public string Field1 { get; set; } = null!;
+    public string Field2 { get; set; } = null!;
+    public string Field3 { get; set; } = null!;
     public int Field4 { get; set; }
     public DateTime Field5 { get; set; }
-    public string MultiWord { get; set; }
+    public string MultiWord { get; set; } = null!;
     public Dictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
 }
 

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/InvertQueryTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/InvertQueryTests.cs
@@ -105,10 +105,12 @@ public class InvertQueryTests : ElasticsearchTestBase<SampleDataFixture>
         if (!String.IsNullOrWhiteSpace(alternateInvertedCriteria))
         {
             var invertedAlternate = await parser.ParseAsync(alternateInvertedCriteria);
-            context.SetAlternateInvertedCriteria(invertedAlternate!);
+            Assert.NotNull(invertedAlternate);
+            context.SetAlternateInvertedCriteria(invertedAlternate);
         }
 
-        result = await invertQueryVisitor.AcceptAsync(result!, context);
+        Assert.NotNull(result);
+        result = await invertQueryVisitor.AcceptAsync(result, context);
         string invertedQuery = result.ToString();
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/InvertQueryTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/InvertQueryTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries;
@@ -84,11 +84,11 @@ public class InvertQueryTests : ElasticsearchTestBase<SampleDataFixture>
         return InvertAndValidateQuery("(field1:value organizationId:value) field2:value", "((NOT field1:value) organizationId:value) (NOT field2:value)", null, true);
     }
 
-    private async Task InvertAndValidateQuery(string query, string expected, string alternateInvertedCriteria, bool isValid)
+    private async Task InvertAndValidateQuery(string query, string expected, string? alternateInvertedCriteria, bool isValid)
     {
         var parser = new LuceneQueryParser();
 
-        IQueryNode result;
+        IQueryNode? result;
         try
         {
             result = await parser.ParseAsync(query);
@@ -105,10 +105,10 @@ public class InvertQueryTests : ElasticsearchTestBase<SampleDataFixture>
         if (!String.IsNullOrWhiteSpace(alternateInvertedCriteria))
         {
             var invertedAlternate = await parser.ParseAsync(alternateInvertedCriteria);
-            context.SetAlternateInvertedCriteria(invertedAlternate);
+            context.SetAlternateInvertedCriteria(invertedAlternate!);
         }
 
-        result = await invertQueryVisitor.AcceptAsync(result, context);
+        result = await invertQueryVisitor.AcceptAsync(result!, context);
         string invertedQuery = result.ToString();
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);
@@ -127,9 +127,9 @@ public class InvertTest
     public const string OrgId = "1";
     public const string AltOrgId = "2";
 
-    public string Id { get; set; }
-    public string OrganizationId { get; set; }
-    public string Description { get; set; }
+    public string Id { get; set; } = null!;
+    public string OrganizationId { get; set; } = null!;
+    public string Description { get; set; } = null!;
     public string Status { get; set; } = "open";
     public bool IsDeleted { get; set; }
 }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/InvertQueryTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/InvertQueryTests.cs
@@ -111,6 +111,7 @@ public class InvertQueryTests : ElasticsearchTestBase<SampleDataFixture>
 
         Assert.NotNull(result);
         result = await invertQueryVisitor.AcceptAsync(result, context);
+        Assert.NotNull(result);
         string invertedQuery = result.ToString();
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/Utility/ElasticsearchTestBase.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/Utility/ElasticsearchTestBase.cs
@@ -27,17 +27,17 @@ public abstract class ElasticsearchTestBase<T> : TestWithLoggingBase, IAsyncLife
 
     protected IElasticClient Client => _fixture.Client;
 
-    protected void CreateNamedIndex<TModel>(string index, Func<TypeMappingDescriptor<TModel>, ITypeMapping> configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>> configureIndex = null) where TModel : class
+    protected void CreateNamedIndex<TModel>(string index, Func<TypeMappingDescriptor<TModel>, ITypeMapping>? configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>>? configureIndex = null) where TModel : class
     {
         _fixture.CreateNamedIndex(index, configureMappings, configureIndex);
     }
 
-    protected string CreateRandomIndex<TModel>(Func<TypeMappingDescriptor<TModel>, ITypeMapping> configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>> configureIndex = null) where TModel : class
+    protected string CreateRandomIndex<TModel>(Func<TypeMappingDescriptor<TModel>, ITypeMapping>? configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>>? configureIndex = null) where TModel : class
     {
         return _fixture.CreateRandomIndex(configureMappings, configureIndex);
     }
 
-    protected CreateIndexResponse CreateIndex(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest> configureIndex = null)
+    protected CreateIndexResponse CreateIndex(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest>? configureIndex = null)
     {
         return _fixture.CreateIndex(index, configureIndex);
     }
@@ -63,7 +63,7 @@ public class ElasticsearchFixture : IAsyncLifetime
 {
     private readonly List<IndexName> _createdIndexes = new();
     private static bool _elaticsearchReady;
-    protected readonly ILogger _logger;
+    protected readonly ILogger _logger = null!;
     private readonly Lazy<IElasticClient> _client;
 
     public ElasticsearchFixture()
@@ -71,10 +71,10 @@ public class ElasticsearchFixture : IAsyncLifetime
         _client = new Lazy<IElasticClient>(() => GetClient(ConfigureConnectionSettings));
     }
 
-    public TestLogger Log { get; set; }
+    public TestLogger Log { get; set; } = null!;
     public IElasticClient Client => _client.Value;
 
-    protected IElasticClient GetClient(Action<ConnectionSettings> configure = null)
+    protected IElasticClient GetClient(Action<ConnectionSettings>? configure = null)
     {
         string elasticsearchUrl = Environment.GetEnvironmentVariable("ELASTICSEARCH_URL") ?? "http://localhost:9200";
         var settings = new ConnectionSettings(new Uri(elasticsearchUrl));
@@ -95,7 +95,7 @@ public class ElasticsearchFixture : IAsyncLifetime
 
     protected virtual void ConfigureConnectionSettings(ConnectionSettings settings) { }
 
-    public void CreateNamedIndex<T>(string index, Func<TypeMappingDescriptor<T>, ITypeMapping> configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>> configureIndex = null) where T : class
+    public void CreateNamedIndex<T>(string index, Func<TypeMappingDescriptor<T>, ITypeMapping>? configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>>? configureIndex = null) where T : class
     {
         if (configureMappings == null)
             configureMappings = m => m.AutoMap<T>().Dynamic();
@@ -106,7 +106,7 @@ public class ElasticsearchFixture : IAsyncLifetime
         Client.ConnectionSettings.DefaultIndices[typeof(T)] = index;
     }
 
-    public string CreateRandomIndex<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>> configureIndex = null) where T : class
+    public string CreateRandomIndex<T>(Func<TypeMappingDescriptor<T>, ITypeMapping>? configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>>? configureIndex = null) where T : class
     {
         string index = "test_" + Guid.NewGuid().ToString("N");
         if (configureMappings == null)
@@ -120,7 +120,7 @@ public class ElasticsearchFixture : IAsyncLifetime
         return index;
     }
 
-    public CreateIndexResponse CreateIndex(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest> configureIndex = null)
+    public CreateIndexResponse CreateIndex(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest>? configureIndex = null)
     {
         _createdIndexes.Add(index);
 

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/CleanupQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/CleanupQueryVisitorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -48,7 +48,7 @@ public class CleanupQueryVisitorTests : TestWithLoggingBase
         IQueryNode result;
         try
         {
-            result = await parser.ParseAsync(query);
+            result = (await parser.ParseAsync(query))!;
         }
         catch (FormatException ex)
         {

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/CleanupQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/CleanupQueryVisitorTests.cs
@@ -56,7 +56,7 @@ public class CleanupQueryVisitorTests : TestWithLoggingBase
             return;
         }
 
-        string cleanedQuery = await CleanupQueryVisitor.RunAsync(result);
+        string? cleanedQuery = await CleanupQueryVisitor.RunAsync(result);
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);
         Assert.Equal(expected, cleanedQuery);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/CleanupQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/CleanupQueryVisitorTests.cs
@@ -45,10 +45,10 @@ public class CleanupQueryVisitorTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        IQueryNode result;
+        IQueryNode? result;
         try
         {
-            result = (await parser.ParseAsync(query))!;
+            result = await parser.ParseAsync(query);
         }
         catch (FormatException ex)
         {
@@ -56,6 +56,7 @@ public class CleanupQueryVisitorTests : TestWithLoggingBase
             return;
         }
 
+        Assert.NotNull(result);
         string? cleanedQuery = await CleanupQueryVisitor.RunAsync(result);
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
@@ -15,7 +15,7 @@ public class FieldResolverVisitorTests
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value");
         var aliasMap = new FieldMap { { "field1", "field2" } };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("field2:value", aliased.ToString());
     }
 
@@ -33,7 +33,7 @@ public class FieldResolverVisitorTests
             };
 
         var resolver = map.ToHierarchicalFieldResolver();
-        string resolvedField = await resolver(field, null);
+        string? resolvedField = await resolver(field, null!);
         Assert.Equal(expected, resolvedField);
     }
 
@@ -45,7 +45,7 @@ public class FieldResolverVisitorTests
         var aliasMap = new FieldMap {
                 { "nested", "field2" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("field1.nested:value", aliased.ToString());
     }
 
@@ -57,7 +57,7 @@ public class FieldResolverVisitorTests
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("field2.other:value", aliased.ToString());
     }
 
@@ -69,7 +69,7 @@ public class FieldResolverVisitorTests
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("field2.other:value", aliased.ToString());
     }
 
@@ -81,7 +81,7 @@ public class FieldResolverVisitorTests
         var aliasMap = new FieldMap {
                 { "field1.nested.childproperty", "field2.other.childproperty" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("field2.other.childproperty:value", aliased.ToString());
     }
 
@@ -93,7 +93,7 @@ public class FieldResolverVisitorTests
         var aliasMap = new FieldMap {
                 { "field1.nested.childproperty", "field2.other.childproperty" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("field2.other.childproperty:value", aliased.ToString());
     }
 
@@ -105,7 +105,7 @@ public class FieldResolverVisitorTests
         var aliasMap = new FieldMap {
                 { "field1.nested.hey", "field2.other.blah" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("field2.other.blah:value", aliased.ToString());
     }
 
@@ -117,7 +117,7 @@ public class FieldResolverVisitorTests
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("(field2.other:value field1.another:blah)", aliased.ToString());
     }
 
@@ -129,7 +129,7 @@ public class FieldResolverVisitorTests
         var aliasMap = new FieldMap {
                 { "level1.level2.level3.level4", "alias1.alias2.level3.level4" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("alias1.alias2.level3.level4:value", aliased.ToString());
     }
 
@@ -141,7 +141,7 @@ public class FieldResolverVisitorTests
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.nested" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("field2.nested:value", aliased.ToString());
     }
 
@@ -153,7 +153,7 @@ public class FieldResolverVisitorTests
         var aliasMap = new FieldMap {
                 { "field1.nested.morenested", "field2.nested.morenested" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("field2.nested.morenested:value", aliased.ToString());
     }
 
@@ -166,7 +166,7 @@ public class FieldResolverVisitorTests
                 { "field1.nested", "field2.other" },
                 { "field1.thing", "field2.nice" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
         Assert.Equal("(field2.other:value OR field2.nice:yep) another:works", aliased.ToString());
     }
 
@@ -175,7 +175,7 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, f => f == "field1.nested" ? "field2.nested" : null);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, f => f == "field1.nested" ? "field2.nested" : null!);
         Assert.Equal("field2.nested:value", aliased.ToString());
     }
 
@@ -186,7 +186,7 @@ public class FieldResolverVisitorTests
         var result = await parser.ParseAsync("field1.nested:value");
 
         var context = new QueryVisitorContext();
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, _ => throw new ApplicationException("Bam"), context);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, _ => throw new ApplicationException("Bam"), context);
         var validationResult = context.GetValidationResult();
 
         Assert.False(validationResult.IsValid);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
@@ -17,6 +17,7 @@ public class FieldResolverVisitorTests
         Assert.NotNull(result);
         var aliasMap = new FieldMap { { "field1", "field2" } };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2:value", aliased.ToString());
     }
 
@@ -48,6 +49,7 @@ public class FieldResolverVisitorTests
                 { "nested", "field2" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field1.nested:value", aliased.ToString());
     }
 
@@ -61,6 +63,7 @@ public class FieldResolverVisitorTests
                 { "field1.nested", "field2.other" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.other:value", aliased.ToString());
     }
 
@@ -74,6 +77,7 @@ public class FieldResolverVisitorTests
                 { "field1.nested", "field2.other" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.other:value", aliased.ToString());
     }
 
@@ -87,6 +91,7 @@ public class FieldResolverVisitorTests
                 { "field1.nested.childproperty", "field2.other.childproperty" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.other.childproperty:value", aliased.ToString());
     }
 
@@ -100,6 +105,7 @@ public class FieldResolverVisitorTests
                 { "field1.nested.childproperty", "field2.other.childproperty" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.other.childproperty:value", aliased.ToString());
     }
 
@@ -113,6 +119,7 @@ public class FieldResolverVisitorTests
                 { "field1.nested.hey", "field2.other.blah" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.other.blah:value", aliased.ToString());
     }
 
@@ -126,6 +133,7 @@ public class FieldResolverVisitorTests
                 { "field1.nested", "field2.other" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("(field2.other:value field1.another:blah)", aliased.ToString());
     }
 
@@ -139,6 +147,7 @@ public class FieldResolverVisitorTests
                 { "level1.level2.level3.level4", "alias1.alias2.level3.level4" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("alias1.alias2.level3.level4:value", aliased.ToString());
     }
 
@@ -152,6 +161,7 @@ public class FieldResolverVisitorTests
                 { "field1.nested", "field2.nested" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.nested:value", aliased.ToString());
     }
 
@@ -165,6 +175,7 @@ public class FieldResolverVisitorTests
                 { "field1.nested.morenested", "field2.nested.morenested" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.nested.morenested:value", aliased.ToString());
     }
 
@@ -179,6 +190,7 @@ public class FieldResolverVisitorTests
                 { "field1.thing", "field2.nice" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("(field2.other:value OR field2.nice:yep) another:works", aliased.ToString());
     }
 
@@ -189,6 +201,7 @@ public class FieldResolverVisitorTests
         var result = await parser.ParseAsync("field1.nested:value");
         Assert.NotNull(result);
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, f => f == "field1.nested" ? "field2.nested" : null!);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.nested:value", aliased.ToString());
     }
 

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
@@ -34,7 +34,7 @@ public class FieldResolverVisitorTests
             };
 
         var resolver = map.ToHierarchicalFieldResolver();
-        string? resolvedField = await resolver(field, null!);
+        string? resolvedField = await resolver(field, null);
         Assert.Equal(expected, resolvedField);
     }
 

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
@@ -14,8 +14,9 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap { { "field1", "field2" } };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("field2:value", aliased.ToString());
     }
 
@@ -42,10 +43,11 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "nested", "field2" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("field1.nested:value", aliased.ToString());
     }
 
@@ -54,10 +56,11 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("field2.other:value", aliased.ToString());
     }
 
@@ -66,10 +69,11 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("field2.other:value", aliased.ToString());
     }
 
@@ -78,10 +82,11 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested.childproperty:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested.childproperty", "field2.other.childproperty" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("field2.other.childproperty:value", aliased.ToString());
     }
 
@@ -90,10 +95,11 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested.childproperty:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested.childproperty", "field2.other.childproperty" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("field2.other.childproperty:value", aliased.ToString());
     }
 
@@ -102,10 +108,11 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested.hey:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested.hey", "field2.other.blah" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("field2.other.blah:value", aliased.ToString());
     }
 
@@ -114,10 +121,11 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("(field1.nested:value field1.another:blah)");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("(field2.other:value field1.another:blah)", aliased.ToString());
     }
 
@@ -126,10 +134,11 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("level1.level2.level3.level4:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "level1.level2.level3.level4", "alias1.alias2.level3.level4" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("alias1.alias2.level3.level4:value", aliased.ToString());
     }
 
@@ -138,10 +147,11 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.nested" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("field2.nested:value", aliased.ToString());
     }
 
@@ -150,10 +160,11 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested.morenested:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested.morenested", "field2.nested.morenested" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("field2.nested.morenested:value", aliased.ToString());
     }
 
@@ -162,11 +173,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("(field1.nested:value OR field1.thing:yep) another:works");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" },
                 { "field1.thing", "field2.nice" }
             };
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, aliasMap);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
         Assert.Equal("(field2.other:value OR field2.nice:yep) another:works", aliased.ToString());
     }
 
@@ -175,7 +187,8 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, f => f == "field1.nested" ? "field2.nested" : null!);
+        Assert.NotNull(result);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, f => f == "field1.nested" ? "field2.nested" : null!);
         Assert.Equal("field2.nested:value", aliased.ToString());
     }
 
@@ -184,9 +197,10 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
+        Assert.NotNull(result);
 
         var context = new QueryVisitorContext();
-        await FieldResolverQueryVisitor.RunAsync(result!, _ => throw new ApplicationException("Bam"), context);
+        await FieldResolverQueryVisitor.RunAsync(result, _ => throw new ApplicationException("Bam"), context);
         var validationResult = context.GetValidationResult();
 
         Assert.False(validationResult.IsValid);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
@@ -186,7 +186,7 @@ public class FieldResolverVisitorTests
         var result = await parser.ParseAsync("field1.nested:value");
 
         var context = new QueryVisitorContext();
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result!, _ => throw new ApplicationException("Bam"), context);
+        await FieldResolverQueryVisitor.RunAsync(result!, _ => throw new ApplicationException("Bam"), context);
         var validationResult = context.GetValidationResult();
 
         Assert.False(validationResult.IsValid);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/GenerateQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/GenerateQueryVisitorTests.cs
@@ -41,7 +41,8 @@ public class GenerateQueryVisitorTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        var parsedQuery = (await parser.ParseAsync(query))!;
+        var parsedQuery = await parser.ParseAsync(query);
+        Assert.NotNull(parsedQuery);
 
         var context = new QueryVisitorContext { DefaultOperator = defaultOperator };
         string result = await GenerateQueryVisitor.RunAsync(parsedQuery, context);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/GenerateQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/GenerateQueryVisitorTests.cs
@@ -41,7 +41,7 @@ public class GenerateQueryVisitorTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        IQueryNode parsedQuery = await parser.ParseAsync(query);
+        var parsedQuery = (await parser.ParseAsync(query))!;
 
         var context = new QueryVisitorContext { DefaultOperator = defaultOperator };
         string result = await GenerateQueryVisitor.RunAsync(parsedQuery, context);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/IncludeQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/IncludeQueryVisitorTests.cs
@@ -74,7 +74,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result!, includes, context);
+        await IncludeVisitor.RunAsync(result!, includes, context);
         var validationResult = context.GetValidationResult();
         Assert.False(validationResult.IsValid);
         Assert.Contains("Recursive", validationResult.Message);
@@ -91,7 +91,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result!, includes, context);
+        await IncludeVisitor.RunAsync(result!, includes, context);
         var validationResult = context.GetValidationResult();
         Assert.Contains("include1", validationResult.UnresolvedIncludes);
         Assert.False(validationResult.IsValid);
@@ -106,7 +106,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var result = await parser.ParseAsync("field1:value1 @include:include1");
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result!, _ => throw new ApplicationException("Bam"), context);
+        await IncludeVisitor.RunAsync(result!, _ => throw new ApplicationException("Bam"), context);
         var validationResult = context.GetValidationResult();
         Assert.Contains("include1", validationResult.UnresolvedIncludes);
         Assert.False(validationResult.IsValid);
@@ -124,7 +124,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result!, includes, context);
+        await IncludeVisitor.RunAsync(result!, includes, context);
         Assert.True(context.IsValid());
     }
 

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/IncludeQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/IncludeQueryVisitorTests.cs
@@ -24,6 +24,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
         Assert.NotNull(result);
         var resolved = await IncludeVisitor.RunAsync(result, includes);
+        Assert.NotNull(resolved);
         Assert.Equal("(field:value)", resolved.ToString());
     }
 
@@ -38,17 +39,21 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
             };
         Assert.NotNull(result);
         var resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: (_, _) => true);
+        Assert.NotNull(resolved);
         Assert.Equal("outter @include:other @skipped:(other stuff @include:other)", resolved.ToString());
 
         resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: ShouldSkipInclude);
+        Assert.NotNull(resolved);
         Assert.Equal("outter (field:value) @skipped:(other stuff @include:other)", resolved.ToString());
 
         resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: (n, ctx) => !ShouldSkipInclude(n, ctx));
+        Assert.NotNull(resolved);
         Assert.Equal("outter (field:value) @skipped:(other stuff (field:value))", resolved.ToString());
 
         var nestedResult = await parser.ParseAsync("outter @skipped:(other stuff @include:nested)");
         Assert.NotNull(nestedResult);
         resolved = await IncludeVisitor.RunAsync(nestedResult, includes, shouldSkipInclude: ShouldSkipInclude);
+        Assert.NotNull(resolved);
         Assert.Equal("outter @skipped:(other stuff @include:nested)", resolved.ToString());
     }
 
@@ -143,6 +148,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
         Assert.NotNull(result);
         var resolved = await IncludeVisitor.RunAsync(result, includes);
+        Assert.NotNull(resolved);
         Assert.Equal("field1:value1 (field:value)", resolved.ToString());
     }
 
@@ -154,6 +160,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
         Assert.NotNull(result);
         var resolved = await IncludeVisitor.RunAsync(result, includes);
+        Assert.NotNull(resolved);
         Assert.Equal("field1:value1 OR ((field:value) field2:value2)", resolved.ToString());
     }
 
@@ -168,6 +175,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
             };
         Assert.NotNull(result);
         var resolved = await IncludeVisitor.RunAsync(result, includes);
+        Assert.NotNull(resolved);
         Assert.Equal("((field2:value2))", resolved.ToString());
     }
 }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/IncludeQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/IncludeQueryVisitorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
@@ -22,7 +22,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("@include:other");
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
-        var resolved = await IncludeVisitor.RunAsync(result, includes);
+        var resolved = await IncludeVisitor.RunAsync(result!, includes);
         Assert.Equal("(field:value)", resolved.ToString());
     }
 
@@ -35,17 +35,17 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
                 { "other", "field:value" },
                 { "nested", "field:value @include:other" }
             };
-        var resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: (_, _) => true);
+        var resolved = await IncludeVisitor.RunAsync(result!, includes, shouldSkipInclude: (_, _) => true);
         Assert.Equal("outter @include:other @skipped:(other stuff @include:other)", resolved.ToString());
 
-        resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: ShouldSkipInclude);
+        resolved = await IncludeVisitor.RunAsync(result!, includes, shouldSkipInclude: ShouldSkipInclude);
         Assert.Equal("outter (field:value) @skipped:(other stuff @include:other)", resolved.ToString());
 
-        resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: (n, ctx) => !ShouldSkipInclude(n, ctx));
+        resolved = await IncludeVisitor.RunAsync(result!, includes, shouldSkipInclude: (n, ctx) => !ShouldSkipInclude(n, ctx));
         Assert.Equal("outter (field:value) @skipped:(other stuff (field:value))", resolved.ToString());
 
         var nestedResult = await parser.ParseAsync("outter @skipped:(other stuff @include:nested)");
-        resolved = await IncludeVisitor.RunAsync(nestedResult, includes, shouldSkipInclude: ShouldSkipInclude);
+        resolved = await IncludeVisitor.RunAsync(nestedResult!, includes, shouldSkipInclude: ShouldSkipInclude);
         Assert.Equal("outter @skipped:(other stuff @include:nested)", resolved.ToString());
     }
 
@@ -74,7 +74,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result, includes, context);
+        var resolved = await IncludeVisitor.RunAsync(result!, includes, context);
         var validationResult = context.GetValidationResult();
         Assert.False(validationResult.IsValid);
         Assert.Contains("Recursive", validationResult.Message);
@@ -91,7 +91,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result, includes, context);
+        var resolved = await IncludeVisitor.RunAsync(result!, includes, context);
         var validationResult = context.GetValidationResult();
         Assert.Contains("include1", validationResult.UnresolvedIncludes);
         Assert.False(validationResult.IsValid);
@@ -106,7 +106,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var result = await parser.ParseAsync("field1:value1 @include:include1");
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result, _ => throw new ApplicationException("Bam"), context);
+        var resolved = await IncludeVisitor.RunAsync(result!, _ => throw new ApplicationException("Bam"), context);
         var validationResult = context.GetValidationResult();
         Assert.Contains("include1", validationResult.UnresolvedIncludes);
         Assert.False(validationResult.IsValid);
@@ -124,7 +124,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result, includes, context);
+        var resolved = await IncludeVisitor.RunAsync(result!, includes, context);
         Assert.True(context.IsValid());
     }
 
@@ -134,7 +134,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value1 @include:other");
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
-        var resolved = await IncludeVisitor.RunAsync(result, includes);
+        var resolved = await IncludeVisitor.RunAsync(result!, includes);
         Assert.Equal("field1:value1 (field:value)", resolved.ToString());
     }
 
@@ -144,7 +144,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value1 OR (@include:other field2:value2)");
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
-        var resolved = await IncludeVisitor.RunAsync(result, includes);
+        var resolved = await IncludeVisitor.RunAsync(result!, includes);
         Assert.Equal("field1:value1 OR ((field:value) field2:value2)", resolved.ToString());
     }
 
@@ -157,7 +157,7 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
                 { "other", "@include:other2" },
                 { "other2", "field2:value2" }
             };
-        var resolved = await IncludeVisitor.RunAsync(result, includes);
+        var resolved = await IncludeVisitor.RunAsync(result!, includes);
         Assert.Equal("((field2:value2))", resolved.ToString());
     }
 }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/IncludeQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/IncludeQueryVisitorTests.cs
@@ -22,7 +22,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("@include:other");
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
-        var resolved = await IncludeVisitor.RunAsync(result!, includes);
+        Assert.NotNull(result);
+        var resolved = await IncludeVisitor.RunAsync(result, includes);
         Assert.Equal("(field:value)", resolved.ToString());
     }
 
@@ -35,17 +36,19 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
                 { "other", "field:value" },
                 { "nested", "field:value @include:other" }
             };
-        var resolved = await IncludeVisitor.RunAsync(result!, includes, shouldSkipInclude: (_, _) => true);
+        Assert.NotNull(result);
+        var resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: (_, _) => true);
         Assert.Equal("outter @include:other @skipped:(other stuff @include:other)", resolved.ToString());
 
-        resolved = await IncludeVisitor.RunAsync(result!, includes, shouldSkipInclude: ShouldSkipInclude);
+        resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: ShouldSkipInclude);
         Assert.Equal("outter (field:value) @skipped:(other stuff @include:other)", resolved.ToString());
 
-        resolved = await IncludeVisitor.RunAsync(result!, includes, shouldSkipInclude: (n, ctx) => !ShouldSkipInclude(n, ctx));
+        resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: (n, ctx) => !ShouldSkipInclude(n, ctx));
         Assert.Equal("outter (field:value) @skipped:(other stuff (field:value))", resolved.ToString());
 
         var nestedResult = await parser.ParseAsync("outter @skipped:(other stuff @include:nested)");
-        resolved = await IncludeVisitor.RunAsync(nestedResult!, includes, shouldSkipInclude: ShouldSkipInclude);
+        Assert.NotNull(nestedResult);
+        resolved = await IncludeVisitor.RunAsync(nestedResult, includes, shouldSkipInclude: ShouldSkipInclude);
         Assert.Equal("outter @skipped:(other stuff @include:nested)", resolved.ToString());
     }
 
@@ -74,7 +77,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        await IncludeVisitor.RunAsync(result!, includes, context);
+        Assert.NotNull(result);
+        await IncludeVisitor.RunAsync(result, includes, context);
         var validationResult = context.GetValidationResult();
         Assert.False(validationResult.IsValid);
         Assert.Contains("Recursive", validationResult.Message);
@@ -91,7 +95,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        await IncludeVisitor.RunAsync(result!, includes, context);
+        Assert.NotNull(result);
+        await IncludeVisitor.RunAsync(result, includes, context);
         var validationResult = context.GetValidationResult();
         Assert.Contains("include1", validationResult.UnresolvedIncludes);
         Assert.False(validationResult.IsValid);
@@ -106,7 +111,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var result = await parser.ParseAsync("field1:value1 @include:include1");
 
         var context = new QueryVisitorContext();
-        await IncludeVisitor.RunAsync(result!, _ => throw new ApplicationException("Bam"), context);
+        Assert.NotNull(result);
+        await IncludeVisitor.RunAsync(result, _ => throw new ApplicationException("Bam"), context);
         var validationResult = context.GetValidationResult();
         Assert.Contains("include1", validationResult.UnresolvedIncludes);
         Assert.False(validationResult.IsValid);
@@ -124,7 +130,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        await IncludeVisitor.RunAsync(result!, includes, context);
+        Assert.NotNull(result);
+        await IncludeVisitor.RunAsync(result, includes, context);
         Assert.True(context.IsValid());
     }
 
@@ -134,7 +141,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value1 @include:other");
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
-        var resolved = await IncludeVisitor.RunAsync(result!, includes);
+        Assert.NotNull(result);
+        var resolved = await IncludeVisitor.RunAsync(result, includes);
         Assert.Equal("field1:value1 (field:value)", resolved.ToString());
     }
 
@@ -144,7 +152,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value1 OR (@include:other field2:value2)");
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
-        var resolved = await IncludeVisitor.RunAsync(result!, includes);
+        Assert.NotNull(result);
+        var resolved = await IncludeVisitor.RunAsync(result, includes);
         Assert.Equal("field1:value1 OR ((field:value) field2:value2)", resolved.ToString());
     }
 
@@ -157,7 +166,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
                 { "other", "@include:other2" },
                 { "other2", "field2:value2" }
             };
-        var resolved = await IncludeVisitor.RunAsync(result!, includes);
+        Assert.NotNull(result);
+        var resolved = await IncludeVisitor.RunAsync(result, includes);
         Assert.Equal("((field2:value2))", resolved.ToString());
     }
 }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/InvertQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/InvertQueryVisitorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
 using Foundatio.Parsers.LuceneQueries.Nodes;
@@ -99,12 +99,12 @@ public class InvertQueryVisitorTests : TestWithLoggingBase
     [InlineData("noninvertedfield1:value field1:value field2:value field3:value", "noninvertedfield1:value (is_deleted:true OR (NOT (field1:value field2:value field3:value)))", "is_deleted:true")]
     [InlineData("noninvertedfield1:123 (status:open OR status:regressed) noninvertedfield1:234", "noninvertedfield1:123 (NOT (status:open OR status:regressed)) noninvertedfield1:234")]
     [InlineData("first_occurrence:[1609459200000 TO 1609730450521] (noninvertedfield1:537650f3b77efe23a47914f4 (status:open OR status:regressed))", "(NOT first_occurrence:[1609459200000 TO 1609730450521]) (noninvertedfield1:537650f3b77efe23a47914f4 (NOT (status:open OR status:regressed)))")]
-    public Task CanInvertQuery(string query, string expected, string alternateInvertedCriteria = null)
+    public Task CanInvertQuery(string query, string expected, string? alternateInvertedCriteria = null)
     {
         return InvertAndValidateQuery(query, expected, alternateInvertedCriteria, true);
     }
 
-    private async Task InvertAndValidateQuery(string query, string expected, string alternateInvertedCriteria, bool isValid)
+    private async Task InvertAndValidateQuery(string query, string expected, string? alternateInvertedCriteria, bool isValid)
     {
 #if ENABLE_TRACING
             var tracer = new LoggingTracer(_logger, reportPerformance: true);
@@ -116,7 +116,7 @@ public class InvertQueryVisitorTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        IQueryNode result;
+        IQueryNode? result;
         try
         {
             result = await parser.ParseAsync(query);
@@ -133,10 +133,10 @@ public class InvertQueryVisitorTests : TestWithLoggingBase
         if (!String.IsNullOrWhiteSpace(alternateInvertedCriteria))
         {
             var invertedAlternate = await parser.ParseAsync(alternateInvertedCriteria);
-            context.SetAlternateInvertedCriteria(invertedAlternate);
+            context.SetAlternateInvertedCriteria(invertedAlternate!);
         }
 
-        result = await invertQueryVisitor.AcceptAsync(result, context);
+        result = await invertQueryVisitor.AcceptAsync(result!, context);
         string invertedQuery = result.ToString();
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/InvertQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/InvertQueryVisitorTests.cs
@@ -133,10 +133,12 @@ public class InvertQueryVisitorTests : TestWithLoggingBase
         if (!String.IsNullOrWhiteSpace(alternateInvertedCriteria))
         {
             var invertedAlternate = await parser.ParseAsync(alternateInvertedCriteria);
-            context.SetAlternateInvertedCriteria(invertedAlternate!);
+            Assert.NotNull(invertedAlternate);
+            context.SetAlternateInvertedCriteria(invertedAlternate);
         }
 
-        result = await invertQueryVisitor.AcceptAsync(result!, context);
+        Assert.NotNull(result);
+        result = await invertQueryVisitor.AcceptAsync(result, context);
         string invertedQuery = result.ToString();
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/InvertQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/InvertQueryVisitorTests.cs
@@ -139,6 +139,7 @@ public class InvertQueryVisitorTests : TestWithLoggingBase
 
         Assert.NotNull(result);
         result = await invertQueryVisitor.AcceptAsync(result, context);
+        Assert.NotNull(result);
         string invertedQuery = result.ToString();
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -38,9 +38,10 @@ public class QueryParserTests : TestWithLoggingBase
         try
         {
             var result = await parser.ParseAsync(query);
+            Assert.NotNull(result);
 
-            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
-            string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
+            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
+            string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
             Assert.Equal(query, generatedQuery);
         }
         catch (FormatException ex)
@@ -73,9 +74,10 @@ public class QueryParserTests : TestWithLoggingBase
         try
         {
             var result = await parser.ParseAsync(query);
+            Assert.NotNull(result);
 
-            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
-            string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
+            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
+            string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
             Assert.Equal(query, generatedQuery);
 
             var groupNode = result as GroupNode;
@@ -114,9 +116,10 @@ public class QueryParserTests : TestWithLoggingBase
         try
         {
             var result = await parser.ParseAsync(query);
+            Assert.NotNull(result);
 
-            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
-            string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
+            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
+            string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
             Assert.Equal(query, generatedQuery);
 
             var groupNode = result as GroupNode;
@@ -159,9 +162,10 @@ public class QueryParserTests : TestWithLoggingBase
         };
         string query = "mydate:[now/d TO now/d+30d/d]";
         var result = sut.Parse(query);
+        Assert.NotNull(result);
         _logger.LogInformation(DebugQueryVisitor.Run(result));
 
-        string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
+        string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
         Assert.Equal(query, generatedQuery);
 
         var groupNode = result as GroupNode;
@@ -216,9 +220,10 @@ public class QueryParserTests : TestWithLoggingBase
         try
         {
             var result = await parser.ParseAsync(query);
+            Assert.NotNull(result);
 
-            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
-            string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
+            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
+            string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
             Assert.Equal(query, generatedQuery);
 
             var groupNode = result as GroupNode;
@@ -508,13 +513,14 @@ public class QueryParserTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
 
         var result = await parser.ParseAsync(query);
+        Assert.NotNull(result);
 
-        _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
-        string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
+        _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
+        string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
         Assert.Equal(expected, generatedQuery);
 
-        await new AssignOperationTypeVisitor().AcceptAsync(result!, null!);
-        _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
+        await new AssignOperationTypeVisitor().AcceptAsync(result, null!);
+        _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
     }
 
     [Theory]

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -519,7 +519,7 @@ public class QueryParserTests : TestWithLoggingBase
         string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
         Assert.Equal(expected, generatedQuery);
 
-        await new AssignOperationTypeVisitor().AcceptAsync(result, null!);
+        await new AssignOperationTypeVisitor().AcceptAsync(result, new QueryVisitorContext());
         _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
     }
 

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -39,8 +39,8 @@ public class QueryParserTests : TestWithLoggingBase
         {
             var result = await parser.ParseAsync(query);
 
-            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
-            string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
+            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
+            string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
             Assert.Equal(query, generatedQuery);
         }
         catch (FormatException ex)
@@ -74,8 +74,8 @@ public class QueryParserTests : TestWithLoggingBase
         {
             var result = await parser.ParseAsync(query);
 
-            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
-            string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
+            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
+            string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
             Assert.Equal(query, generatedQuery);
 
             var groupNode = result as GroupNode;
@@ -115,8 +115,8 @@ public class QueryParserTests : TestWithLoggingBase
         {
             var result = await parser.ParseAsync(query);
 
-            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
-            string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
+            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
+            string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
             Assert.Equal(query, generatedQuery);
 
             var groupNode = result as GroupNode;
@@ -161,7 +161,7 @@ public class QueryParserTests : TestWithLoggingBase
         var result = sut.Parse(query);
         _logger.LogInformation(DebugQueryVisitor.Run(result));
 
-        string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
+        string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
         Assert.Equal(query, generatedQuery);
 
         var groupNode = result as GroupNode;
@@ -217,8 +217,8 @@ public class QueryParserTests : TestWithLoggingBase
         {
             var result = await parser.ParseAsync(query);
 
-            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
-            string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
+            _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
+            string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
             Assert.Equal(query, generatedQuery);
 
             var groupNode = result as GroupNode;
@@ -260,8 +260,8 @@ public class QueryParserTests : TestWithLoggingBase
         string ast = DebugQueryVisitor.Run(result);
 
         Assert.IsType<GroupNode>(result.Left);
-        Assert.True((result.Left as GroupNode).HasParens);
-        Assert.True((result.Left as GroupNode).IsNegated);
+        Assert.True((result.Left as GroupNode)!.HasParens);
+        Assert.True((result.Left as GroupNode)!.IsNegated);
     }
 
     [Fact]
@@ -438,7 +438,7 @@ public class QueryParserTests : TestWithLoggingBase
 
         Assert.IsType<TermNode>(result.Left);
         Assert.True(((TermNode)result.Left).IsQuotedTerm);
-        Assert.Empty(((TermNode)result.Left).Term);
+        Assert.Empty(((TermNode)result.Left).Term!);
     }
 
     [Fact]
@@ -509,12 +509,12 @@ public class QueryParserTests : TestWithLoggingBase
 
         var result = await parser.ParseAsync(query);
 
-        _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
-        string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
+        _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
+        string generatedQuery = await GenerateQueryVisitor.RunAsync(result!);
         Assert.Equal(expected, generatedQuery);
 
-        await new AssignOperationTypeVisitor().AcceptAsync(result, null);
-        _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
+        await new AssignOperationTypeVisitor().AcceptAsync(result!, null!);
+        _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result!));
     }
 
     [Theory]
@@ -524,7 +524,7 @@ public class QueryParserTests : TestWithLoggingBase
     [InlineData("\"phrase query\"~2", null, true, "2")]
     [InlineData("field:term~", "field", false, "")]
     [InlineData("field:\"phrase\"~3", "field", true, "3")]
-    public void Parse_WithProximityModifier_SetsProximityOnTermNode(string query, string expectedField, bool expectedQuoted, string expectedProximity)
+    public void Parse_WithProximityModifier_SetsProximityOnTermNode(string query, string? expectedField, bool expectedQuoted, string expectedProximity)
     {
         var parser = new LuceneQueryParser();
         var result = parser.Parse(query);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserValidationTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserValidationTests.cs
@@ -177,10 +177,10 @@ public class QueryParserValidationTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        IQueryNode result;
+        IQueryNode? result;
         try
         {
-            result = (await parser.ParseAsync(query))!;
+            result = await parser.ParseAsync(query);
         }
         catch (FormatException ex)
         {
@@ -188,6 +188,7 @@ public class QueryParserValidationTests : TestWithLoggingBase
             return;
         }
 
+        Assert.NotNull(result);
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);
         string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
@@ -230,7 +231,8 @@ public class QueryParserValidationTests : TestWithLoggingBase
         try
         {
             _logger.LogInformation("Attempting: {Escaped}", escaped);
-            var result = (await parser.ParseAsync(query))!;
+            var result = await parser.ParseAsync(query);
+            Assert.NotNull(result);
 
             _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
             string generatedQuery = await GenerateQueryVisitor.RunAsync(result);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserValidationTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserValidationTests.cs
@@ -180,7 +180,7 @@ public class QueryParserValidationTests : TestWithLoggingBase
         IQueryNode result;
         try
         {
-            result = await parser.ParseAsync(query);
+            result = (await parser.ParseAsync(query))!;
         }
         catch (FormatException ex)
         {
@@ -230,7 +230,7 @@ public class QueryParserValidationTests : TestWithLoggingBase
         try
         {
             _logger.LogInformation("Attempting: {Escaped}", escaped);
-            var result = await parser.ParseAsync(query);
+            var result = (await parser.ParseAsync(query))!;
 
             _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
             string generatedQuery = await GenerateQueryVisitor.RunAsync(result);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryValidatorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryValidatorTests.cs
@@ -143,7 +143,7 @@ public class QueryValidatorTests : TestWithLoggingBase
             AllowUnresolvedFields = false
         };
         var context = new QueryVisitorContext();
-        context.SetFieldResolver(f => f == "field1" ? f : null!);
+        context.SetFieldResolver(f => f == "field1" ? f : null);
         var info = await QueryValidator.ValidateQueryAsync(@"field1:blah", options, context);
         Assert.True(info.IsValid);
     }
@@ -156,7 +156,7 @@ public class QueryValidatorTests : TestWithLoggingBase
             AllowUnresolvedFields = false
         };
         var context = new QueryVisitorContext();
-        context.SetFieldResolver(f => f == "field1" ? f : null!);
+        context.SetFieldResolver(f => f == "field1" ? f : null);
         var info = await QueryValidator.ValidateQueryAsync(@"field1:blah field2:blah", options, context);
         Assert.False(info.IsValid);
         Assert.Contains("field2", info.UnresolvedFields!);
@@ -170,7 +170,7 @@ public class QueryValidatorTests : TestWithLoggingBase
             AllowUnresolvedFields = false
         };
         var context = new QueryVisitorContext();
-        context.SetFieldResolver(f => f == "field1" ? f : null!);
+        context.SetFieldResolver(f => f == "field1" ? f : null);
         var ex = await Assert.ThrowsAsync<QueryValidationException>(() => QueryValidator.ValidateQueryAndThrowAsync(@"field1:blah field2:blah", options, context));
         Assert.Contains("resolved", ex.Message);
         Assert.NotNull(ex.Result);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryValidatorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryValidatorTests.cs
@@ -29,9 +29,10 @@ public class QueryValidatorTests : TestWithLoggingBase
     {
         var ex = await Assert.ThrowsAsync<QueryValidationException>(() => QueryValidator.ValidateQueryAndThrowAsync(@":"));
         Assert.Contains("Unexpected", ex.Message);
-        Assert.False(ex.Result!.IsValid);
+        Assert.NotNull(ex.Result);
+        Assert.False(ex.Result.IsValid);
         Assert.NotNull(ex.Result.Message);
-        Assert.Contains("Unexpected", ex.Result.Message!);
+        Assert.Contains("Unexpected", ex.Result.Message);
     }
 
     [Fact]
@@ -172,7 +173,9 @@ public class QueryValidatorTests : TestWithLoggingBase
         context.SetFieldResolver(f => f == "field1" ? f : null!);
         var ex = await Assert.ThrowsAsync<QueryValidationException>(() => QueryValidator.ValidateQueryAndThrowAsync(@"field1:blah field2:blah", options, context));
         Assert.Contains("resolved", ex.Message);
-        Assert.Contains("field2", ex.Result!.UnresolvedFields!);
+        Assert.NotNull(ex.Result);
+        Assert.NotNull(ex.Result.UnresolvedFields);
+        Assert.Contains("field2", ex.Result.UnresolvedFields);
         Assert.False(ex.Result.IsValid);
         Assert.NotNull(ex.Result.Message);
         Assert.Contains("resolved", ex.Result.Message!);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryValidatorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryValidatorTests.cs
@@ -29,9 +29,9 @@ public class QueryValidatorTests : TestWithLoggingBase
     {
         var ex = await Assert.ThrowsAsync<QueryValidationException>(() => QueryValidator.ValidateQueryAndThrowAsync(@":"));
         Assert.Contains("Unexpected", ex.Message);
-        Assert.False(ex.Result.IsValid);
+        Assert.False(ex.Result!.IsValid);
         Assert.NotNull(ex.Result.Message);
-        Assert.Contains("Unexpected", ex.Result.Message);
+        Assert.Contains("Unexpected", ex.Result.Message!);
     }
 
     [Fact]
@@ -142,7 +142,7 @@ public class QueryValidatorTests : TestWithLoggingBase
             AllowUnresolvedFields = false
         };
         var context = new QueryVisitorContext();
-        context.SetFieldResolver(f => f == "field1" ? f : null);
+        context.SetFieldResolver(f => f == "field1" ? f : null!);
         var info = await QueryValidator.ValidateQueryAsync(@"field1:blah", options, context);
         Assert.True(info.IsValid);
     }
@@ -155,10 +155,10 @@ public class QueryValidatorTests : TestWithLoggingBase
             AllowUnresolvedFields = false
         };
         var context = new QueryVisitorContext();
-        context.SetFieldResolver(f => f == "field1" ? f : null);
+        context.SetFieldResolver(f => f == "field1" ? f : null!);
         var info = await QueryValidator.ValidateQueryAsync(@"field1:blah field2:blah", options, context);
         Assert.False(info.IsValid);
-        Assert.Contains("field2", info.UnresolvedFields);
+        Assert.Contains("field2", info.UnresolvedFields!);
     }
 
     [Fact]
@@ -169,13 +169,13 @@ public class QueryValidatorTests : TestWithLoggingBase
             AllowUnresolvedFields = false
         };
         var context = new QueryVisitorContext();
-        context.SetFieldResolver(f => f == "field1" ? f : null);
+        context.SetFieldResolver(f => f == "field1" ? f : null!);
         var ex = await Assert.ThrowsAsync<QueryValidationException>(() => QueryValidator.ValidateQueryAndThrowAsync(@"field1:blah field2:blah", options, context));
         Assert.Contains("resolved", ex.Message);
-        Assert.Contains("field2", ex.Result.UnresolvedFields);
+        Assert.Contains("field2", ex.Result!.UnresolvedFields!);
         Assert.False(ex.Result.IsValid);
         Assert.NotNull(ex.Result.Message);
-        Assert.Contains("resolved", ex.Result.Message);
+        Assert.Contains("resolved", ex.Result.Message!);
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/ReferencedFieldsTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/ReferencedFieldsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
 using Foundatio.Xunit;
 using Xunit;
@@ -16,7 +16,7 @@ public class ReferencedFieldsTests : TestWithLoggingBase
     public async Task CanGetReferencedFields()
     {
         var parser = new LuceneQueryParser();
-        var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
+        var result = (await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value"))!;
         var fields = result.GetReferencedFields();
 
         Assert.Equal(6, fields.Count);
@@ -43,7 +43,7 @@ public class ReferencedFieldsTests : TestWithLoggingBase
     public async Task CanGetTopLevelReferencedFields()
     {
         var parser = new LuceneQueryParser();
-        var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
+        var result = (await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value"))!;
         var fields = result.GetReferencedFields(currentGroupOnly: true);
 
         Assert.Equal(3, fields.Count);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/ReferencedFieldsTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/ReferencedFieldsTests.cs
@@ -16,7 +16,8 @@ public class ReferencedFieldsTests : TestWithLoggingBase
     public async Task CanGetReferencedFields()
     {
         var parser = new LuceneQueryParser();
-        var result = (await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value"))!;
+        var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
+        Assert.NotNull(result);
         var fields = result.GetReferencedFields();
 
         Assert.Equal(6, fields.Count);
@@ -43,7 +44,8 @@ public class ReferencedFieldsTests : TestWithLoggingBase
     public async Task CanGetTopLevelReferencedFields()
     {
         var parser = new LuceneQueryParser();
-        var result = (await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value"))!;
+        var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
+        Assert.NotNull(result);
         var fields = result.GetReferencedFields(currentGroupOnly: true);
 
         Assert.Equal(3, fields.Count);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/RemoveFieldsQueryVisitor.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/RemoveFieldsQueryVisitor.cs
@@ -17,7 +17,8 @@ public class RemoveFieldsQueryVisitorTests : TestWithLoggingBase
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
-        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result!, ["field1"]);
+        Assert.NotNull(result);
+        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, ["field1"]);
 
         Assert.Equal("field2:value (field3:value OR field4:value (field5:value)) field6:value", queryResult);
     }
@@ -27,7 +28,8 @@ public class RemoveFieldsQueryVisitorTests : TestWithLoggingBase
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
-        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result!, f => f == "field3");
+        Assert.NotNull(result);
+        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, f => f == "field3");
 
         Assert.Equal("field1:value field2:value (field4:value (field5:value)) field6:value", queryResult);
     }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/RemoveFieldsQueryVisitor.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/RemoveFieldsQueryVisitor.cs
@@ -18,7 +18,7 @@ public class RemoveFieldsQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
         Assert.NotNull(result);
-        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, ["field1"]);
+        string? queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, ["field1"]);
 
         Assert.Equal("field2:value (field3:value OR field4:value (field5:value)) field6:value", queryResult);
     }
@@ -29,7 +29,7 @@ public class RemoveFieldsQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
         Assert.NotNull(result);
-        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, f => f == "field3");
+        string? queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, f => f == "field3");
 
         Assert.Equal("field1:value field2:value (field4:value (field5:value)) field6:value", queryResult);
     }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/RemoveFieldsQueryVisitor.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/RemoveFieldsQueryVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Visitors;
 using Foundatio.Xunit;
 using Xunit;
@@ -17,7 +17,7 @@ public class RemoveFieldsQueryVisitorTests : TestWithLoggingBase
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
-        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, ["field1"]);
+        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result!, ["field1"]);
 
         Assert.Equal("field2:value (field3:value OR field4:value (field5:value)) field6:value", queryResult);
     }
@@ -27,7 +27,7 @@ public class RemoveFieldsQueryVisitorTests : TestWithLoggingBase
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
-        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, f => f == "field3");
+        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result!, f => f == "field3");
 
         Assert.Equal("field1:value field2:value (field4:value (field5:value)) field6:value", queryResult);
     }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/UnescapeTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/UnescapeTests.cs
@@ -21,7 +21,7 @@ public sealed class UnescapeTests : TestWithLoggingBase
     [InlineData(@"At end \", @"At end \")]
     public void UnescapingWorks(string test, string expected)
     {
-        string result = test.Unescape();
+        string? result = test.Unescape();
         Assert.Equal(expected, result);
     }
 }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/Utility/LoggingTracer.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/Utility/LoggingTracer.cs
@@ -197,18 +197,18 @@ public class LoggingTracer : ITracer
         /// <summary>
         /// Gets the name of the rule.
         /// </summary>
-        public string Name { get; internal set; }
+        public string Name { get; internal set; } = null!;
     }
 
     private class RuleStackEntry
     {
         public bool? CacheHit { get; set; }
 
-        public Cursor Cursor { get; set; }
+        public Cursor Cursor { get; set; } = null!;
 
-        public string RuleName { get; set; }
+        public string RuleName { get; set; } = null!;
 
-        public Stopwatch Stopwatch { get; set; }
+        public Stopwatch Stopwatch { get; set; } = null!;
     }
 
     private class RuleStats

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/DynamicFieldVisitor.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/DynamicFieldVisitor.cs
@@ -15,7 +15,7 @@ public class DynamicFieldVisitor : ChainableMutatingQueryVisitor
 
         var field = SqlNodeExtensions.GetFieldInfo(sqlContext.Fields, node.Field);
 
-        if (field == null || !field.Data.TryGetValue("DataDefinitionId", out object value) ||
+        if (field == null || !field.Data.TryGetValue("DataDefinitionId", out object? value) ||
             value is not int dataDefinitionId)
         {
             return node;

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/DynamicFieldVisitor.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/DynamicFieldVisitor.cs
@@ -15,7 +15,7 @@ public class DynamicFieldVisitor : ChainableMutatingQueryVisitor
 
         var field = SqlNodeExtensions.GetFieldInfo(sqlContext.Fields, node.Field);
 
-        if (field == null || !field.Data.TryGetValue("DataDefinitionId", out object? value) ||
+        if (field is null || !field.Data.TryGetValue("DataDefinitionId", out object? value) ||
             value is not int dataDefinitionId)
         {
             return node;

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/Foundatio.Parsers.SqlQueries.Tests.csproj
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/Foundatio.Parsers.SqlQueries.Tests.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
-      <PackageReference Include="libphonenumber-csharp" Version="9.0.26" />
+      <PackageReference Include="libphonenumber-csharp" Version="9.0.27" />
     </ItemGroup>
 
 </Project>

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SampleContext.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SampleContext.cs
@@ -58,15 +58,15 @@ public class SampleContext : DbContext
 public class Employee
 {
     public int Id { get; set; }
-    public string FullName { get; set; }
-    public string PhoneNumber { get; set; }
-    public string NationalPhoneNumber { get; set; }
-    public string Title { get; set; }
+    public string FullName { get; set; } = null!;
+    public string PhoneNumber { get; set; } = null!;
+    public string NationalPhoneNumber { get; set; } = null!;
+    public string Title { get; set; } = null!;
     public int Salary { get; set; }
     public int? CurrentCompanyId { get; set; }
-    public Company CurrentCompany { get; set; }
-    public List<Company> Companies { get; set; }
-    public List<DataValue> DataValues { get; set; }
+    public Company? CurrentCompany { get; set; }
+    public List<Company> Companies { get; set; } = null!;
+    public List<DataValue> DataValues { get; set; } = null!;
     public TimeOnly HappyHour { get; set; }
     public DateOnly Birthday { get; set; }
 
@@ -76,11 +76,11 @@ public class Employee
 public class Company
 {
     public int Id { get; set; }
-    public string Name { get; set; }
-    public string Description { get; set; }
-    public string Location { get; set; }
-    public List<Employee> Employees { get; set; }
-    public List<DataDefinition> DataDefinitions { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Description { get; set; }
+    public string? Location { get; set; }
+    public List<Employee> Employees { get; set; } = null!;
+    public List<DataDefinition> DataDefinitions { get; set; } = null!;
 }
 
 public class DataValue
@@ -91,16 +91,16 @@ public class DataValue
     public int EmployeeId { get; set; }
 
     // store the values separately as sparse columns for querying purposes
-    public string StringValue { get; set; }
+    public string? StringValue { get; set; }
     public DateTime? DateValue { get; set; }
     public DateOnly? DateOnlyValue { get; set; }
     public decimal? MoneyValue { get; set; }
     public bool? BooleanValue { get; set; }
     public decimal? NumberValue { get; set; }
 
-    public DataDefinition Definition { get; set; } = null;
+    public DataDefinition? Definition { get; set; } = null;
 
-    public object GetValue(DataType? dataType = null)
+    public object? GetValue(DataType? dataType = null)
     {
         if (!dataType.HasValue && Definition != null)
             dataType = Definition.DataType;
@@ -136,6 +136,7 @@ public class DataValue
     {
         StringValue = null;
         DateValue = null;
+        DateOnlyValue = null;
         NumberValue = null;
         BooleanValue = null;
         MoneyValue = null;
@@ -175,7 +176,7 @@ public class DataValue
 
     // relationships
     [DeleteBehavior(DeleteBehavior.NoAction)]
-    public Employee Employee { get; set; } = null;
+    public Employee? Employee { get; set; } = null;
 }
 
 public class DataDefinition
@@ -188,7 +189,7 @@ public class DataDefinition
 
     // relationships
     [DeleteBehavior(DeleteBehavior.Cascade)]
-    public Company Company { get; set; } = null;
+    public Company? Company { get; set; } = null;
 }
 
 public enum DataType

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -586,10 +586,10 @@ public class SqlQueryParserTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        IQueryNode result;
+        IQueryNode? result;
         try
         {
-            result = (await parser.ParseAsync(query))!;
+            result = await parser.ParseAsync(query);
         }
         catch (FormatException ex)
         {
@@ -597,6 +597,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
             return;
         }
 
+        Assert.NotNull(result);
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Nodes}", nodes);
         var context = new SqlQueryVisitorContext

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -430,8 +430,10 @@ public class SqlQueryParserTests : TestWithLoggingBase
         var parser = sp.GetRequiredService<SqlQueryParser>();
 
         var context = parser.GetContext(db.Employees.EntityType);
+        context.Fields ??= [];
         context.Fields.Add(new EntityFieldInfo { Name = "age", FullName = "age", IsNumber = true, Data = { { "DataDefinitionId", 1 } } });
-        context.ValidationOptions!.AllowedFields.Add("age");
+        Assert.NotNull(context.ValidationOptions);
+        context.ValidationOptions.AllowedFields.Add("age");
 
         string sqlExpected = db.Employees.Where(e => e.Companies.Any(c => c.Name == "acme") && e.DataValues.Any(dv => dv.DataDefinitionId == 1 && dv.NumberValue == 30)).ToQueryString();
         string sqlActual = db.Employees.Where("""Companies.Any(Name = "acme") AND DataValues.Any(DataDefinitionId = 1 AND NumberValue = 30) """).ToQueryString();

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -97,7 +97,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
             if (s.FieldInfo.FullName != "NationalPhoneNumber")
                 return;
 
-            s.Tokens = [TryGetNationalNumber(s.Term)];
+            s.Tokens = [TryGetNationalNumber(s.Term)!];
             s.Operator = SqlSearchOperator.StartsWith;
         });
 
@@ -344,7 +344,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
 
         var context = parser.GetContext(db.Employees.EntityType);
 
-        string sqlExpected = db.Employees.Where(e => EF.Functions.Contains(e.CurrentCompany.Name, "\"acme*\"") || EF.Functions.Contains(e.CurrentCompany.Location, "\"acme*\"")).ToQueryString();
+        string sqlExpected = db.Employees.Where(e => EF.Functions.Contains(e.CurrentCompany!.Name, "\"acme*\"") || EF.Functions.Contains(e.CurrentCompany!.Location!, "\"acme*\"")).ToQueryString();
 
         await SqlWaiter.WaitForFullTextIndexAsync(db, "ftCatalog");
 
@@ -431,7 +431,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
 
         var context = parser.GetContext(db.Employees.EntityType);
         context.Fields.Add(new EntityFieldInfo { Name = "age", FullName = "age", IsNumber = true, Data = { { "DataDefinitionId", 1 } } });
-        context.ValidationOptions.AllowedFields.Add("age");
+        context.ValidationOptions!.AllowedFields.Add("age");
 
         string sqlExpected = db.Employees.Where(e => e.Companies.Any(c => c.Name == "acme") && e.DataValues.Any(dv => dv.DataDefinitionId == 1 && dv.NumberValue == 30)).ToQueryString();
         string sqlActual = db.Employees.Where("""Companies.Any(Name = "acme") AND DataValues.Any(DataDefinitionId = 1 AND NumberValue = 30) """).ToQueryString();
@@ -455,7 +455,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
         Assert.Equal("John Doe", employee.FullName);
     }
 
-    public static string TryGetNationalNumber(string phoneNumber, string regionCode = "US")
+    public static string? TryGetNationalNumber(string phoneNumber, string regionCode = "US")
     {
         var phoneNumberUtil = PhoneNumberUtil.GetInstance();
         try
@@ -587,7 +587,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
         IQueryNode result;
         try
         {
-            result = await parser.ParseAsync(query);
+            result = (await parser.ParseAsync(query))!;
         }
         catch (FormatException ex)
         {


### PR DESCRIPTION
## Summary
- Replaced ineffective \<WarningsAsErrors>true</WarningsAsErrors>\ with correct \<TreatWarningsAsErrors>true</TreatWarningsAsErrors>\
- Fixed nullable reference annotations across Lucene, Elastic, and SQL query parsers

## Test plan
- [x] \dotnet build Foundatio.All.slnx\ — 0 warnings, 0 errors