### PR TITLE
Merge NRT changes from main into elastic-client-nrt

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -15,6 +15,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
     <PackageIcon>foundatio-icon.png</PackageIcon>

--- a/build/common.props
+++ b/build/common.props
@@ -13,7 +13,7 @@
     <Copyright>Copyright © $([System.DateTime]::Now.ToString(yyyy)) Foundatio.  All rights reserved.</Copyright>
     <Authors>FoundatioFx</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
-    <WarningsAsErrors>true</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.11
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.14
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'
@@ -19,7 +19,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:8.19.11
+    image: docker.elastic.co/kibana/kibana:8.19.14
     ports:
       - 5601:5601
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.3
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'
@@ -19,7 +19,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:9.3.2
+    image: docker.elastic.co/kibana/kibana:9.3.3
     ports:
       - 5601:5601
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.14
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.2
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'
@@ -19,7 +19,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:8.19.14
+    image: docker.elastic.co/kibana/kibana:9.3.2
     ports:
       - 5601:5601
     networks:

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "devDependencies": {
         "@types/node": "^24.0.0",
-        "mermaid": "^11.13.0",
+        "mermaid": "^11.14.0",
         "vitepress": "^2.0.0-alpha.16",
-        "vitepress-plugin-llms": "^1.11.0",
+        "vitepress-plugin-llms": "^1.12.0",
         "vitepress-plugin-mermaid": "^2.0.17"
       }
     },
@@ -87,46 +87,44 @@
       "license": "MIT"
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
-      "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/gast": "11.1.2",
-        "@chevrotain/types": "11.1.2",
-        "lodash-es": "4.17.23"
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
       }
     },
     "node_modules/@chevrotain/gast": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
-      "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/types": "11.1.2",
-        "lodash-es": "4.17.23"
+        "@chevrotain/types": "12.0.0"
       }
     },
     "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
-      "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/types": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
-      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
-      "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -655,9 +653,9 @@
       "optional": true
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.1.tgz",
-      "integrity": "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1937,31 +1935,33 @@
       }
     },
     "node_modules/chevrotain": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
-      "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.1.2",
-        "@chevrotain/gast": "11.1.2",
-        "@chevrotain/regexp-to-ast": "11.1.2",
-        "@chevrotain/types": "11.1.2",
-        "@chevrotain/utils": "11.1.2",
-        "lodash-es": "4.17.23"
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/chevrotain-allstar": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.21"
       },
       "peerDependencies": {
-        "chevrotain": "^11.0.0"
+        "chevrotain": "^12.0.0"
       }
     },
     "node_modules/cliui": {
@@ -3095,14 +3095,15 @@
       }
     },
     "node_modules/langium": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
-      "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chevrotain": "~11.1.1",
-        "chevrotain-allstar": "~0.3.1",
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.1",
         "vscode-languageserver": "~9.0.1",
         "vscode-languageserver-textdocument": "~1.0.11",
         "vscode-uri": "~3.1.0"
@@ -3213,9 +3214,9 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3337,15 +3338,15 @@
       "license": "MIT"
     },
     "node_modules/mermaid": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.13.0.tgz",
-      "integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.1",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.0.1",
+        "@mermaid-js/parser": "^1.1.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
         "cytoscape": "^3.33.1",
@@ -4805,26 +4806,29 @@
       }
     },
     "node_modules/vitepress-plugin-llms": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/vitepress-plugin-llms/-/vitepress-plugin-llms-1.11.0.tgz",
-      "integrity": "sha512-n6fjWzBNKy40p8cij+d2cHiC2asNW1eQKdmc06gX9VAv7vWppIoVLH/f7Ht1bK0vSpGzzW2QimvNfbfv1oCdJw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-llms/-/vitepress-plugin-llms-1.12.0.tgz",
+      "integrity": "sha512-zuzL7a8UJuGl46le5cAy/QxKMGlpSylcsLjDDn6BYPc1u+eP3nzoQk9ne9XFBqrE7exoJlIYJELVN8HMgYlFKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "gray-matter": "^4.0.3",
         "markdown-it": "^14.1.0",
         "markdown-title": "^1.0.2",
-        "mdast-util-from-markdown": "^2.0.2",
+        "mdast-util-from-markdown": "^2.0.3",
         "millify": "^6.1.0",
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.2.4",
         "path-to-regexp": "^6.3.0",
         "picocolors": "^1.1.1",
         "pretty-bytes": "^7.1.0",
         "remark": "^15.0.1",
         "remark-frontmatter": "^5.0.0",
-        "tokenx": "^1.2.1",
+        "tokenx": "^1.3.0",
         "unist-util-remove": "^4.0.0",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/okineadev"

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,9 +10,9 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "mermaid": "^11.13.0",
+    "mermaid": "^11.14.0",
     "vitepress": "^2.0.0-alpha.16",
-    "vitepress-plugin-llms": "^1.11.0",
+    "vitepress-plugin-llms": "^1.12.0",
     "vitepress-plugin-mermaid": "^2.0.17"
   },
   "overrides": {

--- a/src/Foundatio.Parsers.ElasticQueries/AggregationMap.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/AggregationMap.cs
@@ -44,7 +44,7 @@ public class AggregationMap
     public List<AggregationMap> Aggregations { get; } = [];
 
     /// <summary>Metadata key/value pairs attached to this aggregation via the <c>meta</c> field.</summary>
-    public Dictionary<string, object> Meta { get; } = [];
+    public Dictionary<string, object?> Meta { get; } = [];
 
     /// <summary>
     /// Converts the tree into an Elasticsearch aggregation dictionary suitable for
@@ -122,7 +122,7 @@ public class AggregationMap
         {
             aggregation.Meta = map.Meta
                 .Where(kvp => kvp.Value is not null)
-                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
 
             if (aggregation.Meta.Count == 0)
                 aggregation.Meta = null;

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -12,9 +12,9 @@ namespace Foundatio.Parsers.ElasticQueries;
 
 public class ElasticMappingResolver : IDisposable
 {
-    private ITypeMapping _serverMapping;
-    private readonly ITypeMapping _codeMapping;
-    private readonly Inferrer _inferrer;
+    private ITypeMapping? _serverMapping;
+    private readonly ITypeMapping? _codeMapping;
+    private readonly Inferrer? _inferrer;
     private readonly ConcurrentDictionary<string, FieldMapping> _mappingCache = new();
     private readonly object _mappingLock = new();
     private readonly SemaphoreSlim _fetchSemaphore = new(1, 1);
@@ -24,7 +24,7 @@ public class ElasticMappingResolver : IDisposable
 
     public static ElasticMappingResolver NullInstance = new(() => null);
 
-    public ElasticMappingResolver(Func<ITypeMapping> getMapping, Inferrer inferrer = null, TimeProvider timeProvider = null, ILogger logger = null)
+    public ElasticMappingResolver(Func<ITypeMapping?> getMapping, Inferrer? inferrer = null, TimeProvider? timeProvider = null, ILogger? logger = null)
     {
         GetServerMappingFunc = getMapping;
         _inferrer = inferrer;
@@ -32,7 +32,7 @@ public class ElasticMappingResolver : IDisposable
         _logger = logger ?? NullLogger.Instance;
     }
 
-    public ElasticMappingResolver(ITypeMapping codeMapping, Inferrer inferrer, Func<ITypeMapping> getMapping, TimeProvider timeProvider = null, ILogger logger = null)
+    public ElasticMappingResolver(ITypeMapping codeMapping, Inferrer inferrer, Func<ITypeMapping?> getMapping, TimeProvider? timeProvider = null, ILogger? logger = null)
         : this(getMapping, inferrer, timeProvider, logger)
     {
         _codeMapping = codeMapping;
@@ -59,7 +59,7 @@ public class ElasticMappingResolver : IDisposable
         _logger.LogInformation("Mapping refresh triggered.");
     }
 
-    public FieldMapping GetMapping(string field, bool followAlias = false)
+    public FieldMapping? GetMapping(string? field, bool followAlias = false)
     {
         if (String.IsNullOrWhiteSpace(field))
             return null;
@@ -99,7 +99,7 @@ public class ElasticMappingResolver : IDisposable
 
         // Snapshot server mapping under lock so readers see a consistent pair of
         // _serverMapping + _lastMappingUpdateTicks (both are set together in GetServerMapping).
-        ITypeMapping serverMapping;
+        ITypeMapping? serverMapping;
         DateTime? mappingServerTime;
         lock (_mappingLock)
         {
@@ -124,14 +124,14 @@ public class ElasticMappingResolver : IDisposable
         for (int depth = 0; depth < fieldParts.Length; depth++)
         {
             string fieldPart = fieldParts[depth];
-            IProperty fieldMapping = null;
+            IProperty? fieldMapping = null;
             if (currentProperties == null || !currentProperties.TryGetValue(fieldPart, out fieldMapping))
             {
                 // check to see if there is an name match
                 if (currentProperties != null)
                     fieldMapping = currentProperties.Values.FirstOrDefault(m =>
                     {
-                        string propertyName = _inferrer.PropertyName(m?.Name);
+                        string? propertyName = _inferrer?.PropertyName(m?.Name);
                         return propertyName != null && propertyName.Equals(fieldPart, StringComparison.OrdinalIgnoreCase);
                     });
 
@@ -174,9 +174,9 @@ public class ElasticMappingResolver : IDisposable
                 fieldMapping.Name = new PropertyName(clrOrigin.ClrOrigin);
 
             if (depth == 0)
-                resolvedFieldName += _inferrer.PropertyName(fieldMapping.Name);
+                resolvedFieldName += _inferrer!.PropertyName(fieldMapping.Name);
             else
-                resolvedFieldName += "." + _inferrer.PropertyName(fieldMapping.Name);
+                resolvedFieldName += "." + _inferrer!.PropertyName(fieldMapping.Name);
 
             if (depth == fieldParts.Length - 1)
             {
@@ -214,7 +214,7 @@ public class ElasticMappingResolver : IDisposable
         return notFoundMapping;
     }
 
-    public FieldMapping GetMapping(Field field, bool followAlias = false)
+    public FieldMapping? GetMapping(Field field, bool followAlias = false)
     {
         if (_inferrer == null)
             throw new InvalidOperationException("Unable to resolve Field without inferrer");
@@ -222,17 +222,17 @@ public class ElasticMappingResolver : IDisposable
         return GetMapping(_inferrer.Field(field), followAlias);
     }
 
-    public IProperty GetMappingProperty(string field, bool followAlias = false)
+    public IProperty? GetMappingProperty(string? field, bool followAlias = false)
     {
         return GetMapping(field, followAlias)?.Property;
     }
 
-    public IProperty GetMappingProperty(Field field, bool followAlias = false)
+    public IProperty? GetMappingProperty(Field field, bool followAlias = false)
     {
         return GetMapping(field, followAlias)?.Property;
     }
 
-    public string GetResolvedField(string field)
+    public string? GetResolvedField(string? field)
     {
         var result = GetMapping(field, true);
         return result?.FullPath ?? field;
@@ -243,35 +243,35 @@ public class ElasticMappingResolver : IDisposable
         if (_inferrer == null)
             throw new InvalidOperationException("Unable to resolve Field without inferrer");
 
-        return GetResolvedField(_inferrer.Field(field));
+        return GetResolvedField(_inferrer.Field(field))!;
     }
 
-    public string GetSortFieldName(string field)
+    public string? GetSortFieldName(string? field)
     {
         return GetNonAnalyzedFieldName(field, ElasticMapping.SortFieldName);
     }
 
     public string GetSortFieldName(Field field)
     {
-        return GetNonAnalyzedFieldName(GetResolvedField(field), ElasticMapping.SortFieldName);
+        return GetNonAnalyzedFieldName(GetResolvedField(field), ElasticMapping.SortFieldName)!;
     }
 
-    public string GetAggregationsFieldName(string field)
+    public string? GetAggregationsFieldName(string? field)
     {
         return GetNonAnalyzedFieldName(field, ElasticMapping.KeywordFieldName);
     }
 
     public string GetAggregationsFieldName(Field field)
     {
-        return GetNonAnalyzedFieldName(field, ElasticMapping.KeywordFieldName);
+        return GetNonAnalyzedFieldName(field, ElasticMapping.KeywordFieldName)!;
     }
 
-    public string GetNonAnalyzedFieldName(Field field, string preferredSubField = null)
+    public string GetNonAnalyzedFieldName(Field field, string? preferredSubField = null)
     {
-        return GetNonAnalyzedFieldName(GetResolvedField(field), preferredSubField);
+        return GetNonAnalyzedFieldName(GetResolvedField(field), preferredSubField)!;
     }
 
-    public string GetNonAnalyzedFieldName(string field, string preferredSubField = null)
+    public string? GetNonAnalyzedFieldName(string? field, string? preferredSubField = null)
     {
         if (String.IsNullOrEmpty(field))
             return field;
@@ -302,17 +302,17 @@ public class ElasticMappingResolver : IDisposable
         return mapping.FullPath;
     }
 
-    public bool IsPropertyAnalyzed(string field)
+    public bool IsPropertyAnalyzed(string? field)
     {
         // assume default is analyzed
         if (String.IsNullOrEmpty(field))
             return true;
 
         var property = GetMapping(field, true);
-        if (!property.Found)
+        if (property is null || !property.Found)
             return false;
 
-        return IsPropertyAnalyzed(property.Property);
+        return IsPropertyAnalyzed(property.Property!);
     }
 
     public bool IsPropertyAnalyzed(IProperty property)
@@ -323,7 +323,7 @@ public class ElasticMappingResolver : IDisposable
         return false;
     }
 
-    public bool IsNestedPropertyType(string field)
+    public bool IsNestedPropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
@@ -331,7 +331,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is INestedProperty;
     }
 
-    public bool IsGeoPropertyType(string field)
+    public bool IsGeoPropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
@@ -339,7 +339,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is IGeoPointProperty;
     }
 
-    public bool IsNumericPropertyType(string field)
+    public bool IsNumericPropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
@@ -347,7 +347,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is INumberProperty;
     }
 
-    public bool IsBooleanPropertyType(string field)
+    public bool IsBooleanPropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
@@ -355,7 +355,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is IBooleanProperty;
     }
 
-    public bool IsDatePropertyType(string field)
+    public bool IsDatePropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
@@ -363,7 +363,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is IDateProperty;
     }
 
-    public FieldType GetFieldType(string field)
+    public FieldType GetFieldType(string? field)
     {
         if (String.IsNullOrWhiteSpace(field))
             return FieldType.None;
@@ -407,12 +407,12 @@ public class ElasticMappingResolver : IDisposable
         };
     }
 
-    private IProperties MergeProperties(IProperties codeProperties, IProperties serverProperties)
+    private IProperties? MergeProperties(IProperties? codeProperties, IProperties? serverProperties)
     {
         if (codeProperties == null && serverProperties == null)
             return null;
 
-        IProperties mergedCodeProperties = null;
+        IProperties? mergedCodeProperties = null;
         // resolve code mapping property expressions using inferrer
         if (codeProperties != null)
         {
@@ -482,7 +482,7 @@ public class ElasticMappingResolver : IDisposable
         return properties;
     }
 
-    private Func<ITypeMapping> GetServerMappingFunc { get; set; }
+    private Func<ITypeMapping?>? GetServerMappingFunc { get; set; }
     private long _lastMappingUpdateTicks;
 
     private bool IsSnapshotCurrent(long snapshotEpoch, DateTime? snapshotServerTime)
@@ -524,7 +524,7 @@ public class ElasticMappingResolver : IDisposable
                     return false;
             }
 
-            ITypeMapping newMapping;
+            ITypeMapping? newMapping;
             try
             {
                 newMapping = GetServerMappingFunc();
@@ -554,7 +554,7 @@ public class ElasticMappingResolver : IDisposable
         }
     }
 
-    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, IElasticClient client, ILogger logger = null) where T : class
+    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, IElasticClient client, ILogger? logger = null) where T : class
     {
         logger ??= NullLogger.Instance;
 
@@ -569,7 +569,7 @@ public class ElasticMappingResolver : IDisposable
         }, logger);
     }
 
-    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, IElasticClient client, string index, ILogger logger = null) where T : class
+    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, IElasticClient client, string index, ILogger? logger = null) where T : class
     {
         logger ??= NullLogger.Instance;
 
@@ -584,14 +584,14 @@ public class ElasticMappingResolver : IDisposable
         }, logger);
     }
 
-    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, Inferrer inferrer, Func<ITypeMapping> getMapping, ILogger logger = null) where T : class
+    public static ElasticMappingResolver Create<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> mappingBuilder, Inferrer inferrer, Func<ITypeMapping?> getMapping, ILogger? logger = null) where T : class
     {
         var codeMapping = new TypeMappingDescriptor<T>();
         codeMapping = mappingBuilder(codeMapping) as TypeMappingDescriptor<T>;
-        return new ElasticMappingResolver(codeMapping, inferrer, getMapping, logger: logger);
+        return new ElasticMappingResolver(codeMapping!, inferrer, getMapping, logger: logger);
     }
 
-    public static ElasticMappingResolver Create<T>(IElasticClient client, ILogger logger = null)
+    public static ElasticMappingResolver Create<T>(IElasticClient client, ILogger? logger = null)
     {
         logger ??= NullLogger.Instance;
 
@@ -606,7 +606,7 @@ public class ElasticMappingResolver : IDisposable
         }, client.Infer, logger);
     }
 
-    public static ElasticMappingResolver Create(IElasticClient client, string index, ILogger logger = null)
+    public static ElasticMappingResolver Create(IElasticClient client, string index, ILogger? logger = null)
     {
         logger ??= NullLogger.Instance;
 
@@ -621,7 +621,7 @@ public class ElasticMappingResolver : IDisposable
         }, client.Infer, logger);
     }
 
-    public static ElasticMappingResolver Create(Func<ITypeMapping> getMapping, Inferrer inferrer, ILogger logger = null)
+    public static ElasticMappingResolver Create(Func<ITypeMapping?> getMapping, Inferrer? inferrer, ILogger? logger = null)
     {
         return new ElasticMappingResolver(getMapping, inferrer, logger: logger);
     }
@@ -634,7 +634,7 @@ public class ElasticMappingResolver : IDisposable
 
 public class FieldMapping
 {
-    public FieldMapping(string path, IProperty property, DateTime? serverMapTime, long epoch = 0)
+    public FieldMapping(string path, IProperty? property, DateTime? serverMapTime, long epoch = 0)
     {
         FullPath = path;
         Property = property;
@@ -644,7 +644,7 @@ public class FieldMapping
 
     public bool Found => Property != null;
     public string FullPath { get; private set; }
-    public IProperty Property { get; private set; }
+    public IProperty? Property { get; private set; }
     public DateTime Date { get; private set; } = DateTime.UtcNow;
     internal DateTime? ServerMapTime { get; private set; }
     internal long Epoch { get; private set; }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,7 +15,7 @@ namespace Foundatio.Parsers.ElasticQueries;
 
 public class ElasticQueryParser : LuceneQueryParser
 {
-    public ElasticQueryParser(Action<ElasticQueryParserConfiguration> configure = null)
+    public ElasticQueryParser(Action<ElasticQueryParserConfiguration>? configure = null)
     {
         var config = new ElasticQueryParserConfiguration();
         configure?.Invoke(config);
@@ -24,7 +24,7 @@ public class ElasticQueryParser : LuceneQueryParser
 
     public ElasticQueryParserConfiguration Configuration { get; }
 
-    public override async Task<IQueryNode> ParseAsync(string query, IQueryVisitorContext context = null)
+    public override async Task<IQueryNode?> ParseAsync(string query, IQueryVisitorContext? context = null)
     {
         query ??= String.Empty;
         context ??= new ElasticQueryVisitorContext();
@@ -33,6 +33,9 @@ public class ElasticQueryParser : LuceneQueryParser
         try
         {
             var result = await base.ParseAsync(query, context).ConfigureAwait(false);
+            if (result is null)
+                return null;
+
             switch (context.QueryType)
             {
                 case QueryTypes.Aggregation:
@@ -52,7 +55,7 @@ public class ElasticQueryParser : LuceneQueryParser
         {
             var cursor = ex.Data["cursor"] as Cursor;
             context.GetValidationResult().QueryType = context.QueryType;
-            context.AddValidationError(ex.Message, cursor.Column);
+            context.AddValidationError(ex.Message, cursor?.Column ?? 0);
 
             return null;
         }
@@ -66,29 +69,29 @@ public class ElasticQueryParser : LuceneQueryParser
         if (Configuration.RuntimeFieldResolver != null && context.GetRuntimeFieldResolver() == null)
             context.SetRuntimeFieldResolver(Configuration.RuntimeFieldResolver);
 
-        context.SetMappingResolver(Configuration.MappingResolver);
+        context.SetMappingResolver(Configuration.MappingResolver ?? ElasticMappingResolver.NullInstance);
 
         if (!context.Data.ContainsKey("@OriginalContextResolver"))
-            context.SetValue("@OriginalContextResolver", context.GetFieldResolver());
+            context.SetValue("@OriginalContextResolver", context.GetFieldResolver()!);
 
         context.SetFieldResolver(async (field, context) =>
         {
-            string resolvedField = null;
-            if (context.Data.TryGetValue("@OriginalContextResolver", out object data) && data is QueryFieldResolver resolver)
+            string? resolvedField = null;
+            if (context?.Data.TryGetValue("@OriginalContextResolver", out object? data) is true && data is QueryFieldResolver resolver)
             {
-                string contextResolvedField = await resolver(field, context).ConfigureAwait(false);
+                string? contextResolvedField = await resolver(field, context).ConfigureAwait(false);
                 if (contextResolvedField != null)
                     resolvedField = contextResolvedField;
             }
 
             if (Configuration.FieldResolver != null)
             {
-                string configResolvedField = await Configuration.FieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
+                string? configResolvedField = await Configuration.FieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
                 if (configResolvedField != null)
                     resolvedField = configResolvedField;
             }
 
-            string mappingResolvedField = await MappingFieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
+            string? mappingResolvedField = await MappingFieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
             if (mappingResolvedField != null)
                 resolvedField = mappingResolvedField;
 
@@ -100,13 +103,14 @@ public class ElasticQueryParser : LuceneQueryParser
 
         if (context.QueryType == QueryTypes.Query)
         {
-            context.SetDefaultFields(Configuration.DefaultFields);
+            if (Configuration.DefaultFields is not null)
+                context.SetDefaultFields(Configuration.DefaultFields);
             if (Configuration.IncludeResolver != null && context.GetIncludeResolver() == null)
                 context.SetIncludeResolver(Configuration.IncludeResolver);
         }
     }
 
-    private async Task<string> MappingFieldResolver(string field, IQueryVisitorContext context)
+    private async Task<string?> MappingFieldResolver(string? field, IQueryVisitorContext? context)
     {
         if (field == null)
             return null;
@@ -121,7 +125,7 @@ public class ElasticQueryParser : LuceneQueryParser
         if (elasticContext.MappingResolver != null)
         {
             var resolvedField = elasticContext.MappingResolver.GetMapping(field);
-            if (resolvedField.Found)
+            if (resolvedField?.Found is true)
                 return resolvedField.FullPath;
         }
 
@@ -139,7 +143,7 @@ public class ElasticQueryParser : LuceneQueryParser
             var newRuntimeField = await elasticContext.RuntimeFieldResolver(field);
             if (newRuntimeField != null)
             {
-                elasticContext.RuntimeFields.Add(newRuntimeField);
+                elasticContext.RuntimeFields?.Add(newRuntimeField);
                 return newRuntimeField.Name;
             }
         }
@@ -147,18 +151,19 @@ public class ElasticQueryParser : LuceneQueryParser
         return null;
     }
 
-    public async Task<QueryValidationResult> ValidateQueryAsync(string query, QueryValidationOptions options = null, IElasticQueryVisitorContext context = null)
+    public async Task<QueryValidationResult> ValidateQueryAsync(string query, QueryValidationOptions? options = null, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Query;
-        context.SetValidationOptions(options);
+        if (options is not null)
+            context.SetValidationOptions(options);
 
         await ParseAsync(query, context).ConfigureAwait(false);
 
         return context.GetValidationResult();
     }
 
-    public async Task<QueryContainer> BuildQueryAsync(string query, IElasticQueryVisitorContext context = null)
+    public async Task<QueryContainer> BuildQueryAsync(string query, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Query;
@@ -166,10 +171,13 @@ public class ElasticQueryParser : LuceneQueryParser
         var result = await ParseAsync(query, context).ConfigureAwait(false);
         context.ThrowIfInvalid();
 
+        if (result is null)
+            throw new FormatException("Failed to parse query.");
+
         return await BuildQueryAsync(result, context).ConfigureAwait(false);
     }
 
-    public async Task<QueryContainer> BuildQueryAsync(IQueryNode query, IElasticQueryVisitorContext context = null)
+    public async Task<QueryContainer> BuildQueryAsync(IQueryNode query, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         var q = await query.GetQueryAsync() ?? new MatchAllQuery();
@@ -184,18 +192,19 @@ public class ElasticQueryParser : LuceneQueryParser
         return q;
     }
 
-    public async Task<QueryValidationResult> ValidateAggregationsAsync(string query, QueryValidationOptions options = null, IElasticQueryVisitorContext context = null)
+    public async Task<QueryValidationResult> ValidateAggregationsAsync(string query, QueryValidationOptions? options = null, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Aggregation;
-        context.SetValidationOptions(options);
+        if (options is not null)
+            context.SetValidationOptions(options);
 
         await ParseAsync(query, context).ConfigureAwait(false);
 
         return context.GetValidationResult();
     }
 
-    public async Task<AggregationContainer> BuildAggregationsAsync(string aggregations, IElasticQueryVisitorContext context = null)
+    public async Task<AggregationContainer?> BuildAggregationsAsync(string aggregations, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Aggregation;
@@ -206,39 +215,42 @@ public class ElasticQueryParser : LuceneQueryParser
         return await BuildAggregationsAsync(result, context).ConfigureAwait(false);
     }
 
-#pragma warning disable IDE0060 // Remove unused parameter
-    public async Task<AggregationContainer> BuildAggregationsAsync(IQueryNode aggregations, IElasticQueryVisitorContext context = null)
+    public async Task<AggregationContainer?> BuildAggregationsAsync(IQueryNode? aggregations, IElasticQueryVisitorContext? context = null)
     {
         if (aggregations == null)
             return null;
 
-#pragma warning restore IDE0060 // Remove unused parameter
-        return await aggregations?.GetAggregationAsync();
+        return await aggregations.GetAggregationAsync().ConfigureAwait(false);
     }
 
-    public async Task<QueryValidationResult> ValidateSortAsync(string query, QueryValidationOptions options = null, IElasticQueryVisitorContext context = null)
+    public async Task<QueryValidationResult> ValidateSortAsync(string query, QueryValidationOptions? options = null, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Sort;
-        context.SetValidationOptions(options);
+        if (options is not null)
+            context.SetValidationOptions(options);
 
         await ParseAsync(query, context).ConfigureAwait(false);
 
         return context.GetValidationResult();
     }
 
-    public async Task<IEnumerable<IFieldSort>> BuildSortAsync(string sort, IElasticQueryVisitorContext context = null)
+    public async Task<IEnumerable<IFieldSort>> BuildSortAsync(string? sort, IElasticQueryVisitorContext? context = null)
     {
+        sort ??= String.Empty;
         context ??= new ElasticQueryVisitorContext();
         context.QueryType = QueryTypes.Sort;
 
         var result = await ParseAsync(sort, context).ConfigureAwait(false);
         context.ThrowIfInvalid();
 
+        if (result is null)
+            throw new FormatException("Failed to parse sort.");
+
         return await BuildSortAsync(result, context).ConfigureAwait(false);
     }
 
-    public Task<IEnumerable<IFieldSort>> BuildSortAsync(IQueryNode sort, IElasticQueryVisitorContext context = null)
+    public Task<IEnumerable<IFieldSort>> BuildSortAsync(IQueryNode sort, IElasticQueryVisitorContext? context = null)
     {
         context ??= new ElasticQueryVisitorContext();
         return GetSortFieldsVisitor.RunAsync(sort, context);

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -20,7 +20,7 @@ namespace Foundatio.Parsers.ElasticQueries;
 /// <param name="originalField">The field name before alias resolution (from GetOriginalField()).</param>
 /// <param name="resolvedField">The field name after alias resolution (the current node.Field).</param>
 /// <param name="context">The visitor context, providing Data dictionary for arbitrary state.</param>
-public delegate Task<QueryContainer> NestedFilterResolver(
+public delegate Task<QueryContainer?> NestedFilterResolver(
     string nestedPath,
     string originalField,
     string resolvedField,
@@ -38,19 +38,19 @@ public class ElasticQueryParserConfiguration
         AddSortVisitor(new TermToFieldVisitor(), 0);
         AddAggregationVisitor(new AssignOperationTypeVisitor(), 0);
         AddAggregationVisitor(new CombineAggregationsVisitor(), 10000);
-        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver != null ? FieldResolver(field, context) : Task.FromResult<string>(null)), 10);
+        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver is not null ? FieldResolver(field, context) : Task.FromResult<string?>(null)), 10);
         AddVisitor(new ValidationVisitor(), 30);
     }
 
     public ILoggerFactory LoggerFactory { get; private set; } = NullLoggerFactory.Instance;
-    public string[] DefaultFields { get; private set; }
-    public QueryFieldResolver FieldResolver { get; private set; }
-    public IncludeResolver IncludeResolver { get; private set; }
-    public NestedFilterResolver NestedFilterResolver { get; private set; }
-    public RuntimeFieldResolver RuntimeFieldResolver { get; private set; }
+    public string[]? DefaultFields { get; private set; }
+    public QueryFieldResolver? FieldResolver { get; private set; }
+    public IncludeResolver? IncludeResolver { get; private set; }
+    public NestedFilterResolver? NestedFilterResolver { get; private set; }
+    public RuntimeFieldResolver? RuntimeFieldResolver { get; private set; }
     public bool? EnableRuntimeFieldResolver { get; private set; }
-    public ElasticMappingResolver MappingResolver { get; private set; }
-    public QueryValidationOptions ValidationOptions { get; private set; }
+    public ElasticMappingResolver? MappingResolver { get; private set; }
+    public QueryValidationOptions? ValidationOptions { get; private set; }
     public ChainedQueryVisitor SortVisitor { get; } = new ChainedQueryVisitor();
     public ChainedQueryVisitor QueryVisitor { get; } = new ChainedQueryVisitor();
     public ChainedQueryVisitor AggregationVisitor { get; } = new ChainedQueryVisitor();
@@ -58,7 +58,7 @@ public class ElasticQueryParserConfiguration
     public ElasticQueryParserConfiguration SetLoggerFactory(ILoggerFactory loggerFactory)
     {
         LoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
-        _logger = loggerFactory.CreateLogger<ElasticQueryParserConfiguration>();
+        _logger = LoggerFactory.CreateLogger<ElasticQueryParserConfiguration>();
 
         return this;
     }
@@ -69,7 +69,7 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    public ElasticQueryParserConfiguration UseFieldResolver(QueryFieldResolver resolver, int priority = 10)
+    public ElasticQueryParserConfiguration UseFieldResolver(QueryFieldResolver? resolver, int priority = 10)
     {
         FieldResolver = resolver;
         ReplaceVisitor<FieldResolverQueryVisitor>(new FieldResolverQueryVisitor(resolver), priority);
@@ -77,7 +77,7 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    public ElasticQueryParserConfiguration UseFieldMap(IDictionary<string, string> fields, int priority = 10)
+    public ElasticQueryParserConfiguration UseFieldMap(IDictionary<string, string>? fields, int priority = 10)
     {
         if (fields != null)
             return UseFieldResolver(fields.ToHierarchicalFieldResolver(), priority);
@@ -90,12 +90,12 @@ public class ElasticQueryParserConfiguration
         return UseGeo(location => Task.FromResult(resolveGeoLocation(location)), priority);
     }
 
-    public ElasticQueryParserConfiguration UseGeo(Func<string, Task<string>> resolveGeoLocation, int priority = 200)
+    public ElasticQueryParserConfiguration UseGeo(Func<string, Task<string>>? resolveGeoLocation, int priority = 200)
     {
         return AddVisitor(new GeoVisitor(resolveGeoLocation), priority);
     }
 
-    public ElasticQueryParserConfiguration UseIncludes(IncludeResolver includeResolver, ShouldSkipIncludeFunc shouldSkipInclude = null, int priority = 0)
+    public ElasticQueryParserConfiguration UseIncludes(IncludeResolver includeResolver, ShouldSkipIncludeFunc? shouldSkipInclude = null, int priority = 0)
     {
         IncludeResolver = includeResolver;
 
@@ -117,12 +117,12 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    public ElasticQueryParserConfiguration UseIncludes(Func<string, string> resolveInclude, ShouldSkipIncludeFunc shouldSkipInclude = null, int priority = 0)
+    public ElasticQueryParserConfiguration UseIncludes(Func<string, string?> resolveInclude, ShouldSkipIncludeFunc? shouldSkipInclude = null, int priority = 0)
     {
         return UseIncludes(name => Task.FromResult(resolveInclude(name)), shouldSkipInclude, priority);
     }
 
-    public ElasticQueryParserConfiguration UseIncludes(IDictionary<string, string> includes, ShouldSkipIncludeFunc shouldSkipInclude = null, int priority = 0)
+    public ElasticQueryParserConfiguration UseIncludes(IDictionary<string, string> includes, ShouldSkipIncludeFunc? shouldSkipInclude = null, int priority = 0)
     {
         return UseIncludes(name => includes.ContainsKey(name) ? includes[name] : null, shouldSkipInclude, priority);
     }
@@ -141,7 +141,7 @@ public class ElasticQueryParserConfiguration
         return AddVisitor(new NestedVisitor(NestedFilterResolver), priority);
     }
 
-    public ElasticQueryParserConfiguration UseNestedFilter(NestedFilterResolver resolver)
+    public ElasticQueryParserConfiguration UseNestedFilter(NestedFilterResolver? resolver)
     {
         NestedFilterResolver = resolver;
         if (_nestedPriority.HasValue)
@@ -154,10 +154,10 @@ public class ElasticQueryParserConfiguration
     }
 
     public ElasticQueryParserConfiguration UseNestedFilter(
-        Func<string, string, string, IQueryVisitorContext, QueryContainer> resolver)
+        Func<string, string, string, IQueryVisitorContext, QueryContainer?>? resolver)
     {
         if (resolver is null)
-            return UseNestedFilter((NestedFilterResolver)null);
+            return UseNestedFilter((NestedFilterResolver?)null);
 
         return UseNestedFilter((path, orig, resolved, ctx) =>
             Task.FromResult(resolver(path, orig, resolved, ctx)));
@@ -341,7 +341,7 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    public ElasticQueryParserConfiguration UseMappings(Func<ITypeMapping> getMapping, Inferrer inferrer = null)
+    public ElasticQueryParserConfiguration UseMappings(Func<ITypeMapping> getMapping, Inferrer? inferrer = null)
     {
         MappingResolver = ElasticMappingResolver.Create(getMapping, inferrer, logger: _logger);
 

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -287,7 +287,7 @@ public static class DefaultAggregationNodeExtensions
         var start = context.GetDate("StartDate");
         var end = context.GetDate("EndDate");
         bool isValidRange = start.HasValue && start.Value > DateTime.MinValue && end.HasValue && end.Value < DateTime.MaxValue && start.Value <= end.Value;
-        var bounds = isValidRange ? new ExtendedBounds<FieldDateMath> { Min = start!.Value, Max = end!.Value } : null;
+        var bounds = isValidRange ? new ExtendedBounds<FieldDateMath> { Min = start.GetValueOrDefault(), Max = end.GetValueOrDefault() } : null;
 
         var interval = GetInterval(proximity, start, end);
         string? timezone = TryConvertTimeUnitToUtcOffset(boost);
@@ -336,7 +336,8 @@ public static class DefaultAggregationNodeExtensions
         if (String.IsNullOrEmpty(proximity))
             return GetInterval(start, end);
 
-        return proximity.Trim() switch
+        string trimmed = proximity.Trim();
+        return trimmed switch
         {
             "s" or "1s" or "second" => CalendarInterval.Second,
             "m" or "1m" or "minute" => CalendarInterval.Minute,
@@ -346,7 +347,7 @@ public static class DefaultAggregationNodeExtensions
             "M" or "1M" or "month" => CalendarInterval.Month,
             "q" or "1q" or "quarter" => CalendarInterval.Quarter,
             "y" or "1y" or "year" => CalendarInterval.Year,
-            _ => new Union<CalendarInterval, Duration>(proximity!),
+            _ => new Union<CalendarInterval, Duration>(trimmed),
         };
     }
 
@@ -481,14 +482,16 @@ public static class DefaultAggregationNodeExtensions
             {
                 if (topHitsAggregation.Source is null)
                 {
-                    topHitsAggregation.Source = node.GetSourceFilter(() => new SourceFilter())!;
+                    var sourceFilter = node.GetSourceFilter(() => new SourceFilter());
+                    if (sourceFilter is not null)
+                        topHitsAggregation.Source = sourceFilter;
                 }
 
-                topHitsAggregation.Source.Match(
+                topHitsAggregation.Source?.Match(
                     b => { },
                     filter =>
                     {
-                        if (filter is null)
+                        if (filter is null || termNode.UnescapedTerm is not { } term)
                             return;
 
                         switch (termNode.Field)
@@ -496,17 +499,17 @@ public static class DefaultAggregationNodeExtensions
                             case "@exclude":
                                 {
                                     if (filter.Excludes is null)
-                                        filter.Excludes = termNode.UnescapedTerm!;
+                                        filter.Excludes = term;
                                     else
-                                        filter.Excludes!.And(termNode.UnescapedTerm!);
+                                        filter.Excludes.And(term);
                                     break;
                                 }
                             case "@include":
                                 {
                                     if (filter.Includes is null)
-                                        filter.Includes = termNode.UnescapedTerm!;
+                                        filter.Includes = term;
                                     else
-                                        filter.Includes!.And(termNode.UnescapedTerm!);
+                                        filter.Includes.And(term);
                                     break;
                                 }
                         }
@@ -540,7 +543,8 @@ public static class DefaultAggregationNodeExtensions
                         break;
                     }
                 case "@offset":
-                    dateHistogramAggregation.Offset = termNode.IsExcluded() ? "-" + termNode.Term : termNode.Term!;
+                    if (termNode.Term is { } offset)
+                        dateHistogramAggregation.Offset = termNode.IsExcluded() ? "-" + offset : offset;
                     break;
             }
 

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Exceptionless.DateTimeExtensions;
@@ -16,9 +16,9 @@ public static class DefaultAggregationNodeExtensions
     // NOTE: We may want to read this dynamically from server settings.
     public const int MAX_BUCKET_SIZE = 10000;
 
-    public static async Task<AggregationBase> GetDefaultAggregationAsync(this IQueryNode node, IQueryVisitorContext context)
+    public static async Task<AggregationBase?> GetDefaultAggregationAsync(this IQueryNode node, IQueryVisitorContext context)
     {
-        AggregationBase aggregation = null;
+        AggregationBase? aggregation = null;
         if (node is GroupNode groupNode)
             aggregation = await groupNode.GetDefaultAggregationAsync(context);
 
@@ -46,7 +46,7 @@ public static class DefaultAggregationNodeExtensions
         return aggregation;
     }
 
-    public static async Task<AggregationBase> GetDefaultAggregationAsync(this GroupNode node, IQueryVisitorContext context)
+    public static async Task<AggregationBase?> GetDefaultAggregationAsync(this GroupNode node, IQueryVisitorContext context)
     {
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
@@ -54,9 +54,12 @@ public static class DefaultAggregationNodeExtensions
         if (!node.HasParens || String.IsNullOrEmpty(node.Field) || node.Left != null)
             return null;
 
-        string field = elasticContext.MappingResolver.GetAggregationsFieldName(node.UnescapedField);
+        string? field = elasticContext.MappingResolver.GetAggregationsFieldName(node.UnescapedField);
+        if (field is null)
+            return null;
+
         var property = elasticContext.MappingResolver.GetMappingProperty(field, true);
-        string originalField = node.GetOriginalField().Unescape();
+        string? originalField = node.GetOriginalField().Unescape();
 
         switch (node.GetOperationType())
         {
@@ -75,10 +78,10 @@ public static class DefaultAggregationNodeExtensions
                 {
                     Field = field,
                     Precision = precision,
-                    Aggregations = new AverageAggregation("avg_lat", null)
+                    Aggregations = new AverageAggregation("avg_lat", null!)
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lat")
-                    } && new AverageAggregation("avg_lon", null)
+                    } && new AverageAggregation("avg_lon", null!)
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lon")
                     }
@@ -90,11 +93,11 @@ public static class DefaultAggregationNodeExtensions
                     Field = field,
                     Size = node.GetProximityAsInt32(),
                     MinimumDocumentCount = node.GetBoostAsInt32(),
-                    Meta = new Dictionary<string, object> { { "@field_type", property?.Type } }
+                    Meta = BuildFieldTypeMeta(property?.Type)
                 };
 
                 if (agg.Size.HasValue && (agg.Size * 1.5 + 10) > MAX_BUCKET_SIZE)
-                    agg.ShardSize = Math.Max((int)agg.Size, MAX_BUCKET_SIZE);
+                    agg.ShardSize = Math.Max(agg.Size.Value, MAX_BUCKET_SIZE);
 
                 return agg;
 
@@ -105,35 +108,38 @@ public static class DefaultAggregationNodeExtensions
         return null;
     }
 
-    public static async Task<AggregationBase> GetDefaultAggregationAsync(this TermNode node, IQueryVisitorContext context)
+    public static async Task<AggregationBase?> GetDefaultAggregationAsync(this TermNode node, IQueryVisitorContext context)
     {
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        string aggField = elasticContext.MappingResolver.GetAggregationsFieldName(node.UnescapedField);
+        string? aggField = elasticContext.MappingResolver.GetAggregationsFieldName(node.UnescapedField);
+        if (aggField is null)
+            return null;
+
         var property = elasticContext.MappingResolver.GetMappingProperty(node.UnescapedField, true);
-        string timezone = !String.IsNullOrWhiteSpace(node.UnescapedBoost) ? node.UnescapedBoost : node.GetTimeZone(await elasticContext.GetTimeZoneAsync());
-        string originalField = node.GetOriginalField().Unescape();
+        string? timezone = !String.IsNullOrWhiteSpace(node.UnescapedBoost) ? node.UnescapedBoost : node.GetTimeZone(await elasticContext.GetTimeZoneAsync());
+        string? originalField = node.GetOriginalField().Unescape();
 
         switch (node.GetOperationType())
         {
             case AggregationType.Min:
-                return new MinAggregation("min_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type }, { "@timezone", timezone } } };
+                return new MinAggregation("min_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type, timezone) };
 
             case AggregationType.Max:
-                return new MaxAggregation("max_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type }, { "@timezone", timezone } } };
+                return new MaxAggregation("max_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type, timezone) };
 
             case AggregationType.Avg:
-                return new AverageAggregation("avg_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type } } };
+                return new AverageAggregation("avg_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type) };
 
             case AggregationType.Sum:
-                return new SumAggregation("sum_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type } } };
+                return new SumAggregation("sum_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type) };
 
             case AggregationType.Stats:
-                return new StatsAggregation("stats_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type } } };
+                return new StatsAggregation("stats_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type) };
 
             case AggregationType.ExtendedStats:
-                return new ExtendedStatsAggregation("exstats_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = new Dictionary<string, object> { { "@field_type", property?.Type } } };
+                return new ExtendedStatsAggregation("exstats_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), Meta = BuildFieldTypeMeta(property?.Type) };
 
             case AggregationType.Cardinality:
                 return new CardinalityAggregation("cardinality_" + originalField, aggField) { Missing = node.GetProximityAsDouble(), PrecisionThreshold = node.GetBoostAsInt32() };
@@ -162,10 +168,10 @@ public static class DefaultAggregationNodeExtensions
                 {
                     Field = aggField,
                     Precision = precision,
-                    Aggregations = new AverageAggregation("avg_lat", null)
+                    Aggregations = new AverageAggregation("avg_lat", null!)
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lat")
-                    } && new AverageAggregation("avg_lon", null)
+                    } && new AverageAggregation("avg_lon", null!)
                     {
                         Script = new InlineScript($"doc['{node.Field}'].lon")
                     }
@@ -177,11 +183,11 @@ public static class DefaultAggregationNodeExtensions
                     Field = aggField,
                     Size = node.GetProximityAsInt32(),
                     MinimumDocumentCount = node.GetBoostAsInt32(),
-                    Meta = new Dictionary<string, object> { { "@field_type", property?.Type } }
+                    Meta = BuildFieldTypeMeta(property?.Type)
                 };
 
                 if (agg.Size.HasValue && (agg.Size * 1.5 + 10) > MAX_BUCKET_SIZE)
-                    agg.ShardSize = Math.Max((int)agg.Size, MAX_BUCKET_SIZE);
+                    agg.ShardSize = Math.Max(agg.Size.Value, MAX_BUCKET_SIZE);
 
                 return agg;
         }
@@ -189,9 +195,20 @@ public static class DefaultAggregationNodeExtensions
         return null;
     }
 
-    private static AggregationBase GetPercentilesAggregation(string originalField, string field, string proximity, string boost, IQueryVisitorContext context)
+    private static Dictionary<string, object> BuildFieldTypeMeta(string? fieldType, string? timezone = null)
     {
-        List<double> percents = null;
+        var meta = new Dictionary<string, object>();
+        if (fieldType is not null)
+            meta["@field_type"] = fieldType;
+        if (timezone is not null)
+            meta["@timezone"] = timezone;
+
+        return meta;
+    }
+
+    private static AggregationBase GetPercentilesAggregation(string originalField, string field, string? proximity, string? boost, IQueryVisitorContext context)
+    {
+        List<double>? percents = null;
         if (!String.IsNullOrWhiteSpace(proximity))
         {
             string[] percentStrings = proximity.Split(',');
@@ -209,7 +226,7 @@ public static class DefaultAggregationNodeExtensions
         };
     }
 
-    private static AggregationBase GetHistogramAggregation(string originalField, string field, string proximity, string boost, IQueryVisitorContext context)
+    private static AggregationBase GetHistogramAggregation(string originalField, string field, string? proximity, string? boost, IQueryVisitorContext context)
     {
         double interval = 50;
         if (Double.TryParse(proximity, out double prox))
@@ -223,16 +240,16 @@ public static class DefaultAggregationNodeExtensions
         };
     }
 
-    private static AggregationBase GetDateHistogramAggregation(string originalField, string field, string proximity, string boost, IQueryVisitorContext context)
+    private static AggregationBase GetDateHistogramAggregation(string originalField, string field, string? proximity, string? boost, IQueryVisitorContext context)
     {
         // NOTE: StartDate and EndDate are set in the Repositories QueryBuilderContext.
         var start = context.GetDate("StartDate");
         var end = context.GetDate("EndDate");
         bool isValidRange = start.HasValue && start.Value > DateTime.MinValue && end.HasValue && end.Value < DateTime.MaxValue && start.Value <= end.Value;
-        var bounds = isValidRange ? new ExtendedBounds<DateMath> { Minimum = start.Value, Maximum = end.Value } : null;
+        var bounds = isValidRange ? new ExtendedBounds<DateMath> { Minimum = start!.Value, Maximum = end!.Value } : null;
 
         var interval = GetInterval(proximity, start, end);
-        string timezone = TryConvertTimeUnitToUtcOffset(boost);
+        string? timezone = TryConvertTimeUnitToUtcOffset(boost);
         var agg = new DateHistogramAggregation(originalField)
         {
             Field = field,
@@ -247,7 +264,7 @@ public static class DefaultAggregationNodeExtensions
         return agg;
     }
 
-    private static string TryConvertTimeUnitToUtcOffset(string boost)
+    private static string? TryConvertTimeUnitToUtcOffset(string? boost)
     {
         if (String.IsNullOrEmpty(boost))
             return null;
@@ -267,7 +284,7 @@ public static class DefaultAggregationNodeExtensions
         return "+" + timezoneOffset.Value.ToString("hh\\:mm");
     }
 
-    private static Union<DateInterval, Time> GetInterval(string proximity, DateTime? start, DateTime? end)
+    private static Union<DateInterval, Time> GetInterval(string? proximity, DateTime? start, DateTime? end)
     {
         if (String.IsNullOrEmpty(proximity))
             return GetInterval(start, end);
@@ -364,6 +381,9 @@ public static class DefaultAggregationNodeExtensions
             switch (termNode?.Field)
             {
                 case "@exclude":
+                    if (termNode.UnescapedTerm is null)
+                        break;
+
                     if (termNode.IsRegexTerm)
                     {
                         termsAggregation.Exclude = new TermsExclude(termNode.UnescapedTerm);
@@ -374,6 +394,9 @@ public static class DefaultAggregationNodeExtensions
                     }
                     break;
                 case "@include":
+                    if (termNode.UnescapedTerm is null)
+                        break;
+
                     if (termNode.IsRegexTerm)
                     {
                         termsAggregation.Include = new TermsInclude(termNode.UnescapedTerm);

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -437,7 +437,7 @@ public static class DefaultAggregationNodeExtensions
                     }
                     else
                     {
-                        termsAggregation.Exclude = termsAggregation.Exclude!.AddValue(termNode.UnescapedTerm);
+                        termsAggregation.Exclude = (termsAggregation.Exclude ?? new TermsExclude([])).AddValue(termNode.UnescapedTerm);
                     }
                     break;
                 case "@include":
@@ -450,7 +450,7 @@ public static class DefaultAggregationNodeExtensions
                     }
                     else
                     {
-                        termsAggregation.Include = termsAggregation.Include!.AddValue(termNode.UnescapedTerm);
+                        termsAggregation.Include = (termsAggregation.Include ?? new TermsInclude([])).AddValue(termNode.UnescapedTerm);
                     }
                     break;
                 case "@missing":

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -107,7 +107,7 @@ public static class DefaultAggregationNodeExtensions
 
                 return new AggregationMap($"terms_{originalField}", termsAggregation)
                 {
-                    Meta = { { "@field_type", property?.Type! } }
+                    Meta = { { "@field_type", property?.Type } }
                 };
 
             case AggregationType.TopHits:
@@ -146,37 +146,37 @@ public static class DefaultAggregationNodeExtensions
             case AggregationType.Min:
                 return new AggregationMap($"min_{originalField}", new MinAggregation { Field = aggField, Missing = node.GetProximityAsDouble() })
                 {
-                    Meta = { { "@field_type", property?.Type! }, { "@timezone", timezone! } }
+                    Meta = { { "@field_type", property?.Type }, { "@timezone", timezone } }
                 };
 
             case AggregationType.Max:
                 return new AggregationMap($"max_{originalField}", new MaxAggregation { Field = aggField, Missing = node.GetProximityAsDouble() })
                 {
-                    Meta = { { "@field_type", property?.Type! }, { "@timezone", timezone! } }
+                    Meta = { { "@field_type", property?.Type }, { "@timezone", timezone } }
                 };
 
             case AggregationType.Avg:
                 return new AggregationMap($"avg_{originalField}", new AverageAggregation { Field = aggField, Missing = node.GetProximityAsDouble() })
                 {
-                    Meta = { { "@field_type", property?.Type! } }
+                    Meta = { { "@field_type", property?.Type } }
                 };
 
             case AggregationType.Sum:
                 return new AggregationMap($"sum_{originalField}", new SumAggregation { Field = aggField, Missing = node.GetProximityAsDouble() })
                 {
-                    Meta = { { "@field_type", property?.Type! } }
+                    Meta = { { "@field_type", property?.Type } }
                 };
 
             case AggregationType.Stats:
                 return new AggregationMap($"stats_{originalField}", new StatsAggregation { Field = aggField, Missing = node.GetProximityAsDouble() })
                 {
-                    Meta = { { "@field_type", property?.Type! } }
+                    Meta = { { "@field_type", property?.Type } }
                 };
 
             case AggregationType.ExtendedStats:
                 return new AggregationMap($"exstats_{originalField}", new ExtendedStatsAggregation { Field = aggField, Missing = node.GetProximityAsDouble() })
                 {
-                    Meta = { { "@field_type", property?.Type! } }
+                    Meta = { { "@field_type", property?.Type } }
                 };
 
             case AggregationType.Cardinality:
@@ -239,7 +239,7 @@ public static class DefaultAggregationNodeExtensions
 
                 return new AggregationMap($"terms_{originalField}", termsAggregation)
                 {
-                    Meta = { { "@field_type", property?.Type! } }
+                    Meta = { { "@field_type", property?.Type } }
                 };
         }
 

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -119,7 +119,10 @@ public static class DefaultQueryNodeExtensions
         // Handle null or empty fields - use default multi_match behavior
         if (fields is null or { Length: 0 })
         {
-            var defaultQuery = new MultiMatchQuery(node.UnescapedTerm!);
+            if (node.UnescapedTerm is null)
+                return null;
+
+            var defaultQuery = new MultiMatchQuery(node.UnescapedTerm);
             if (node.IsQuotedTerm)
                 defaultQuery.Type = TextQueryType.Phrase;
             return defaultQuery;

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -332,18 +332,24 @@ public static class DefaultQueryNodeExtensions
         }
     }
 
-    public static Query GetDefaultQuery(this ExistsNode node, IQueryVisitorContext context)
+    public static Query? GetDefaultQuery(this ExistsNode node, IQueryVisitorContext context)
     {
-        return new ExistsQuery(node.UnescapedField!);
+        if (node.UnescapedField is not { } field)
+            return null;
+
+        return new ExistsQuery(field);
     }
 
-    public static Query GetDefaultQuery(this MissingNode node, IQueryVisitorContext context)
+    public static Query? GetDefaultQuery(this MissingNode node, IQueryVisitorContext context)
     {
+        if (node.UnescapedField is not { } field)
+            return null;
+
         return new BoolQuery
         {
             MustNot =
             [
-                new ExistsQuery(node.UnescapedField!)
+                new ExistsQuery(field)
             ]
         };
     }

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -71,10 +71,13 @@ public static class DefaultQueryNodeExtensions
     {
         if (context.MappingResolver.IsPropertyAnalyzed(field))
         {
+            if (node.UnescapedTerm is not { } term)
+                return null;
+
             // MatchQuery treats '*' as literal; use QueryStringQuery for wildcard support on analyzed fields
-            if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") is true)
+            if (!node.IsQuotedTerm && term.EndsWith("*"))
             {
-                return new QueryStringQuery(node.UnescapedTerm)
+                return new QueryStringQuery(term)
                 {
                     Fields = new[] { field },
                     AllowLeadingWildcard = false,
@@ -83,9 +86,9 @@ public static class DefaultQueryNodeExtensions
             }
 
             if (node.IsQuotedTerm)
-                return new MatchPhraseQuery(field, node.UnescapedTerm!);
+                return new MatchPhraseQuery(field, term);
 
-            return new MatchQuery(field, node.UnescapedTerm!);
+            return new MatchQuery(field, term);
         }
 
         if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") is true)
@@ -149,7 +152,9 @@ public static class DefaultQueryNodeExtensions
         // multi_match doesn't work well across analyzed + non-analyzed field types,
         // so split into separate queries and combine with bool should.
         var queries = new List<Query>();
-        queries.Add(GetAnalyzedFieldsQuery(node, analyzedFields.ToArray()));
+        var analyzedQuery = GetAnalyzedFieldsQuery(node, analyzedFields.ToArray());
+        if (analyzedQuery is not null)
+            queries.Add(analyzedQuery);
 
         foreach (string field in nonAnalyzedFields)
         {
@@ -161,11 +166,14 @@ public static class DefaultQueryNodeExtensions
         return new BoolQuery { Should = queries };
     }
 
-    private static Query GetAnalyzedFieldsQuery(TermNode node, string[] fields)
+    private static Query? GetAnalyzedFieldsQuery(TermNode node, string[] fields)
     {
-        if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") is true)
+        if (node.UnescapedTerm is not { } term)
+            return null;
+
+        if (!node.IsQuotedTerm && term.EndsWith("*"))
         {
-            return new QueryStringQuery(node.UnescapedTerm)
+            return new QueryStringQuery(term)
             {
                 Fields = fields,
                 AllowLeadingWildcard = false,
@@ -176,12 +184,12 @@ public static class DefaultQueryNodeExtensions
         if (fields.Length == 1)
         {
             if (node.IsQuotedTerm)
-                return new MatchPhraseQuery(fields[0], node.UnescapedTerm!);
+                return new MatchPhraseQuery(fields[0], term);
 
-            return new MatchQuery(fields[0], node.UnescapedTerm!);
+            return new MatchQuery(fields[0], term);
         }
 
-        var query = new MultiMatchQuery(node.UnescapedTerm!);
+        var query = new MultiMatchQuery(term);
         query.Fields = fields;
         if (node.IsQuotedTerm)
             query.Type = TextQueryType.Phrase;
@@ -271,15 +279,18 @@ public static class DefaultQueryNodeExtensions
         return new BoolQuery { Should = queryList };
     }
 
-    public static async Task<Query> GetDefaultQueryAsync(this TermRangeNode node, IQueryVisitorContext context)
+    public static async Task<Query?> GetDefaultQueryAsync(this TermRangeNode node, IQueryVisitorContext context)
     {
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
         string? field = node.UnescapedField;
+        if (String.IsNullOrEmpty(field))
+            return null;
+
         if (elasticContext.MappingResolver.IsDatePropertyType(field))
         {
-            var range = new DateRangeQuery(field!) { TimeZone = node.Boost ?? node.GetTimeZone(await elasticContext.GetTimeZoneAsync().AnyContext()) };
+            var range = new DateRangeQuery(field) { TimeZone = node.Boost ?? node.GetTimeZone(await elasticContext.GetTimeZoneAsync().AnyContext()) };
             if (!String.IsNullOrWhiteSpace(node.UnescapedMin) && node.UnescapedMin != "*")
             {
                 if (node.MinInclusive.HasValue && !node.MinInclusive.Value)
@@ -300,7 +311,7 @@ public static class DefaultQueryNodeExtensions
         }
         else
         {
-            var range = new TermRangeQuery(field!);
+            var range = new TermRangeQuery(field);
             if (!String.IsNullOrWhiteSpace(node.UnescapedMin) && node.UnescapedMin != "*")
             {
                 if (node.MinInclusive.HasValue && !node.MinInclusive.Value)

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -13,13 +13,13 @@ namespace Foundatio.Parsers.ElasticQueries.Extensions;
 
 public static class DefaultQueryNodeExtensions
 {
-    public static async Task<QueryBase> GetDefaultQueryAsync(this IQueryNode node, IQueryVisitorContext context)
+    public static async Task<QueryBase?> GetDefaultQueryAsync(this IQueryNode node, IQueryVisitorContext context)
     {
         if (node is TermNode termNode)
             return termNode.GetDefaultQuery(context);
 
         if (node is TermRangeNode termRangeNode)
-            return await termRangeNode.GetDefaultQueryAsync(context);
+            return await termRangeNode.GetDefaultQueryAsync(context).ConfigureAwait(false);
 
         if (node is ExistsNode existsNode)
             return existsNode.GetDefaultQuery(context);
@@ -30,13 +30,13 @@ public static class DefaultQueryNodeExtensions
         return null;
     }
 
-    public static QueryBase GetDefaultQuery(this TermNode node, IQueryVisitorContext context)
+    public static QueryBase? GetDefaultQuery(this TermNode node, IQueryVisitorContext context)
     {
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        string field = node.UnescapedField;
-        string[] defaultFields = node.GetDefaultFields(elasticContext.DefaultFields);
+        string? field = node.UnescapedField;
+        string[]? defaultFields = node.GetDefaultFields(elasticContext.DefaultFields);
 
         // If a specific field is set, use single-field query
         if (!String.IsNullOrEmpty(field))
@@ -65,12 +65,12 @@ public static class DefaultQueryNodeExtensions
         return GetMultiFieldQuery(node, defaultFields, elasticContext);
     }
 
-    private static QueryBase GetSingleFieldQuery(TermNode node, string field, IElasticQueryVisitorContext context)
+    private static QueryBase? GetSingleFieldQuery(TermNode node, string field, IElasticQueryVisitorContext context)
     {
         if (context.MappingResolver.IsPropertyAnalyzed(field))
         {
             // MatchQuery treats '*' as literal; PrefixQuery only works on non-analyzed fields.
-            if (!node.IsQuotedTerm && node.UnescapedTerm.EndsWith("*"))
+            if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") is true)
             {
                 return new QueryStringQuery
                 {
@@ -97,7 +97,7 @@ public static class DefaultQueryNodeExtensions
             };
         }
 
-        if (!node.IsQuotedTerm && node.UnescapedTerm.EndsWith("*"))
+        if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") is true)
         {
             return new PrefixQuery
             {
@@ -105,6 +105,9 @@ public static class DefaultQueryNodeExtensions
                 Value = node.UnescapedTerm.TrimEnd('*')
             };
         }
+
+        if (node.UnescapedTerm is null)
+            return null;
 
         // For non-analyzed fields, try to convert value to appropriate type
         object termValue = GetTypedValue(node.UnescapedTerm, field, context);
@@ -131,7 +134,7 @@ public static class DefaultQueryNodeExtensions
         };
     }
 
-    private static QueryBase GetMultiFieldQuery(TermNode node, string[] fields, IElasticQueryVisitorContext context)
+    private static QueryBase? GetMultiFieldQuery(TermNode node, string[]? fields, IElasticQueryVisitorContext context)
     {
         // Handle null or empty fields - use default multi_match behavior
         if (fields is null or { Length: 0 })
@@ -179,7 +182,9 @@ public static class DefaultQueryNodeExtensions
         // Add individual queries for non-analyzed fields
         foreach (string field in nonAnalyzedFields)
         {
-            queries.Add(GetSingleFieldQuery(node, field, context));
+            var query = GetSingleFieldQuery(node, field, context);
+            if (query is not null)
+                queries.Add(query);
         }
 
         return new BoolQuery
@@ -190,7 +195,7 @@ public static class DefaultQueryNodeExtensions
 
     private static QueryBase GetAnalyzedFieldsQuery(TermNode node, string[] fields)
     {
-        if (!node.IsQuotedTerm && node.UnescapedTerm.EndsWith("*"))
+        if (!node.IsQuotedTerm && node.UnescapedTerm?.EndsWith("*") is true)
         {
             return new QueryStringQuery
             {
@@ -220,14 +225,14 @@ public static class DefaultQueryNodeExtensions
         return query;
     }
 
-    private static QueryBase GetNonAnalyzedFieldsQuery(TermNode node, List<string> fields, IElasticQueryVisitorContext context)
+    private static QueryBase? GetNonAnalyzedFieldsQuery(TermNode node, List<string> fields, IElasticQueryVisitorContext context)
     {
         // For a single non-analyzed field, use single query
         if (fields.Count == 1)
             return GetSingleFieldQuery(node, fields[0], context);
 
         // Multiple non-analyzed fields - combine with bool should
-        var queries = fields.Select(f => GetSingleFieldQuery(node, f, context)).ToList();
+        var queries = fields.Select(f => GetSingleFieldQuery(node, f, context)).Where(q => q is not null).ToList();
         return new BoolQuery
         {
             Should = queries.Select(q => (QueryContainer)q).ToList()
@@ -252,9 +257,9 @@ public static class DefaultQueryNodeExtensions
         return result;
     }
 
-    private static string GetNestedPath(string fullName, IElasticQueryVisitorContext context)
+    private static string? GetNestedPath(string fullName, IElasticQueryVisitorContext context)
     {
-        string[] nameParts = fullName?.Split('.');
+        string[]? nameParts = fullName?.Split('.');
 
         if (nameParts is null or { Length: 0 })
             return null;
@@ -281,9 +286,12 @@ public static class DefaultQueryNodeExtensions
 
         foreach (var (nestedPath, fields) in fieldsByNestedPath)
         {
-            QueryBase query = fields.Count == 1
+            QueryBase? query = fields.Count == 1
                 ? GetSingleFieldQuery(node, fields[0], context)
                 : GetMultiFieldQuery(node, fields.ToArray(), context);
+
+            if (query is null)
+                continue;
 
             if (!String.IsNullOrEmpty(nestedPath))
             {
@@ -313,10 +321,10 @@ public static class DefaultQueryNodeExtensions
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        string field = node.UnescapedField;
+        string? field = node.UnescapedField;
         if (elasticContext.MappingResolver.IsDatePropertyType(field))
         {
-            var range = new DateRangeQuery { Field = field, TimeZone = node.Boost ?? node.GetTimeZone(await elasticContext.GetTimeZoneAsync()) };
+            var range = new DateRangeQuery { Field = field, TimeZone = node.Boost ?? node.GetTimeZone(await elasticContext.GetTimeZoneAsync().ConfigureAwait(false)) };
             if (!String.IsNullOrWhiteSpace(node.UnescapedMin) && node.UnescapedMin != "*")
             {
                 if (node.MinInclusive.HasValue && !node.MinInclusive.Value)

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
@@ -14,7 +14,7 @@ public static class DefaultSortNodeExtensions
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        string field = elasticContext.MappingResolver.GetSortFieldName(node.UnescapedField);
+        string? field = elasticContext.MappingResolver.GetSortFieldName(node.UnescapedField);
         var fieldType = elasticContext.MappingResolver.GetFieldType(field);
 
         var sort = new FieldSort
@@ -24,7 +24,7 @@ public static class DefaultSortNodeExtensions
             Order = node.IsNodeOrGroupNegated() ? SortOrder.Descending : SortOrder.Ascending
         };
 
-        string nestedPath = node.GetNestedPath();
+        string? nestedPath = node.GetNestedPath();
         if (nestedPath is not null)
         {
             var nestedSort = new NestedSort { Path = nestedPath };

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/ElasticExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/ElasticExtensions.cs
@@ -37,7 +37,7 @@ public static class ElasticExtensions
     }
 
     // TODO: Handle IFailureReason/BulkIndexByScrollFailure and other bulk response types.
-    public static string GetErrorMessage(this IElasticsearchResponse elasticResponse, string message = null, bool normalize = false, bool includeResponse = false, bool includeDebugInformation = false)
+    public static string GetErrorMessage(this IElasticsearchResponse elasticResponse, string? message = null, bool normalize = false, bool includeResponse = false, bool includeDebugInformation = false)
     {
         if (elasticResponse == null)
             return String.Empty;
@@ -55,7 +55,7 @@ public static class ElasticExtensions
             sb.AppendLine($"Original: [{response.OriginalException.GetType().Name}] {response.OriginalException.Message}");
 
         if (response?.ServerError?.Error != null)
-            sb.AppendLine($"Server Error (Index={response.ServerError.Error?.Index}): {response.ServerError.Error.Reason}");
+            sb.AppendLine($"Server Error (Index={response.ServerError.Error.Index}): {response.ServerError.Error.Reason}");
 
         if (elasticResponse is BulkResponse bulkResponse)
             sb.AppendLine($"Bulk: {String.Join("\r\n", bulkResponse.ItemsWithErrors.Select(i => i.Error))}");
@@ -65,16 +65,16 @@ public static class ElasticExtensions
 
         if (elasticResponse.ApiCall?.RequestBodyInBytes != null)
         {
-            string body = Encoding.UTF8.GetString(elasticResponse.ApiCall?.RequestBodyInBytes);
+            string body = Encoding.UTF8.GetString(elasticResponse.ApiCall.RequestBodyInBytes);
             if (normalize)
                 body = JsonUtility.Normalize(body);
             sb.AppendLine(body);
         }
 
-        var apiCall = response.ApiCall;
-        if (includeResponse && apiCall.ResponseBodyInBytes != null && apiCall.ResponseBodyInBytes.Length > 0 && apiCall.ResponseBodyInBytes.Length < 20000)
+        var apiCall = response?.ApiCall;
+        if (includeResponse && apiCall?.ResponseBodyInBytes is not null && apiCall.ResponseBodyInBytes.Length > 0 && apiCall.ResponseBodyInBytes.Length < 20000)
         {
-            string body = Encoding.UTF8.GetString(apiCall?.ResponseBodyInBytes);
+            string body = Encoding.UTF8.GetString(apiCall.ResponseBodyInBytes);
             if (normalize)
                 body = JsonUtility.Normalize(body);
 
@@ -93,7 +93,7 @@ public static class ElasticExtensions
         return GetErrorMessage(elasticResponse, null, normalize, includeResponse, includeDebugInformation);
     }
 
-    public static async Task<bool> WaitForReadyAsync(this IElasticClient client, CancellationToken cancellationToken, ILogger logger = null)
+    public static async Task<bool> WaitForReadyAsync(this IElasticClient client, CancellationToken cancellationToken, ILogger? logger = null)
     {
         var nodes = client.ConnectionSettings.ConnectionPool.Nodes.Select(n => n.Uri.ToString());
         var startTime = DateTime.UtcNow;
@@ -116,7 +116,7 @@ public static class ElasticExtensions
         return false;
     }
 
-    public static bool WaitForReady(this IElasticClient client, CancellationToken cancellationToken, ILogger logger = null)
+    public static bool WaitForReady(this IElasticClient client, CancellationToken cancellationToken, ILogger? logger = null)
     {
         var nodes = client.ConnectionSettings.ConnectionPool.Nodes.Select(n => n.Uri.ToString());
         var startTime = DateTime.UtcNow;

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/ElasticMappingExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/ElasticMappingExtensions.cs
@@ -13,7 +13,7 @@ public static class ElasticMapping
     /// <summary>
     /// Not chainable with AddSortField. Use AddKeywordAndSortFields to add both.
     /// </summary>
-    public static TextPropertyDescriptor<T> AddKeywordField<T>(this TextPropertyDescriptor<T> descriptor, string normalizer) where T : class
+    public static TextPropertyDescriptor<T> AddKeywordField<T>(this TextPropertyDescriptor<T> descriptor, string? normalizer) where T : class
     {
         return descriptor.Fields(f => f.Keyword(s => s.Name(KeywordFieldName).Normalizer(normalizer).IgnoreAbove(256)));
     }
@@ -34,7 +34,7 @@ public static class ElasticMapping
         return descriptor.Fields(f => f.Keyword(s => s.Name(SortFieldName).Normalizer(normalizer).IgnoreAbove(256)));
     }
 
-    public static TextPropertyDescriptor<T> AddKeywordAndSortFields<T>(this TextPropertyDescriptor<T> descriptor, string sortNormalizer = "sort", string keywordNormalizer = null) where T : class
+    public static TextPropertyDescriptor<T> AddKeywordAndSortFields<T>(this TextPropertyDescriptor<T> descriptor, string sortNormalizer = "sort", string? keywordNormalizer = null) where T : class
     {
         return descriptor.Fields(f => f
             .Keyword(s => s.Name(KeywordFieldName).Normalizer(keywordNormalizer).IgnoreAbove(256))

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryNodeExtensions.cs
@@ -8,22 +8,25 @@ namespace Foundatio.Parsers.ElasticQueries.Extensions;
 public static class QueryNodeExtensions
 {
     private const string QueryKey = "@Query";
-    public static Task<QueryBase> GetQueryAsync(this IQueryNode node, Func<Task<QueryBase>> getDefaultValue = null)
+    public static Task<QueryBase?> GetQueryAsync(this IQueryNode node, Func<Task<QueryBase?>>? getDefaultValue = null)
     {
-        if (!node.Data.TryGetValue(QueryKey, out object value))
+        if (!node.Data.TryGetValue(QueryKey, out object? value))
         {
             if (getDefaultValue == null)
-                return Task.FromResult<QueryBase>(null);
+                return Task.FromResult<QueryBase?>(null);
 
-            return getDefaultValue?.Invoke();
+            return getDefaultValue.Invoke();
         }
 
         return Task.FromResult(value as QueryBase);
     }
 
-    public static void SetQuery(this IQueryNode node, QueryBase container)
+    public static void SetQuery(this IQueryNode node, QueryBase? container)
     {
-        node.Data[QueryKey] = container;
+        if (container is null)
+            node.Data.Remove(QueryKey);
+        else
+            node.Data[QueryKey] = container;
     }
 
     public static void RemoveQuery(this IQueryNode node)
@@ -33,23 +36,23 @@ public static class QueryNodeExtensions
     }
 
     private const string SourceFilterKey = "@SourceFilter";
-    public static SourceFilter GetSourceFilter(this IQueryNode node, Func<SourceFilter> getDefaultValue = null)
+    public static SourceFilter? GetSourceFilter(this IQueryNode node, Func<SourceFilter>? getDefaultValue = null)
     {
-        if (!node.Data.TryGetValue(SourceFilterKey, out object value))
+        if (!node.Data.TryGetValue(SourceFilterKey, out object? value))
             return getDefaultValue?.Invoke();
 
         return value as SourceFilter;
     }
 
     private const string AggregationKey = "@Aggregation";
-    public static Task<AggregationBase> GetAggregationAsync(this IQueryNode node, Func<Task<AggregationBase>> getDefaultValue = null)
+    public static Task<AggregationBase?> GetAggregationAsync(this IQueryNode node, Func<Task<AggregationBase?>>? getDefaultValue = null)
     {
-        if (!node.Data.TryGetValue(AggregationKey, out object value))
+        if (!node.Data.TryGetValue(AggregationKey, out object? value))
         {
             if (getDefaultValue == null)
-                return Task.FromResult<AggregationBase>(null);
+                return Task.FromResult<AggregationBase?>(null);
 
-            return getDefaultValue?.Invoke();
+            return getDefaultValue.Invoke();
         }
 
         return Task.FromResult(value as AggregationBase);
@@ -66,9 +69,9 @@ public static class QueryNodeExtensions
     }
 
     private const string SortKey = "@Sort";
-    public static IFieldSort GetSort(this IQueryNode node, Func<IFieldSort> getDefaultValue = null)
+    public static IFieldSort? GetSort(this IQueryNode node, Func<IFieldSort>? getDefaultValue = null)
     {
-        if (!node.Data.TryGetValue(SortKey, out object value))
+        if (!node.Data.TryGetValue(SortKey, out object? value))
             return getDefaultValue?.Invoke();
 
         return value as IFieldSort;
@@ -85,9 +88,9 @@ public static class QueryNodeExtensions
     }
 
     private const string NestedPathKey = "@NestedPath";
-    public static string GetNestedPath(this IQueryNode node)
+    public static string? GetNestedPath(this IQueryNode node)
     {
-        if (!node.Data.TryGetValue(NestedPathKey, out object value))
+        if (!node.Data.TryGetValue(NestedPathKey, out object? value))
             return null;
 
         return value as string;
@@ -106,9 +109,9 @@ public static class QueryNodeExtensions
     }
 
     private const string NestedFilterKey = "@NestedFilter";
-    public static QueryContainer GetNestedFilter(this IQueryNode node)
+    public static QueryContainer? GetNestedFilter(this IQueryNode node)
     {
-        if (!node.Data.TryGetValue(NestedFilterKey, out object value))
+        if (!node.Data.TryGetValue(NestedFilterKey, out object? value))
             return null;
 
         return value as QueryContainer;

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
@@ -18,7 +18,7 @@ public static class QueryVisitorContextExtensions
         return elasticContext.EnableRuntimeFieldResolver;
     }
 
-    public static RuntimeFieldResolver GetRuntimeFieldResolver(this IQueryVisitorContext context)
+    public static RuntimeFieldResolver? GetRuntimeFieldResolver(this IQueryVisitorContext context)
     {
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
@@ -46,13 +46,13 @@ public static class QueryVisitorContextExtensions
         return context;
     }
 
-    public static Task<string> GetTimeZoneAsync(this IQueryVisitorContext context)
+    public static Task<string?> GetTimeZoneAsync(this IQueryVisitorContext context)
     {
         var elasticContext = context as IElasticQueryVisitorContext;
         if (elasticContext?.DefaultTimeZone != null)
-            return elasticContext.DefaultTimeZone.Invoke();
+            return elasticContext.DefaultTimeZone.Invoke()!;
 
-        return Task.FromResult<string>(null);
+        return Task.FromResult<string?>(null);
     }
 
     public static T SetMappingResolver<T>(this T context, ElasticMappingResolver mappingResolver) where T : IQueryVisitorContext

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
@@ -34,7 +34,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
             if (aggregation is null)
                 continue;
 
-            string nestedPath = child.GetNestedPath();
+            string? nestedPath = child.GetNestedPath();
             if (nestedPath is not null)
             {
                 if (!nestedAggregations.ContainsKey(nestedPath))
@@ -97,7 +97,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
             node.SetAggregation(container);
     }
 
-    private static void AddAggregation(AggregationBase container, ITermsAggregation termsAggregation, IFieldQueryNode child, AggregationBase aggregation)
+    private static void AddAggregation(AggregationBase container, ITermsAggregation? termsAggregation, IFieldQueryNode child, AggregationBase aggregation)
     {
         if (container is BucketAggregationBase bucketContainer)
         {
@@ -108,7 +108,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
         AddTermsOrder(termsAggregation, child, aggregation);
     }
 
-    private static void AddTermsOrder(ITermsAggregation termsAggregation, IFieldQueryNode child, AggregationBase aggregation, string bucketPathPrefix = null)
+    private static void AddTermsOrder(ITermsAggregation? termsAggregation, IFieldQueryNode child, AggregationBase aggregation, string? bucketPathPrefix = null)
     {
         if (termsAggregation is null || child.Prefix is not "-" and not "+")
             return;
@@ -172,7 +172,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
 
     private async Task<AggregationBase> GetParentContainerAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        AggregationBase container = null;
+        AggregationBase? container = null;
         var currentNode = node;
         while (container is null && currentNode is not null)
         {
@@ -195,7 +195,7 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
         if (container is null)
         {
             container = new ChildrenAggregation(null, null);
-            currentNode.SetAggregation(container);
+            currentNode!.SetAggregation(container);
         }
 
         return container;

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -183,9 +183,9 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         if (query is null)
             return;
 
-        if (query.IsFilterOnlyBoolQuery())
+        if (query.IsFilterOnlyBoolQuery() && query.Bool is { Filter: { } existingFilters })
         {
-            filters.AddRange(query.Bool!.Filter!);
+            filters.AddRange(existingFilters);
         }
         else
         {

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -19,8 +19,8 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        QueryBase query = await node.GetQueryAsync(() => node.GetDefaultQueryAsync(context)).ConfigureAwait(false);
-        QueryBase container = query;
+        QueryBase? query = await node.GetQueryAsync(() => node.GetDefaultQueryAsync(context)).ConfigureAwait(false);
+        QueryBase? container = query;
         var nested = query as NestedQuery;
 
         // Reset container for non-root nested groups so children combine into a fresh
@@ -67,8 +67,8 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
 
         foreach (var (path, pathQueries) in nestedQueries)
         {
-            QueryContainer combinedInner = null;
-            QueryContainer nestedFilter = null;
+            QueryContainer? combinedInner = null;
+            QueryContainer? nestedFilter = null;
             foreach (var (child, innerQuery) in pathQueries)
             {
                 QueryContainer q = innerQuery;
@@ -116,8 +116,11 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         return op;
     }
 
-    private static QueryBase Combine(QueryBase left, QueryBase right, GroupOperator op)
+    private static QueryBase? Combine(QueryBase? left, QueryBase right, GroupOperator op)
     {
+        if (left is null)
+            return right;
+
         if (op is GroupOperator.And)
             return left & right;
 
@@ -127,8 +130,11 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         return left;
     }
 
-    private static QueryContainer Combine(QueryContainer left, QueryContainer right, GroupOperator op)
+    private static QueryContainer? Combine(QueryContainer? left, QueryContainer right, GroupOperator op)
     {
+        if (left is null)
+            return right;
+
         if (op is GroupOperator.And)
             return left & right;
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -121,21 +121,19 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
 
         if (nested is not null)
         {
-            if (container is null)
-            {
-                node.SetQuery(null);
-                return;
-            }
-
             var groupNestedFilter = node.GetNestedFilter();
-            if (groupNestedFilter is not null)
+            if (container is not null && groupNestedFilter is not null)
             {
                 Query inner = container & groupNestedFilter;
                 nested.Query = inner;
             }
-            else
+            else if (container is not null)
             {
                 nested.Query = container;
+            }
+            else if (groupNestedFilter is not null)
+            {
+                nested.Query = groupNestedFilter;
             }
 
             node.SetQuery(nested);

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -121,15 +121,21 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
 
         if (nested is not null)
         {
+            if (container is null)
+            {
+                node.SetQuery(null);
+                return;
+            }
+
             var groupNestedFilter = node.GetNestedFilter();
             if (groupNestedFilter is not null)
             {
-                Query inner = container! & groupNestedFilter;
+                Query inner = container & groupNestedFilter;
                 nested.Query = inner;
             }
             else
             {
-                nested.Query = container!;
+                nested.Query = container;
             }
 
             node.SetQuery(nested);

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/ElasticQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/ElasticQueryVisitorContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -7,10 +7,10 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors;
 
 public class ElasticQueryVisitorContext : QueryVisitorContext, IElasticQueryVisitorContext
 {
-    public Func<Task<string>> DefaultTimeZone { get; set; }
+    public Func<Task<string>>? DefaultTimeZone { get; set; }
     public bool UseScoring { get; set; }
-    public ElasticMappingResolver MappingResolver { get; set; }
+    public ElasticMappingResolver MappingResolver { get; set; } = ElasticMappingResolver.NullInstance;
     public ICollection<ElasticRuntimeField> RuntimeFields { get; } = new List<ElasticRuntimeField>();
     public bool? EnableRuntimeFieldResolver { get; set; }
-    public RuntimeFieldResolver RuntimeFieldResolver { get; set; }
+    public RuntimeFieldResolver? RuntimeFieldResolver { get; set; }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
@@ -10,9 +10,9 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors;
 
 public class GeoVisitor : ChainableQueryVisitor
 {
-    private readonly Func<string, Task<string>> _resolveGeoLocation;
+    private readonly Func<string, Task<string>>? _resolveGeoLocation;
 
-    public GeoVisitor(Func<string, Task<string>> resolveGeoLocation = null)
+    public GeoVisitor(Func<string, Task<string>>? resolveGeoLocation = null)
     {
         _resolveGeoLocation = resolveGeoLocation;
     }
@@ -22,7 +22,10 @@ public class GeoVisitor : ChainableQueryVisitor
         if (context.QueryType != QueryTypes.Query || context is not IElasticQueryVisitorContext elasticContext || !elasticContext.MappingResolver.IsGeoPropertyType(node.Field))
             return;
 
-        string location = _resolveGeoLocation != null ? await _resolveGeoLocation(node.Term).ConfigureAwait(false) ?? node.Term : node.Term;
+        if (String.IsNullOrEmpty(node.Term))
+            return;
+
+        string? location = _resolveGeoLocation is not null ? await _resolveGeoLocation(node.Term).ConfigureAwait(false) ?? node.Term : node.Term;
         var query = new GeoDistanceQuery { Field = node.Field, Location = location, Distance = node.Proximity ?? Distance.Miles(10) };
         node.SetQuery(query);
     }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
@@ -23,17 +23,22 @@ public class GeoVisitor : ChainableQueryVisitor
         if (context.QueryType != QueryTypes.Query || context is not IElasticQueryVisitorContext elasticContext || !elasticContext.MappingResolver.IsGeoPropertyType(node.Field))
             return;
 
+        if (node.Field is null)
+            return;
+
         string? location = null;
 
-        if (elasticContext.GeoLocationResolver is not null)
-            location = await elasticContext.GeoLocationResolver(node.Term!).AnyContext();
+        if (node.Term is not null && elasticContext.GeoLocationResolver is not null)
+            location = await elasticContext.GeoLocationResolver(node.Term).AnyContext();
 
-        if (location is null && _resolveGeoLocation is not null)
-            location = await _resolveGeoLocation(node.Term!).AnyContext();
+        if (location is null && node.Term is not null && _resolveGeoLocation is not null)
+            location = await _resolveGeoLocation(node.Term).AnyContext();
 
         location ??= node.Term;
+        if (location is null)
+            return;
 
-        var query = new GeoDistanceQuery(node.Proximity ?? "10mi", node.Field!, location!);
+        var query = new GeoDistanceQuery(node.Proximity ?? "10mi", node.Field, location);
         node.SetQuery(query);
     }
 
@@ -42,9 +47,12 @@ public class GeoVisitor : ChainableQueryVisitor
         if (context is not IElasticQueryVisitorContext elasticContext || !elasticContext.MappingResolver.IsGeoPropertyType(node.Field))
             return;
 
+        if (node.Field is null || node.Min is null || node.Max is null)
+            return;
+
         // GeoBoundingBoxQuery ergonomic feedback: https://github.com/elastic/elasticsearch-net/issues/8496
-        var box = GeoBounds.TopLeftBottomRight(new TopLeftBottomRightGeoBounds { TopLeft = GeoLocation.Text(node.Min!), BottomRight = GeoLocation.Text(node.Max!) });
-        var query = new GeoBoundingBoxQuery(box, node.Field!);
+        var box = GeoBounds.TopLeftBottomRight(new TopLeftBottomRightGeoBounds { TopLeft = GeoLocation.Text(node.Min), BottomRight = GeoLocation.Text(node.Max) });
+        var query = new GeoBoundingBoxQuery(box, node.Field);
         node.SetQuery(query);
     }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
@@ -18,7 +18,7 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<IEnumerable<I
             return;
 
         var sort = node.GetSort(() => node.GetDefaultSort(context));
-        if (sort.SortKey == null)
+        if (sort?.SortKey is null)
             return;
 
         _fields.Add(sort);
@@ -30,12 +30,13 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<IEnumerable<I
         return _fields;
     }
 
-    public static Task<IEnumerable<IFieldSort>> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task<IEnumerable<IFieldSort>> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext();
         return new GetSortFieldsVisitor().AcceptAsync(node, context);
     }
 
-    public static IEnumerable<IFieldSort> Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static IEnumerable<IFieldSort> Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/IElasticQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/IElasticQueryVisitorContext.cs
@@ -13,7 +13,7 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors
         /// <summary>
         /// Provides the default timezone for date queries when not explicitly specified.
         /// </summary>
-        Func<Task<string>> DefaultTimeZone { get; set; }
+        Func<Task<string>>? DefaultTimeZone { get; set; }
 
         /// <summary>
         /// Whether to use scoring queries (query context) instead of filters (filter context).
@@ -38,7 +38,7 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors
         /// <summary>
         /// Resolves field names to runtime field definitions for dynamic field support.
         /// </summary>
-        RuntimeFieldResolver RuntimeFieldResolver { get; set; }
+        RuntimeFieldResolver? RuntimeFieldResolver { get; set; }
     }
 }
 
@@ -49,7 +49,7 @@ namespace Foundatio.Parsers
     /// </summary>
     /// <param name="field">The field name to resolve.</param>
     /// <returns>The runtime field definition, or null if the field should not be a runtime field.</returns>
-    public delegate Task<ElasticRuntimeField> RuntimeFieldResolver(string field);
+    public delegate Task<ElasticRuntimeField?> RuntimeFieldResolver(string field);
 
     /// <summary>
     /// Defines an Elasticsearch runtime field for dynamic field computation.
@@ -59,7 +59,7 @@ namespace Foundatio.Parsers
         /// <summary>
         /// The name of the runtime field.
         /// </summary>
-        public string Name { get; set; }
+        public required string Name { get; set; }
 
         /// <summary>
         /// The data type of the runtime field.
@@ -69,7 +69,7 @@ namespace Foundatio.Parsers
         /// <summary>
         /// The Painless script that computes the field value.
         /// </summary>
-        public string Script { get; set; }
+        public required string Script { get; set; }
     }
 
     /// <summary>

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -40,9 +40,11 @@ public class NestedVisitor : ChainableQueryVisitor
 
     private async Task VisitGroupWithFilterAsync(GroupNode node, string nestedProperty, IQueryVisitorContext context)
     {
-        string? originalField = node.GetOriginalField();
         ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
-        var filter = await _filterResolver!(nestedProperty, originalField!, node.Field!, context).AnyContext();
+
+        string field = node.Field!; // Caller verified non-empty at VisitAsync entry
+        string? originalField = node.GetOriginalField();
+        var filter = await _filterResolver!(nestedProperty, originalField ?? field, field, context).AnyContext();
         if (filter is not null)
             node.SetNestedFilter(filter);
 
@@ -97,11 +99,11 @@ public class NestedVisitor : ChainableQueryVisitor
     {
         ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
 
-        if (node.Field is null || _filterResolver is null)
+        if (node.Field is not { } field || _filterResolver is null)
             return;
 
         string? originalField = node.GetOriginalField();
-        var filter = await _filterResolver(nestedProperty, originalField ?? node.Field, node.Field, context).AnyContext();
+        var filter = await _filterResolver(nestedProperty, originalField ?? field, field, context).AnyContext();
         if (filter is not null)
             node.SetNestedFilter(filter);
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -95,9 +95,13 @@ public class NestedVisitor : ChainableQueryVisitor
 
     private async Task HandleNestedFieldWithFilterAsync(IFieldQueryNode node, string nestedProperty, IQueryVisitorContext context)
     {
-        string? originalField = node.GetOriginalField();
         ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
-        var filter = await _filterResolver!(nestedProperty, originalField!, node.Field!, context).AnyContext();
+
+        if (node.Field is null || _filterResolver is null)
+            return;
+
+        string? originalField = node.GetOriginalField();
+        var filter = await _filterResolver(nestedProperty, originalField ?? node.Field, node.Field, context).AnyContext();
         if (filter is not null)
             node.SetNestedFilter(filter);
 

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -42,7 +42,7 @@ public class NestedVisitor : ChainableQueryVisitor
     {
         ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
 
-        string field = node.Field!; // Caller verified non-empty at VisitAsync entry
+        string field = node.Field!;
         string? originalField = node.GetOriginalField();
         var filter = await _filterResolver!(nestedProperty, originalField ?? field, field, context).AnyContext();
         if (filter is not null)

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -12,9 +12,9 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors;
 
 public class NestedVisitor : ChainableQueryVisitor
 {
-    private readonly NestedFilterResolver _filterResolver;
+    private readonly NestedFilterResolver? _filterResolver;
 
-    public NestedVisitor(NestedFilterResolver filterResolver = null)
+    public NestedVisitor(NestedFilterResolver? filterResolver = null)
     {
         _filterResolver = filterResolver;
     }
@@ -24,7 +24,7 @@ public class NestedVisitor : ChainableQueryVisitor
         if (String.IsNullOrEmpty(node.Field))
             return base.VisitAsync(node, context);
 
-        string nestedProperty = GetNestedProperty(node.Field, context);
+        string? nestedProperty = GetNestedProperty(node.Field, context);
         if (nestedProperty is null)
             return base.VisitAsync(node, context);
 
@@ -40,9 +40,9 @@ public class NestedVisitor : ChainableQueryVisitor
 
     private async Task VisitGroupWithFilterAsync(GroupNode node, string nestedProperty, IQueryVisitorContext context)
     {
-        string originalField = node.GetOriginalField();
+        string? originalField = node.GetOriginalField();
         ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
-        var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
+        var filter = await _filterResolver!(nestedProperty, originalField!, node.Field!, context).ConfigureAwait(false);
         if (filter is not null)
             node.SetNestedFilter(filter);
 
@@ -74,7 +74,7 @@ public class NestedVisitor : ChainableQueryVisitor
         if (IsInsideNestedGroup(node))
             return Task.CompletedTask;
 
-        string nestedProperty = GetNestedProperty(node.Field, context);
+        string? nestedProperty = GetNestedProperty(node.Field, context);
         if (nestedProperty is null)
             return Task.CompletedTask;
 
@@ -95,9 +95,9 @@ public class NestedVisitor : ChainableQueryVisitor
 
     private async Task HandleNestedFieldWithFilterAsync(IFieldQueryNode node, string nestedProperty, IQueryVisitorContext context)
     {
-        string originalField = node.GetOriginalField();
+        string? originalField = node.GetOriginalField();
         ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
-        var filter = await _filterResolver(nestedProperty, originalField, node.Field, context).ConfigureAwait(false);
+        var filter = await _filterResolver!(nestedProperty, originalField!, node.Field!, context).ConfigureAwait(false);
         if (filter is not null)
             node.SetNestedFilter(filter);
 
@@ -138,9 +138,9 @@ public class NestedVisitor : ChainableQueryVisitor
         return false;
     }
 
-    private static string GetNestedProperty(string fullName, IQueryVisitorContext context)
+    private static string? GetNestedProperty(string? fullName, IQueryVisitorContext context)
     {
-        string[] nameParts = fullName?.Split('.');
+        string[]? nameParts = fullName?.Split('.');
 
         if (nameParts is null || context is not IElasticQueryVisitorContext elasticContext || nameParts is { Length: 0 })
             return null;

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -42,9 +42,14 @@ public class NestedVisitor : ChainableQueryVisitor
     {
         ArgumentException.ThrowIfNullOrEmpty(nestedProperty);
 
-        string field = node.Field!;
+        if (node.Field is not { } field || _filterResolver is null)
+        {
+            await base.VisitAsync(node, context).AnyContext();
+            return;
+        }
+
         string? originalField = node.GetOriginalField();
-        var filter = await _filterResolver!(nestedProperty, originalField ?? field, field, context).AnyContext();
+        var filter = await _filterResolver(nestedProperty, originalField ?? field, field, context).AnyContext();
         if (filter is not null)
             node.SetNestedFilter(filter);
 

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -36,7 +36,7 @@ public static class QueryNodeExtensions
             return false;
 
         if (node is IFieldQueryNode fieldNode)
-            return (fieldNode.IsNegated.HasValue && fieldNode.IsNegated.Value == true) || (!String.IsNullOrEmpty(fieldNode.Prefix) && (fieldNode.Prefix == "-" || fieldNode.Prefix == "!"));
+            return fieldNode.IsNegated is true || (!String.IsNullOrEmpty(fieldNode.Prefix) && fieldNode.Prefix is "-" or "!");
 
         return false;
     }
@@ -123,10 +123,10 @@ public static class QueryNodeExtensions
         if (node.IsRequired())
             return false;
 
-        return node.IsExcluded() || node.GetGroupNode().IsExcluded();
+        return node.IsExcluded() || node.GetGroupNode()?.IsExcluded() is true;
     }
 
-    public static GroupNode GetRootNode(this IQueryNode node)
+    public static GroupNode? GetRootNode(this IQueryNode node)
     {
         if (node == null)
             return null;
@@ -143,7 +143,7 @@ public static class QueryNodeExtensions
         return null;
     }
 
-    public static GroupNode GetGroupNode(this IQueryNode node, bool onlyParensOrRoot = true)
+    public static GroupNode? GetGroupNode(this IQueryNode node, bool onlyParensOrRoot = true)
     {
         if (node == null)
             return null;
@@ -161,9 +161,9 @@ public static class QueryNodeExtensions
     }
 
     private const string TimeZoneKey = "@TimeZone";
-    public static string GetTimeZone(this IFieldQueryNode node, string defaultTimeZone = null)
+    public static string? GetTimeZone(this IFieldQueryNode node, string? defaultTimeZone = null)
     {
-        if (!node.Data.TryGetValue(TimeZoneKey, out object value))
+        if (!node.Data.TryGetValue(TimeZoneKey, out object? value))
             return defaultTimeZone;
 
         return value as string;
@@ -175,9 +175,9 @@ public static class QueryNodeExtensions
     }
 
     private const string OriginalFieldKey = "@OriginalField";
-    public static string GetOriginalField(this IFieldQueryNode node)
+    public static string? GetOriginalField(this IFieldQueryNode node)
     {
-        if (!node.Data.TryGetValue(OriginalFieldKey, out object value))
+        if (!node.Data.TryGetValue(OriginalFieldKey, out object? value))
             return node.Field;
 
         return value as string;
@@ -194,33 +194,35 @@ public static class QueryNodeExtensions
         return node.Data.ContainsKey(OperationTypeKey);
     }
 
-    public static string GetOperationType(this IQueryNode node)
+    public static string? GetOperationType(this IQueryNode node)
     {
-        if (!node.Data.TryGetValue(OperationTypeKey, out object value))
+        if (!node.Data.TryGetValue(OperationTypeKey, out object? value))
             return null;
 
-        return (string)value;
+        return (string?)value;
     }
 
-    public static void SetOperationType(this IQueryNode node, string operationType)
+    public static void SetOperationType(this IQueryNode node, string? operationType)
     {
-        node.Data[OperationTypeKey] = operationType;
+        if (operationType is null)
+            node.Data.Remove(OperationTypeKey);
+        else
+            node.Data[OperationTypeKey] = operationType;
     }
 
-    public static string[] GetDefaultFields(this IQueryNode node, string[] rootDefaultFields)
+    public static string[]? GetDefaultFields(this IQueryNode node, string[]? rootDefaultFields)
     {
         var scopedNode = GetGroupNode(node);
-        return !String.IsNullOrEmpty(scopedNode?.Field) ? [scopedNode.Field] : rootDefaultFields;
+        return !String.IsNullOrEmpty(scopedNode?.Field) ? [scopedNode!.Field!] : rootDefaultFields;
     }
 
-    public static GroupOperator GetOperator(this IQueryNode node, IQueryVisitorContext context)
+    public static GroupOperator GetOperator(this IQueryNode node, IQueryVisitorContext? context)
     {
         var defaultOperator = GroupOperator.And;
         if (context != null && context.DefaultOperator != GroupOperator.Default)
             defaultOperator = context.DefaultOperator;
 
-        if (node is not GroupNode groupNode)
-            groupNode = node.Parent as GroupNode;
+        var groupNode = node as GroupNode ?? node.Parent as GroupNode;
 
         if (groupNode == null)
             return defaultOperator;
@@ -235,12 +237,12 @@ public static class QueryNodeExtensions
 
     private const string ReferencedFieldsKey = "@ReferencedFields";
     private const string CurrentGroupReferencedFieldsKey = "@CurrentGroupReferencedFields";
-    public static ISet<string> GetReferencedFields<T>(this T node, IQueryVisitorContext context = null, bool currentGroupOnly = false) where T : IQueryNode
+    public static ISet<string> GetReferencedFields<T>(this T node, IQueryVisitorContext? context = null, bool currentGroupOnly = false) where T : IQueryNode
     {
-        if (!currentGroupOnly && node.Data.TryGetValue(ReferencedFieldsKey, out object allFieldsObject) && allFieldsObject is ISet<string> allFields)
+        if (!currentGroupOnly && node.Data.TryGetValue(ReferencedFieldsKey, out object? allFieldsObject) && allFieldsObject is ISet<string> allFields)
             return allFields;
 
-        if (currentGroupOnly && node.Data.TryGetValue(CurrentGroupReferencedFieldsKey, out object immediateFieldsObject) && immediateFieldsObject is ISet<string> immediateFields)
+        if (currentGroupOnly && node.Data.TryGetValue(CurrentGroupReferencedFieldsKey, out object? immediateFieldsObject) && immediateFieldsObject is ISet<string> immediateFields)
             return immediateFields;
 
         var fields = new HashSet<string>();
@@ -255,7 +257,7 @@ public static class QueryNodeExtensions
         return fields;
     }
 
-    private static void GatherReferencedFields(IQueryVisitorContext context, IQueryNode node, HashSet<string> fields, int currentGroupDepth, int maxGroupDepth)
+    private static void GatherReferencedFields(IQueryVisitorContext? context, IQueryNode node, HashSet<string> fields, int currentGroupDepth, int maxGroupDepth)
     {
         if (maxGroupDepth >= 0 && currentGroupDepth >= 0 && currentGroupDepth > maxGroupDepth)
             return;
@@ -268,11 +270,11 @@ public static class QueryNodeExtensions
             }
             else if (fieldNode is not GroupNode)
             {
-                string[] defaultFields = node.GetDefaultFields(context?.DefaultFields);
+                string[]? defaultFields = node.GetDefaultFields(context?.DefaultFields);
                 if (defaultFields == null || defaultFields.Length == 0)
                     fields.Add("");
                 else
-                    foreach (string defaultField in fields)
+                    foreach (string defaultField in defaultFields)
                         fields.Add(defaultField);
             }
         }

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryVisitorContextExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryVisitorContextExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -8,18 +9,18 @@ namespace Foundatio.Parsers.LuceneQueries.Extensions;
 
 public static class QueryVisitorContextExtensions
 {
-    public static QueryFieldResolver GetFieldResolver(this IQueryVisitorContext context)
+    public static QueryFieldResolver? GetFieldResolver(this IQueryVisitorContext context)
     {
         var resolverContext = context as IQueryVisitorContextWithFieldResolver;
         return resolverContext?.FieldResolver;
     }
 
-    public static T SetFieldResolver<T>(this T context, Func<string, string> resolver) where T : IQueryVisitorContext
+    public static T SetFieldResolver<T>(this T context, Func<string, string?> resolver) where T : IQueryVisitorContext
     {
         if (context is not IQueryVisitorContextWithFieldResolver resolverContext)
             throw new ArgumentException("Context must be of type IQueryVisitorContextWithFieldResolver", nameof(context));
 
-        resolverContext.FieldResolver = (field, _) => Task.FromResult(resolver(field));
+        resolverContext.FieldResolver = (field, _) => Task.FromResult<string?>(resolver(field));
 
         return context;
     }
@@ -34,7 +35,7 @@ public static class QueryVisitorContextExtensions
         return context;
     }
 
-    public static IncludeResolver GetIncludeResolver(this IQueryVisitorContext context)
+    public static IncludeResolver? GetIncludeResolver(this IQueryVisitorContext context)
     {
         if (context is not IQueryVisitorContextWithIncludeResolver includeContext)
             throw new ArgumentException("Context must be of type IQueryVisitorContextWithIncludeResolver", nameof(context));
@@ -173,9 +174,10 @@ public static class QueryVisitorContextExtensions
         return context;
     }
 
+    [return: MaybeNull]
     public static T GetValue<T>(this IQueryVisitorContext context, string key)
     {
-        if (context.Data.TryGetValue(key, out object value) && value is T typedValue)
+        if (context.Data.TryGetValue(key, out object? value) && value is T typedValue)
             return typedValue;
 
         return default;
@@ -183,7 +185,7 @@ public static class QueryVisitorContextExtensions
 
     public static ICollection<T> GetCollection<T>(this IQueryVisitorContext context, string key)
     {
-        if (context.Data.TryGetValue(key, out object value))
+        if (context.Data.TryGetValue(key, out object? value))
         {
             if (value is ICollection<T> typedValue)
                 return typedValue;
@@ -199,15 +201,15 @@ public static class QueryVisitorContextExtensions
 
     public static DateTime? GetDate(this IQueryVisitorContext context, string key)
     {
-        if (context.Data.TryGetValue(key, out object value) && value is DateTime date)
+        if (context.Data.TryGetValue(key, out object? value) && value is DateTime date)
             return date;
 
         return null;
     }
 
-    public static string GetString(this IQueryVisitorContext context, string key)
+    public static string? GetString(this IQueryVisitorContext context, string key)
     {
-        if (context.Data.TryGetValue(key, out object value) && value is string str)
+        if (context.Data.TryGetValue(key, out object? value) && value is string str)
             return str;
 
         return null;
@@ -215,7 +217,7 @@ public static class QueryVisitorContextExtensions
 
     public static bool GetBoolean(this IQueryVisitorContext context, string key, bool defaultValue = false)
     {
-        if (context.Data.TryGetValue(key, out object value) && value is bool b)
+        if (context.Data.TryGetValue(key, out object? value) && value is bool b)
             return b;
 
         return defaultValue;
@@ -229,7 +231,7 @@ public static class QueryVisitorContextExtensions
         return context;
     }
 
-    public static IQueryNode GetAlternateInvertedCriteria(this IQueryVisitorContext context)
+    public static IQueryNode? GetAlternateInvertedCriteria(this IQueryVisitorContext context)
     {
         return context.GetValue<IQueryNode>(AlternateInvertedCriteriaKey);
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/StringExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/StringExtensions.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Parsers.LuceneQueries.Extensions;
 
 public static class StringExtensions
 {
-    public static string Unescape(this string input)
+    public static string? Unescape(this string? input)
     {
         if (input == null)
             return null;

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/TextWriterExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/TextWriterExtensions.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Parsers.LuceneQueries.Extensions;
 
 public static class TextWriterExtensions
 {
-    public static void WriteIf(this TextWriter writer, bool condition, string content, params object[] arguments)
+    public static void WriteIf(this TextWriter writer, bool condition, string content, params object?[] arguments)
     {
         if (!condition)
             return;
@@ -15,7 +15,7 @@ public static class TextWriterExtensions
             writer.Write(content);
     }
 
-    public static void WriteLineIf(this TextWriter writer, bool condition, string content, params object[] arguments)
+    public static void WriteLineIf(this TextWriter writer, bool condition, string content, params object?[] arguments)
     {
         if (!condition)
             return;

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.cs
@@ -6,13 +6,13 @@ namespace Foundatio.Parsers.LuceneQueries;
 
 public partial class LuceneQueryParser : IQueryParser
 {
-    public virtual Task<IQueryNode> ParseAsync(string query, IQueryVisitorContext context = null)
+    public virtual Task<IQueryNode?> ParseAsync(string query, IQueryVisitorContext? context = null)
     {
         var result = Parse(query);
-        return Task.FromResult<IQueryNode>(result);
+        return Task.FromResult<IQueryNode?>(result);
     }
 
-    public IQueryNode Parse(string query, IQueryVisitorContext context)
+    public IQueryNode? Parse(string query, IQueryVisitorContext? context)
     {
         return ParseAsync(query, context).GetAwaiter().GetResult();
     }
@@ -28,6 +28,6 @@ public interface IQueryParser
     /// </summary>
     /// <param name="query">The query string to parse.</param>
     /// <param name="context">Optional visitor context for parsing configuration.</param>
-    /// <returns>The root node of the parsed query AST.</returns>
-    Task<IQueryNode> ParseAsync(string query, IQueryVisitorContext context = null);
+    /// <returns>The root node of the parsed query AST, or null if parsing failed (check context for validation errors).</returns>
+    Task<IQueryNode?> ParseAsync(string query, IQueryVisitorContext? context = null);
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/ExistsNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/ExistsNode.cs
@@ -7,9 +7,9 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 public class ExistsNode : QueryNodeBase, IFieldQueryNode
 {
     public bool? IsNegated { get; set; }
-    public string Prefix { get; set; }
-    public string Field { get; set; }
-    public string UnescapedField => Field?.Unescape();
+    public string? Prefix { get; set; }
+    public string? Field { get; set; }
+    public string? UnescapedField => Field?.Unescape();
 
     public ExistsNode CopyTo(ExistsNode target)
     {

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/GroupNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/GroupNode.cs
@@ -7,8 +7,8 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 
 public class GroupNode : QueryNodeBase, IFieldQueryWithProximityAndBoostNode
 {
-    private IQueryNode _left;
-    public IQueryNode Left
+    private IQueryNode? _left;
+    public IQueryNode? Left
     {
         get => _left;
         set
@@ -19,8 +19,8 @@ public class GroupNode : QueryNodeBase, IFieldQueryWithProximityAndBoostNode
         }
     }
 
-    private IQueryNode _right;
-    public IQueryNode Right
+    private IQueryNode? _right;
+    public IQueryNode? Right
     {
         get => _right;
         set
@@ -33,14 +33,14 @@ public class GroupNode : QueryNodeBase, IFieldQueryWithProximityAndBoostNode
 
     public GroupOperator Operator { get; set; } = GroupOperator.Default;
     public bool HasParens { get; set; }
-    public string Field { get; set; }
-    public string UnescapedField => Field?.Unescape();
+    public string? Field { get; set; }
+    public string? UnescapedField => Field?.Unescape();
     public bool? IsNegated { get; set; }
-    public string Prefix { get; set; }
-    public string Boost { get; set; }
-    public string UnescapedBoost => Boost?.Unescape();
-    public string Proximity { get; set; }
-    public string UnescapedProximity => Proximity?.Unescape();
+    public string? Prefix { get; set; }
+    public string? Boost { get; set; }
+    public string? UnescapedBoost => Boost?.Unescape();
+    public string? Proximity { get; set; }
+    public string? UnescapedProximity => Proximity?.Unescape();
 
     public GroupNode CopyTo(GroupNode target)
     {

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
@@ -16,7 +16,7 @@ public interface IQueryNode
     /// <summary>
     /// The parent node in the AST, or null for the root node.
     /// </summary>
-    IQueryNode Parent { get; set; }
+    IQueryNode? Parent { get; set; }
 
     /// <summary>
     /// The child nodes of this node.
@@ -31,7 +31,7 @@ public interface IQueryNode
     /// <summary>
     /// Accepts a visitor for tree traversal using the visitor pattern.
     /// </summary>
-    Task<IQueryNode> AcceptAsync(IQueryNodeVisitor visitor, IQueryVisitorContext context);
+    Task<IQueryNode?> AcceptAsync(IQueryNodeVisitor visitor, IQueryVisitorContext context);
 
     /// <summary>
     /// Returns the query string representation of this node.
@@ -57,17 +57,17 @@ public interface IFieldQueryNode : IQueryNode
     /// <summary>
     /// The prefix modifier (+, -, etc.) applied to this node.
     /// </summary>
-    string Prefix { get; set; }
+    string? Prefix { get; set; }
 
     /// <summary>
     /// The field name this query targets, or null for default field queries.
     /// </summary>
-    string Field { get; set; }
+    string? Field { get; set; }
 
     /// <summary>
     /// The field name with escape sequences resolved.
     /// </summary>
-    string UnescapedField { get; }
+    string? UnescapedField { get; }
 }
 
 /// <summary>
@@ -78,12 +78,12 @@ public interface IFieldQueryWithProximityAndBoostNode : IFieldQueryNode
     /// <summary>
     /// The boost factor (^) to increase or decrease relevance scoring.
     /// </summary>
-    string Boost { get; set; }
+    string? Boost { get; set; }
 
     /// <summary>
     /// The boost value with escape sequences resolved.
     /// </summary>
-    string UnescapedBoost { get; }
+    string? UnescapedBoost { get; }
 
     /// <summary>
     /// The proximity/slop factor (~) for fuzzy or phrase proximity searches.
@@ -94,10 +94,10 @@ public interface IFieldQueryWithProximityAndBoostNode : IFieldQueryNode
     /// For quoted terms (e.g., <c>"jakarta apache"~10</c>), this indicates a phrase proximity search with word slop.
     /// An empty string means the bare tilde was used with no explicit value (e.g., <c>term~</c>).
     /// </remarks>
-    string Proximity { get; set; }
+    string? Proximity { get; set; }
 
     /// <summary>
     /// The proximity value with escape sequences resolved.
     /// </summary>
-    string UnescapedProximity { get; }
+    string? UnescapedProximity { get; }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/MissingNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/MissingNode.cs
@@ -7,9 +7,9 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 public class MissingNode : QueryNodeBase, IFieldQueryNode
 {
     public bool? IsNegated { get; set; }
-    public string Prefix { get; set; }
-    public string Field { get; set; }
-    public string UnescapedField => Field?.Unescape();
+    public string? Prefix { get; set; }
+    public string? Field { get; set; }
+    public string? UnescapedField => Field?.Unescape();
 
     public MissingNode CopyTo(MissingNode target)
     {

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/QueryNodeBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/QueryNodeBase.cs
@@ -6,7 +6,7 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 
 public abstract class QueryNodeBase : IQueryNode
 {
-    public virtual Task<IQueryNode> AcceptAsync(IQueryNodeVisitor visitor, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> AcceptAsync(IQueryNodeVisitor visitor, IQueryVisitorContext context)
     {
         if (this is GroupNode groupNode)
             return visitor.VisitAsync(groupNode, context);
@@ -23,12 +23,12 @@ public abstract class QueryNodeBase : IQueryNode
         if (this is ExistsNode existsNode)
             return visitor.VisitAsync(existsNode, context);
 
-        return Task.FromResult<IQueryNode>(this);
+        return Task.FromResult<IQueryNode?>(this);
     }
 
     public IDictionary<string, object> Data { get; } = new Dictionary<string, object>();
     public abstract IEnumerable<IQueryNode> Children { get; }
-    public IQueryNode Parent { get; set; }
+    public IQueryNode? Parent { get; set; }
     public static readonly IList<IQueryNode> EmptyNodeList = new List<IQueryNode>().AsReadOnly();
 
     public abstract IQueryNode Clone();

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/TermNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/TermNode.cs
@@ -8,17 +8,17 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 public class TermNode : QueryNodeBase, IFieldQueryWithProximityAndBoostNode
 {
     public bool? IsNegated { get; set; }
-    public string Prefix { get; set; }
-    public string Field { get; set; }
-    public string UnescapedField => Field?.Unescape();
-    public string Term { get; set; }
-    public string UnescapedTerm => Term?.Unescape();
+    public string? Prefix { get; set; }
+    public string? Field { get; set; }
+    public string? UnescapedField => Field?.Unescape();
+    public string? Term { get; set; }
+    public string? UnescapedTerm => Term?.Unescape();
     public bool IsQuotedTerm { get; set; }
     public bool IsRegexTerm { get; set; }
-    public string Boost { get; set; }
-    public string UnescapedBoost => Boost?.Unescape();
-    public string Proximity { get; set; }
-    public string UnescapedProximity => Proximity?.Unescape();
+    public string? Boost { get; set; }
+    public string? UnescapedBoost => Boost?.Unescape();
+    public string? Proximity { get; set; }
+    public string? UnescapedProximity => Proximity?.Unescape();
 
     public TermNode CopyTo(TermNode target)
     {

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/TermRangeNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/TermRangeNode.cs
@@ -8,22 +8,22 @@ namespace Foundatio.Parsers.LuceneQueries.Nodes;
 public class TermRangeNode : QueryNodeBase, IFieldQueryNode
 {
     public bool? IsNegated { get; set; }
-    public string Field { get; set; }
-    public string UnescapedField => Field?.Unescape();
-    public string Prefix { get; set; }
-    public string Min { get; set; }
-    public string UnescapedMin => Min?.Unescape();
+    public string? Field { get; set; }
+    public string? UnescapedField => Field?.Unescape();
+    public string? Prefix { get; set; }
+    public string? Min { get; set; }
+    public string? UnescapedMin => Min?.Unescape();
     public bool IsMinQuotedTerm { get; set; }
-    public string Max { get; set; }
-    public string UnescapedMax => Max?.Unescape();
+    public string? Max { get; set; }
+    public string? UnescapedMax => Max?.Unescape();
     public bool IsMaxQuotedTerm { get; set; }
-    public string Operator { get; set; }
-    public string Delimiter { get; set; }
+    public string? Operator { get; set; }
+    public string? Delimiter { get; set; }
     public bool? MinInclusive { get; set; }
     public bool? MaxInclusive { get; set; }
-    public string Boost { get; set; }
-    public string UnescapedBoost => Boost?.Unescape();
-    public string Proximity { get; set; }
+    public string? Boost { get; set; }
+    public string? UnescapedBoost => Boost?.Unescape();
+    public string? Proximity { get; set; }
 
     public TermRangeNode CopyTo(TermRangeNode target)
     {

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidation.cs
@@ -22,9 +22,9 @@ public class QueryValidationOptions
 [DebuggerDisplay("IsValid: {IsValid} Message: {Message} Type: {QueryType}")]
 public class QueryValidationResult
 {
-    private ConcurrentDictionary<string, ICollection<string>> _operations = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, ICollection<string?>> _operations = new(StringComparer.OrdinalIgnoreCase);
 
-    public string QueryType { get; set; }
+    public string? QueryType { get; set; }
     public bool IsValid => ValidationErrors.Count == 0;
     public ICollection<QueryValidationError> ValidationErrors { get; } = new List<QueryValidationError>();
     public string Message
@@ -45,7 +45,7 @@ public class QueryValidationResult
     public ICollection<string> UnresolvedFields { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     public ICollection<string> UnresolvedIncludes { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
     public int MaxNodeDepth { get; set; } = 1;
-    public IDictionary<string, ICollection<string>> Operations => _operations;
+    public IDictionary<string, ICollection<string?>> Operations => _operations;
 
     public static implicit operator bool(QueryValidationResult info) => info.IsValid;
 
@@ -61,10 +61,10 @@ public class QueryValidationResult
         }
     }
 
-    internal void AddOperation(string operation, string field)
+    internal void AddOperation(string operation, string? field)
     {
         _operations.AddOrUpdate(operation,
-            _ => new HashSet<string>(StringComparer.OrdinalIgnoreCase) { field },
+            _ => new HashSet<string?>(StringComparer.OrdinalIgnoreCase) { field },
             (_, collection) =>
             {
                 collection.Add(field);
@@ -103,12 +103,12 @@ public class QueryValidationError
 
 public class QueryValidationException : Exception
 {
-    public QueryValidationException(string message, QueryValidationResult result = null,
-        Exception inner = null) : base(message, inner)
+    public QueryValidationException(string message, QueryValidationResult? result = null,
+        Exception? inner = null) : base(message, inner)
     {
         Result = result;
     }
 
-    public QueryValidationResult Result { get; }
-    public ICollection<QueryValidationError> Errors => Result.ValidationErrors;
+    public QueryValidationResult? Result { get; }
+    public ICollection<QueryValidationError>? Errors => Result?.ValidationErrors;
 }

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
@@ -56,13 +56,13 @@ public class QueryValidator
 
             var fieldResolver = context.GetFieldResolver();
             if (fieldResolver is not null)
-                node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver) ?? node;
+                node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver).AnyContext() ?? node;
 
             var includeResolver = context.GetIncludeResolver();
             if (includeResolver is not null)
-                node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver) ?? node;
+                node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver).AnyContext() ?? node;
 
-            return await ValidationVisitor.RunAsync(node, context);
+            return await ValidationVisitor.RunAsync(node, context).AnyContext();
         }
         catch (FormatException ex)
         {
@@ -130,14 +130,14 @@ public class QueryValidator
             node = EnsureNode(node);
 
             var fieldResolver = context.GetFieldResolver();
-            if (fieldResolver != null)
-                node = EnsureNode(await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver));
+            if (fieldResolver is not null)
+                node = EnsureNode(await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver).AnyContext());
 
             var includeResolver = context.GetIncludeResolver();
-            if (includeResolver != null)
-                node = EnsureNode(await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver));
+            if (includeResolver is not null)
+                node = EnsureNode(await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver).AnyContext());
 
-            return await ValidationVisitor.RunAsync(node, context);
+            return await ValidationVisitor.RunAsync(node, context).AnyContext();
         }
         catch (FormatException ex)
         {

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
+using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Parsers.LuceneQueries.Visitors;
 using Pegasus.Common;
 
@@ -8,9 +9,9 @@ namespace Foundatio.Parsers.LuceneQueries;
 
 public class QueryValidator
 {
-    public static Task<QueryValidationResult> ValidateQueryAsync(string query, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateQueryAsync(string query, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Query;
@@ -18,9 +19,9 @@ public class QueryValidator
         return InternalValidateAsync(query, context, options);
     }
 
-    public static Task<QueryValidationResult> ValidateAggregationsAsync(string aggregations, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateAggregationsAsync(string aggregations, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Aggregation;
@@ -28,9 +29,9 @@ public class QueryValidator
         return InternalValidateAsync(aggregations, context, options);
     }
 
-    public static Task<QueryValidationResult> ValidateSortAsync(string sort, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateSortAsync(string sort, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Sort;
@@ -38,40 +39,43 @@ public class QueryValidator
         return InternalValidateAsync(sort, context, options);
     }
 
-    private static async Task<QueryValidationResult> InternalValidateAsync(string query, IQueryVisitorContextWithValidation context, QueryValidationOptions options = null)
+    private static async Task<QueryValidationResult> InternalValidateAsync(string query, IQueryVisitorContextWithValidation context, QueryValidationOptions? options = null)
     {
         var parser = new LuceneQueryParser();
         try
         {
             var node = await parser.ParseAsync(query);
-            if (context == null)
+            if (context is null)
                 context = new QueryVisitorContext();
 
-            if (options != null)
+            if (node is null)
+                return context.GetValidationResult();
+
+            if (options is not null)
                 context.SetValidationOptions(options);
 
             var fieldResolver = context.GetFieldResolver();
-            if (fieldResolver != null)
-                node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver);
+            if (fieldResolver is not null)
+                node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver) ?? node;
 
             var includeResolver = context.GetIncludeResolver();
-            if (includeResolver != null)
-                node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
+            if (includeResolver is not null)
+                node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver) ?? node;
 
             return await ValidationVisitor.RunAsync(node, context);
         }
         catch (FormatException ex)
         {
             var cursor = ex.Data["cursor"] as Cursor;
-            context.AddValidationError(ex.Message, cursor.Column);
+            context.AddValidationError(ex.Message, cursor?.Column ?? 0);
 
             return context.GetValidationResult();
         }
     }
 
-    public static Task<QueryValidationResult> ValidateQueryAndThrowAsync(string query, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateQueryAndThrowAsync(string query, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Query;
@@ -79,9 +83,9 @@ public class QueryValidator
         return InternalValidateAndThrowAsync(query, context, options);
     }
 
-    public static Task<QueryValidationResult> ValidateAggregationsAndThrowAsync(string aggregations, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateAggregationsAndThrowAsync(string aggregations, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Aggregation;
@@ -89,9 +93,9 @@ public class QueryValidator
         return InternalValidateAndThrowAsync(aggregations, context, options);
     }
 
-    public static Task<QueryValidationResult> ValidateSortAndThrowAsync(string sort, QueryValidationOptions options = null, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> ValidateSortAndThrowAsync(string sort, QueryValidationOptions? options = null, IQueryVisitorContextWithValidation? context = null)
     {
-        if (context == null)
+        if (context is null)
             context = new QueryVisitorContext();
 
         context.QueryType = QueryTypes.Sort;
@@ -99,33 +103,46 @@ public class QueryValidator
         return InternalValidateAndThrowAsync(sort, context, options);
     }
 
-    private static async Task<QueryValidationResult> InternalValidateAndThrowAsync(string query, IQueryVisitorContextWithValidation context, QueryValidationOptions options = null)
+    private static async Task<QueryValidationResult> InternalValidateAndThrowAsync(string query, IQueryVisitorContextWithValidation context, QueryValidationOptions? options = null)
     {
         var parser = new LuceneQueryParser();
         try
         {
             var node = await parser.ParseAsync(query);
-            if (context == null)
+            if (context is null)
                 context = new QueryVisitorContext();
 
             options ??= new QueryValidationOptions();
             options.ShouldThrow = true;
             context.SetValidationOptions(options);
 
+            // Visitors never nullify a non-null root in practice; this guard satisfies NRT
+            // and produces a clear validation error if a visitor unexpectedly returns null.
+            IQueryNode EnsureNode(IQueryNode? node)
+            {
+                if (node is not null)
+                    return node;
+
+                var validationResult = context.GetValidationResult();
+                throw new QueryValidationException(validationResult.Message, validationResult);
+            }
+
+            node = EnsureNode(node);
+
             var fieldResolver = context.GetFieldResolver();
             if (fieldResolver != null)
-                node = await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver);
+                node = EnsureNode(await FieldResolverQueryVisitor.RunAsync(node, fieldResolver, context as IQueryVisitorContextWithFieldResolver));
 
             var includeResolver = context.GetIncludeResolver();
             if (includeResolver != null)
-                node = await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver);
+                node = EnsureNode(await IncludeVisitor.RunAsync(node, includeResolver, context as IQueryVisitorContextWithIncludeResolver));
 
             return await ValidationVisitor.RunAsync(node, context);
         }
         catch (FormatException ex)
         {
             var cursor = ex.Data["cursor"] as Cursor;
-            context.AddValidationError(ex.Message, cursor.Column);
+            context.AddValidationError(ex.Message, cursor?.Column ?? 0);
 
             throw new QueryValidationException(ex.Message, context.GetValidationResult(), ex);
         }

--- a/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/QueryValidator.cs
@@ -44,7 +44,7 @@ public class QueryValidator
         var parser = new LuceneQueryParser();
         try
         {
-            var node = await parser.ParseAsync(query);
+            var node = await parser.ParseAsync(query).AnyContext();
             if (context is null)
                 context = new QueryVisitorContext();
 
@@ -108,7 +108,7 @@ public class QueryValidator
         var parser = new LuceneQueryParser();
         try
         {
-            var node = await parser.ParseAsync(query);
+            var node = await parser.ParseAsync(query).AnyContext();
             if (context is null)
                 context = new QueryVisitorContext();
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
@@ -5,13 +5,13 @@ using Foundatio.Parsers.LuceneQueries.Nodes;
 
 namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
-public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode>, IChainableQueryVisitor
+public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, IChainableQueryVisitor
 {
     private readonly List<QueryVisitorWithPriority> _visitors = new();
-    private QueryVisitorWithPriority[] _frozenVisitors;
+    private QueryVisitorWithPriority[] _frozenVisitors = [];
     private bool _isDirty = true;
 
-    public void AddVisitor(IQueryNodeVisitorWithResult<IQueryNode> visitor, int priority = 0)
+    public void AddVisitor(IQueryNodeVisitorWithResult<IQueryNode?> visitor, int priority = 0)
     {
         AddVisitor(new QueryVisitorWithPriority
         {
@@ -75,14 +75,23 @@ public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode>, I
         _isDirty = true;
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
         if (_isDirty)
+        {
             _frozenVisitors = _visitors.OrderBy(v => v.Priority).ToArray();
+            _isDirty = false;
+        }
 
+        IQueryNode? current = node;
         foreach (var visitor in _frozenVisitors)
-            node = await visitor.AcceptAsync(node, context).ConfigureAwait(false);
+        {
+            if (current is null)
+                break;
 
-        return node;
+            current = await visitor.AcceptAsync(current, context).ConfigureAwait(false);
+        }
+
+        return current;
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ChainedQueryVisitor.cs
@@ -89,7 +89,7 @@ public class ChainedQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, 
             if (current is null)
                 break;
 
-            current = await visitor.AcceptAsync(current, context).ConfigureAwait(false);
+            current = await visitor.AcceptAsync(current, context).AnyContext();
         }
 
         return current;

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
 using Foundatio.Parsers.LuceneQueries.Nodes;
@@ -7,13 +7,15 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public class CleanupQueryVisitor : ChainableQueryVisitor
 {
-    public override async Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         var result = CleanNode(node);
-        if (result == null)
+        if (result is null)
             return null;
 
-        result = await base.VisitAsync(result, context);
+        result = await base.VisitAsync(result, context).ConfigureAwait(false);
+        if (result is null)
+            return null;
 
         return CleanNode(result);
     }
@@ -126,13 +128,14 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
         return node;
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static async Task<string?> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        var result = await new CleanupQueryVisitor().AcceptAsync(node, context);
-        return result.ToString();
+        context ??= new QueryVisitorContext();
+        var result = await new CleanupQueryVisitor().AcceptAsync(node, context).ConfigureAwait(false);
+        return result?.ToString();
     }
 
-    public static string Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static string? Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/CleanupQueryVisitor.cs
@@ -13,7 +13,7 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
         if (result is null)
             return null;
 
-        result = await base.VisitAsync(result, context).ConfigureAwait(false);
+        result = await base.VisitAsync(result, context).AnyContext();
         if (result is null)
             return null;
 
@@ -131,7 +131,7 @@ public class CleanupQueryVisitor : ChainableQueryVisitor
     public static async Task<string?> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
         context ??= new QueryVisitorContext();
-        var result = await new CleanupQueryVisitor().AcceptAsync(node, context).ConfigureAwait(false);
+        var result = await new CleanupQueryVisitor().AcceptAsync(node, context).AnyContext();
         return result?.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/DebugQueryVisitor.cs
@@ -1,4 +1,5 @@
-﻿using System.CodeDom.Compiler;
+﻿using System;
+using System.CodeDom.Compiler;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -135,12 +136,13 @@ public class DebugQueryVisitor : QueryNodeVisitorWithResultBase<string>
         return _builder.ToString();
     }
 
-    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext { DefaultOperator = GroupOperator.Default };
         return new DebugQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static string Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static string Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/FieldResolverQueryVisitor.cs
@@ -8,9 +8,9 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public class FieldResolverQueryVisitor : ChainableQueryVisitor
 {
-    private readonly QueryFieldResolver _globalResolver;
+    private readonly QueryFieldResolver? _globalResolver;
 
-    public FieldResolverQueryVisitor(QueryFieldResolver globalResolver = null)
+    public FieldResolverQueryVisitor(QueryFieldResolver? globalResolver = null)
     {
         _globalResolver = globalResolver;
     }
@@ -52,7 +52,7 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
 
         try
         {
-            string resolvedField = null;
+            string? resolvedField = null;
             if (contextResolver != null)
                 resolvedField = await contextResolver(node.Field, context).ConfigureAwait(false);
             if (resolvedField == null && _globalResolver != null)
@@ -80,88 +80,82 @@ public class FieldResolverQueryVisitor : ChainableQueryVisitor
         }
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
-    {
-        await node.AcceptAsync(this, context).ConfigureAwait(false);
-        return node;
-    }
-
-    public static Task<IQueryNode> RunAsync(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver context = null)
+    public static Task<IQueryNode?> RunAsync(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();
         context.SetFieldResolver(resolver);
         return new FieldResolverQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, Func<string, string> resolver, IQueryVisitorContextWithFieldResolver context = null)
+    public static Task<IQueryNode?> RunAsync(IQueryNode node, Func<string, string?> resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();
-        context.SetFieldResolver((field, _) => Task.FromResult(resolver(field)));
+        context.SetFieldResolver((field, _) => Task.FromResult<string?>(resolver(field)));
         return new FieldResolverQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static IQueryNode Run(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver context = null)
+    public static IQueryNode? Run(IQueryNode node, QueryFieldResolver resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         return RunAsync(node, resolver, context).GetAwaiter().GetResult();
     }
 
-    public static IQueryNode Run(IQueryNode node, Func<string, string> resolver, IQueryVisitorContextWithFieldResolver context = null)
+    public static IQueryNode? Run(IQueryNode node, Func<string, string?> resolver, IQueryVisitorContextWithFieldResolver? context = null)
     {
         return RunAsync(node, resolver, context).GetAwaiter().GetResult();
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver context = null)
+    public static Task<IQueryNode?> RunAsync(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver? context = null)
     {
         context ??= new QueryVisitorContext();
         context.SetFieldResolver(map.ToHierarchicalFieldResolver());
         return new FieldResolverQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static IQueryNode Run(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver context = null)
+    public static IQueryNode? Run(IQueryNode node, IDictionary<string, string> map, IQueryVisitorContextWithFieldResolver? context = null)
     {
         return RunAsync(node, map, context).GetAwaiter().GetResult();
     }
 }
 
-public delegate Task<string> QueryFieldResolver(string field, IQueryVisitorContext context);
+public delegate Task<string?> QueryFieldResolver(string field, IQueryVisitorContext? context);
 
 public class FieldMap : Dictionary<string, string> { }
 
 public static class FieldMapExtensions
 {
-    public static string GetValueOrNull(this IDictionary<string, string> map, string field)
+    public static string? GetValueOrNull(this IDictionary<string, string> map, string? field)
     {
         if (map == null || field == null)
             return null;
 
-        if (map.TryGetValue(field, out string value))
+        if (map.TryGetValue(field, out string? value))
             return value;
 
         return null;
     }
 
-    public static QueryFieldResolver ToHierarchicalFieldResolver(this IDictionary<string, string> map, string resultPrefix = null)
+    public static QueryFieldResolver ToHierarchicalFieldResolver(this IDictionary<string, string> map, string? resultPrefix = null)
     {
         return (field, _) =>
         {
             if (field == null)
-                return null;
+                return Task.FromResult<string?>(null);
 
-            if (map.TryGetValue(field, out string result))
-                return Task.FromResult($"{resultPrefix}{result}");
+            if (map.TryGetValue(field, out string? result))
+                return Task.FromResult<string?>($"{resultPrefix}{result}");
 
             // start at the longest path and go backwards until we find a match in the map
             int currentPart = field.LastIndexOf('.');
             while (currentPart > 0)
             {
                 string currentName = field.Substring(0, currentPart);
-                if (map.TryGetValue(currentName, out string currentResult))
-                    return Task.FromResult($"{resultPrefix}{currentResult}{field.Substring(currentPart)}");
+                if (map.TryGetValue(currentName, out string? currentResult))
+                    return Task.FromResult<string?>($"{resultPrefix}{currentResult}{field.Substring(currentPart)}");
 
                 currentPart = field.LastIndexOf('.', currentPart - 1);
             }
 
-            return Task.FromResult(field);
+            return Task.FromResult<string?>(field);
         };
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GenerateQueryVisitor.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+using System;
+using System.Text;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 
@@ -10,7 +11,7 @@ public class GenerateQueryVisitor : QueryNodeVisitorWithResultBase<string>
 
     public override Task VisitAsync(GroupNode node, IQueryVisitorContext context)
     {
-        _builder.Append(node.ToString(context != null ? context.DefaultOperator : GroupOperator.Default));
+        _builder.Append(node.ToString(context?.DefaultOperator ?? GroupOperator.Default));
 
         return Task.CompletedTask;
     }
@@ -41,12 +42,13 @@ public class GenerateQueryVisitor : QueryNodeVisitorWithResultBase<string>
         return _builder.ToString();
     }
 
-    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext { DefaultOperator = GroupOperator.Default };
         return new GenerateQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static string Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static string Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/GetReferencedFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/GetReferencedFieldsQueryVisitor.cs
@@ -14,12 +14,13 @@ public class GetReferencedFieldsQueryVisitor : QueryNodeVisitorWithResultBase<IS
         return Task.FromResult(node.GetReferencedFields(context));
     }
 
-    public static Task<ISet<string>> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task<ISet<string>> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext();
         return new GetReferencedFieldsQueryVisitor().AcceptAsync(node, context);
     }
 
-    public static ISet<string> Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static ISet<string> Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IChainableQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IChainableQueryVisitor.cs
@@ -8,4 +8,4 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 /// <remarks>
 /// Use <see cref="ChainedQueryVisitor"/> to combine multiple chainable visitors.
 /// </remarks>
-public interface IChainableQueryVisitor : IQueryNodeVisitorWithResult<IQueryNode> { }
+public interface IChainableQueryVisitor : IQueryNodeVisitorWithResult<IQueryNode?> { }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryNodeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryNodeVisitor.cs
@@ -16,6 +16,6 @@ public interface IQueryNodeVisitor
     /// </summary>
     /// <param name="node">The node to visit.</param>
     /// <param name="context">The visitor context containing traversal state.</param>
-    /// <returns>The visited node, potentially transformed.</returns>
-    Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context);
+    /// <returns>The visited node, potentially transformed. Returns null to signal node removal.</returns>
+    Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context);
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContext.cs
@@ -16,7 +16,7 @@ public interface IQueryVisitorContext
     /// <summary>
     /// The default fields to search when no field is specified in a term.
     /// </summary>
-    string[] DefaultFields { get; set; }
+    string[]? DefaultFields { get; set; }
 
     /// <summary>
     /// The type of query being processed (query, aggregation, sort).

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithFieldResolver.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithFieldResolver.cs
@@ -11,5 +11,5 @@ public interface IQueryVisitorContextWithFieldResolver : IQueryVisitorContext
     /// <summary>
     /// Resolves field names to their actual storage names or aliases.
     /// </summary>
-    QueryFieldResolver FieldResolver { get; set; }
+    QueryFieldResolver? FieldResolver { get; set; }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithIncludeResolver.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithIncludeResolver.cs
@@ -11,5 +11,5 @@ public interface IQueryVisitorContextWithIncludeResolver : IQueryVisitorContext
     /// <summary>
     /// Resolves include names to their query string definitions.
     /// </summary>
-    IncludeResolver IncludeResolver { get; set; }
+    IncludeResolver? IncludeResolver { get; set; }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithValidation.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IQueryVisitorContextWithValidation.cs
@@ -8,10 +8,10 @@ public interface IQueryVisitorContextWithValidation : IQueryVisitorContext
     /// <summary>
     /// Configuration options controlling validation behavior.
     /// </summary>
-    QueryValidationOptions ValidationOptions { get; set; }
+    QueryValidationOptions? ValidationOptions { get; set; }
 
     /// <summary>
     /// The validation results populated after validation completes.
     /// </summary>
-    QueryValidationResult ValidationResult { get; set; }
+    QueryValidationResult? ValidationResult { get; set; }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
@@ -7,22 +7,25 @@ using Foundatio.Parsers.LuceneQueries.Nodes;
 namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public delegate bool ShouldSkipIncludeFunc(TermNode node, IQueryVisitorContext context);
-public delegate Task<string> IncludeResolver(string name);
+public delegate Task<string?> IncludeResolver(string name);
 
 public class IncludeVisitor : ChainableMutatingQueryVisitor
 {
     private readonly LuceneQueryParser _parser = new();
-    private readonly ShouldSkipIncludeFunc _shouldSkipInclude;
+    private readonly ShouldSkipIncludeFunc? _shouldSkipInclude;
     private readonly string _includeName;
 
-    public IncludeVisitor(ShouldSkipIncludeFunc shouldSkipInclude = null, string includeName = "include")
+    public IncludeVisitor(ShouldSkipIncludeFunc? shouldSkipInclude = null, string includeName = "include")
     {
         _shouldSkipInclude = shouldSkipInclude;
         _includeName = includeName;
     }
 
-    public override async Task<IQueryNode> VisitAsync(TermNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode?> VisitAsync(TermNode node, IQueryVisitorContext context)
     {
+        if (String.IsNullOrEmpty(node.Term))
+            return node;
+
         if (node.Field != "@" + _includeName || (_shouldSkipInclude != null && _shouldSkipInclude(node, context)))
             return node;
 
@@ -42,7 +45,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
 
         try
         {
-            string includedQuery = await includeResolver(node.Term).ConfigureAwait(false);
+            string? includedQuery = await includeResolver(node.Term).ConfigureAwait(false);
             if (includedQuery == null)
             {
                 context.AddValidationError($"Unresolved {_includeName} ({node.Term})");
@@ -54,7 +57,9 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
 
             includeStack.Push(node.Term);
 
-            var result = (GroupNode)await _parser.ParseAsync(includedQuery).ConfigureAwait(false);
+            var parsed = await _parser.ParseAsync(includedQuery).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"Parser returned null for included query: {includedQuery}");
+            var result = (GroupNode)parsed;
             result.HasParens = true;
             await VisitAsync(result, context).ConfigureAwait(false);
 
@@ -71,7 +76,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
         }
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver context = null, ShouldSkipIncludeFunc shouldSkipInclude = null)
+    public static Task<IQueryNode?> RunAsync(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         context ??= new QueryVisitorContext();
         context.SetIncludeResolver(includeResolver);
@@ -79,22 +84,22 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
         return new IncludeVisitor(shouldSkipInclude).AcceptAsync(node, context);
     }
 
-    public static IQueryNode Run(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver context = null, ShouldSkipIncludeFunc shouldSkipInclude = null)
+    public static IQueryNode? Run(IQueryNode node, IncludeResolver includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         return RunAsync(node, includeResolver, context, shouldSkipInclude).GetAwaiter().GetResult();
     }
 
-    public static IQueryNode Run(IQueryNode node, Func<string, string> includeResolver, IQueryVisitorContextWithIncludeResolver context = null, ShouldSkipIncludeFunc shouldSkipInclude = null)
+    public static IQueryNode? Run(IQueryNode node, Func<string, string?> includeResolver, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
-        return RunAsync(node, name => Task.FromResult(includeResolver(name)), context, shouldSkipInclude).GetAwaiter().GetResult();
+        return RunAsync(node, name => Task.FromResult<string?>(includeResolver(name)), context, shouldSkipInclude).GetAwaiter().GetResult();
     }
 
-    public static Task<IQueryNode> RunAsync(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver context = null, ShouldSkipIncludeFunc shouldSkipInclude = null)
+    public static Task<IQueryNode?> RunAsync(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
-        return RunAsync(node, name => Task.FromResult(includes.ContainsKey(name) ? includes[name] : null), context, shouldSkipInclude);
+        return RunAsync(node, name => Task.FromResult<string?>(includes.TryGetValue(name, out var include) ? include : null), context, shouldSkipInclude);
     }
 
-    public static IQueryNode Run(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver context = null, ShouldSkipIncludeFunc shouldSkipInclude = null)
+    public static IQueryNode? Run(IQueryNode node, IDictionary<string, string> includes, IQueryVisitorContextWithIncludeResolver? context = null, ShouldSkipIncludeFunc? shouldSkipInclude = null)
     {
         return RunAsync(node, includes, context, shouldSkipInclude).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/IncludeVisitor.cs
@@ -45,7 +45,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
 
         try
         {
-            string? includedQuery = await includeResolver(node.Term).ConfigureAwait(false);
+            string? includedQuery = await includeResolver(node.Term).AnyContext();
             if (includedQuery == null)
             {
                 context.AddValidationError($"Unresolved {_includeName} ({node.Term})");
@@ -57,7 +57,7 @@ public class IncludeVisitor : ChainableMutatingQueryVisitor
 
             includeStack.Push(node.Term);
 
-            var parsed = await _parser.ParseAsync(includedQuery).ConfigureAwait(false)
+            var parsed = await _parser.ParseAsync(includedQuery).AnyContext()
                 ?? throw new InvalidOperationException($"Parser returned null for included query: {includedQuery}");
             var result = (GroupNode)parsed;
             result.HasParens = true;

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -9,7 +9,7 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 
 public class InvertQueryVisitor : ChainableMutatingQueryVisitor
 {
-    public InvertQueryVisitor(IEnumerable<string> nonInvertedFields = null)
+    public InvertQueryVisitor(IEnumerable<string>? nonInvertedFields = null)
     {
         if (nonInvertedFields != null)
             NonInvertedFields.AddRange(nonInvertedFields);
@@ -17,7 +17,7 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
 
     public List<string> NonInvertedFields { get; } = new List<string>();
 
-    public override Task<IQueryNode> VisitAsync(GroupNode node, IQueryVisitorContext context)
+    public override Task<IQueryNode?> VisitAsync(GroupNode node, IQueryVisitorContext context)
     {
         bool onlyNonInvertedFields = node.GetReferencedFields().All(f => NonInvertedFields.Contains(f, StringComparer.OrdinalIgnoreCase));
         bool hasNonInvertedFields = node.GetReferencedFields().Any(f => NonInvertedFields.Contains(f, StringComparer.OrdinalIgnoreCase));
@@ -25,12 +25,15 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
 
         // don't invert groups that only contain non-inverted fields
         if (onlyNonInvertedFields)
-            return Task.FromResult<IQueryNode>(node);
+            return Task.FromResult<IQueryNode?>(node);
 
         if (onlyInvertedFields)
         {
             // invert, don't visit children
-            node = node.InvertNegation() as GroupNode;
+            if (node.InvertNegation() is GroupNode inverted)
+                node = inverted;
+            else
+                throw new InvalidOperationException($"InvertNegation on a GroupNode returned an unexpected type: {node.GetType().Name}");
 
             var alternateInvertedCriteria = context.GetAlternateInvertedCriteria();
             if (alternateInvertedCriteria != null)
@@ -42,14 +45,14 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
                     HasParens = true
                 });
 
-            return Task.FromResult<IQueryNode>(node);
+            return Task.FromResult<IQueryNode?>(node);
         }
 
         // otherwise, continue visiting children and invert them
         return base.VisitAsync(node, context);
     }
 
-    public override Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public override Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         if (context.DefaultOperator == GroupOperator.Or)
             throw new ArgumentException("Queries using OR as the default operator can not be inverted.");
@@ -58,7 +61,7 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
             return VisitAsync(groupNode, context);
 
         if (node is IFieldQueryNode fieldNode && NonInvertedFields.Contains(fieldNode.Field, StringComparer.OrdinalIgnoreCase))
-            return Task.FromResult(node);
+            return Task.FromResult<IQueryNode?>(node);
 
         node = node.InvertNegation();
 
@@ -72,21 +75,17 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
                 HasParens = true
             });
 
-        return Task.FromResult(node);
+        return Task.FromResult<IQueryNode?>(node);
     }
 
-    public override Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        return node.AcceptAsync(this, context);
-    }
-
-    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string> nonInvertedFields = null, IQueryVisitorContext context = null)
-    {
+        context ??= new QueryVisitorContext();
         var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
-        return result.ToString();
+        return result?.ToString();
     }
 
-    public static string Run(IQueryNode node, IEnumerable<string> nonInvertedFields = null, IQueryVisitorContext context = null)
+    public static string? Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, nonInvertedFields, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/InvertQueryVisitor.cs
@@ -81,7 +81,7 @@ public class InvertQueryVisitor : ChainableMutatingQueryVisitor
     public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
         context ??= new QueryVisitorContext();
-        var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
+        var result = await new InvertQueryVisitor(nonInvertedFields).AcceptAsync(node, context).AnyContext();
         return result?.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorBase.cs
@@ -43,7 +43,7 @@ public abstract class QueryNodeVisitorBase : IQueryNodeVisitor
         return Task.CompletedTask;
     }
 
-    public virtual async Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public virtual async Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         if (node is GroupNode groupNode)
         {
@@ -81,7 +81,7 @@ public abstract class QueryNodeVisitorBase : IQueryNodeVisitor
 
 public abstract class MutatingQueryNodeVisitorBase : IQueryNodeVisitor
 {
-    public virtual async Task<IQueryNode> VisitAsync(GroupNode node, IQueryVisitorContext context)
+    public virtual async Task<IQueryNode?> VisitAsync(GroupNode node, IQueryVisitorContext context)
     {
         foreach (var child in node.Children)
             await VisitAsync(child, context).ConfigureAwait(false);
@@ -91,33 +91,33 @@ public abstract class MutatingQueryNodeVisitorBase : IQueryNodeVisitor
 
     public virtual IQueryNode Visit(TermNode node, IQueryVisitorContext context) => node;
 
-    public virtual Task<IQueryNode> VisitAsync(TermNode node, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> VisitAsync(TermNode node, IQueryVisitorContext context)
     {
-        return Task.FromResult(Visit(node, context));
+        return Task.FromResult<IQueryNode?>(Visit(node, context));
     }
 
     public virtual IQueryNode Visit(TermRangeNode node, IQueryVisitorContext context) => node;
 
-    public virtual Task<IQueryNode> VisitAsync(TermRangeNode node, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> VisitAsync(TermRangeNode node, IQueryVisitorContext context)
     {
-        return Task.FromResult(Visit(node, context));
+        return Task.FromResult<IQueryNode?>(Visit(node, context));
     }
 
     public virtual IQueryNode Visit(ExistsNode node, IQueryVisitorContext context) => node;
 
-    public virtual Task<IQueryNode> VisitAsync(ExistsNode node, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> VisitAsync(ExistsNode node, IQueryVisitorContext context)
     {
-        return Task.FromResult(Visit(node, context));
+        return Task.FromResult<IQueryNode?>(Visit(node, context));
     }
 
     public virtual IQueryNode Visit(MissingNode node, IQueryVisitorContext context) => node;
 
-    public virtual Task<IQueryNode> VisitAsync(MissingNode node, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> VisitAsync(MissingNode node, IQueryVisitorContext context)
     {
-        return Task.FromResult(Visit(node, context));
+        return Task.FromResult<IQueryNode?>(Visit(node, context));
     }
 
-    public virtual Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public virtual Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         if (node is GroupNode groupNode)
             return VisitAsync(groupNode, context);
@@ -134,6 +134,6 @@ public abstract class MutatingQueryNodeVisitorBase : IQueryNodeVisitor
         if (node is ExistsNode existsNode)
             return VisitAsync(existsNode, context);
 
-        return Task.FromResult(node);
+        return Task.FromResult<IQueryNode?>(node);
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryNodeVisitorWithResultBase.cs
@@ -13,18 +13,18 @@ public abstract class MutatingQueryNodeVisitorWithResultBase<T> : MutatingQueryN
     public abstract Task<T> AcceptAsync(IQueryNode node, IQueryVisitorContext context);
 }
 
-public abstract class ChainableQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode>, IChainableQueryVisitor
+public abstract class ChainableQueryVisitor : QueryNodeVisitorWithResultBase<IQueryNode?>, IChainableQueryVisitor
 {
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
         var result = await node.AcceptAsync(this, context).ConfigureAwait(false);
         return result;
     }
 }
 
-public abstract class ChainableMutatingQueryVisitor : MutatingQueryNodeVisitorWithResultBase<IQueryNode>, IChainableQueryVisitor
+public abstract class ChainableMutatingQueryVisitor : MutatingQueryNodeVisitorWithResultBase<IQueryNode?>, IChainableQueryVisitor
 {
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
         var result = await node.AcceptAsync(this, context).ConfigureAwait(false);
         return result;

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/QueryVisitorContext.cs
@@ -6,11 +6,11 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 public class QueryVisitorContext : IQueryVisitorContext, IQueryVisitorContextWithFieldResolver, IQueryVisitorContextWithIncludeResolver, IQueryVisitorContextWithValidation
 {
     public GroupOperator DefaultOperator { get; set; } = GroupOperator.And;
-    public string[] DefaultFields { get; set; }
+    public string[]? DefaultFields { get; set; }
     public string QueryType { get; set; } = QueryTypes.Query;
     public IDictionary<string, object> Data { get; } = new Dictionary<string, object>();
-    public QueryFieldResolver FieldResolver { get; set; }
-    public IncludeResolver IncludeResolver { get; set; }
-    public QueryValidationOptions ValidationOptions { get; set; }
-    public QueryValidationResult ValidationResult { get; set; }
+    public QueryFieldResolver? FieldResolver { get; set; }
+    public IncludeResolver? IncludeResolver { get; set; }
+    public QueryValidationOptions? ValidationOptions { get; set; }
+    public QueryValidationResult? ValidationResult { get; set; }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -40,14 +40,14 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
     public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
     {
         context ??= new QueryVisitorContext();
-        var result = await new RemoveFieldsQueryVisitor(fieldsToRemove ?? []).AcceptAsync(node, context).ConfigureAwait(false);
+        var result = await new RemoveFieldsQueryVisitor(fieldsToRemove ?? []).AcceptAsync(node, context).AnyContext();
         return result?.ToString();
     }
 
     public static async Task<string?> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
         context ??= new QueryVisitorContext();
-        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context).ConfigureAwait(false);
+        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context).AnyContext();
         return result?.ToString();
     }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,8 +11,7 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
 {
     public RemoveFieldsQueryVisitor(IEnumerable<string> fieldsToRemove)
     {
-        if (fieldsToRemove == null)
-            throw new ArgumentNullException(nameof(fieldsToRemove));
+        ArgumentNullException.ThrowIfNull(fieldsToRemove);
 
         string[] fieldsToRemoveList = fieldsToRemove.ToArray();
         ShouldRemoveField = f => fieldsToRemoveList.Contains(f, StringComparer.OrdinalIgnoreCase);
@@ -20,49 +19,44 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
 
     public RemoveFieldsQueryVisitor(Func<string, bool> shouldRemoveFieldFunc)
     {
-        if (shouldRemoveFieldFunc == null)
-            throw new ArgumentNullException(nameof(shouldRemoveFieldFunc));
+        ArgumentNullException.ThrowIfNull(shouldRemoveFieldFunc);
 
         ShouldRemoveField = shouldRemoveFieldFunc;
     }
 
     public Func<string, bool> ShouldRemoveField { get; }
 
-    public override Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public override Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
-        if (node is IFieldQueryNode fieldNode && fieldNode.Field != null && ShouldRemoveField(fieldNode.Field))
+        if (node is IFieldQueryNode fieldNode && fieldNode.Field is not null && ShouldRemoveField(fieldNode.Field))
         {
             node.RemoveSelf();
-            return Task.FromResult<IQueryNode>(null);
+            return Task.FromResult<IQueryNode?>(null);
         }
 
         return base.VisitAsync(node, context);
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        await node.AcceptAsync(this, context);
-        return node;
+        context ??= new QueryVisitorContext();
+        var result = await new RemoveFieldsQueryVisitor(nonInvertedFields ?? []).AcceptAsync(node, context).ConfigureAwait(false);
+        return result?.ToString();
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, IEnumerable<string> nonInvertedFields = null, IQueryVisitorContext context = null)
+    public static async Task<string?> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
-        var result = await new RemoveFieldsQueryVisitor(nonInvertedFields).AcceptAsync(node, context);
-        return result.ToString();
+        context ??= new QueryVisitorContext();
+        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context).ConfigureAwait(false);
+        return result?.ToString();
     }
 
-    public static async Task<string> RunAsync(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext context = null)
+    public static string? Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        var result = await new RemoveFieldsQueryVisitor(shouldRemoveFieldFunc).AcceptAsync(node, context);
-        return result.ToString();
+        return RunAsync(node, nonInvertedFields ?? [], context).GetAwaiter().GetResult();
     }
 
-    public static string Run(IQueryNode node, IEnumerable<string> nonInvertedFields = null, IQueryVisitorContext context = null)
-    {
-        return RunAsync(node, nonInvertedFields, context).GetAwaiter().GetResult();
-    }
-
-    public static string Run(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext context = null)
+    public static string? Run(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, shouldRemoveFieldFunc, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -37,10 +37,10 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return base.VisitAsync(node, context);
     }
 
-    public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
+    public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
     {
         context ??= new QueryVisitorContext();
-        var result = await new RemoveFieldsQueryVisitor(nonInvertedFields ?? []).AcceptAsync(node, context).ConfigureAwait(false);
+        var result = await new RemoveFieldsQueryVisitor(fieldsToRemove ?? []).AcceptAsync(node, context).ConfigureAwait(false);
         return result?.ToString();
     }
 
@@ -51,9 +51,9 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return result?.ToString();
     }
 
-    public static string? Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
+    public static string? Run(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
     {
-        return RunAsync(node, nonInvertedFields ?? [], context).GetAwaiter().GetResult();
+        return RunAsync(node, fieldsToRemove ?? [], context).GetAwaiter().GetResult();
     }
 
     public static string? Run(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -37,10 +37,10 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return base.VisitAsync(node, context);
     }
 
-    public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
+    public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
         context ??= new QueryVisitorContext();
-        var result = await new RemoveFieldsQueryVisitor(fieldsToRemove ?? []).AcceptAsync(node, context).AnyContext();
+        var result = await new RemoveFieldsQueryVisitor(nonInvertedFields ?? []).AcceptAsync(node, context).AnyContext();
         return result?.ToString();
     }
 
@@ -51,9 +51,9 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return result?.ToString();
     }
 
-    public static string? Run(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
+    public static string? Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
     {
-        return RunAsync(node, fieldsToRemove ?? [], context).GetAwaiter().GetResult();
+        return RunAsync(node, nonInvertedFields ?? [], context).GetAwaiter().GetResult();
     }
 
     public static string? Run(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/RemoveFieldsQueryVisitor.cs
@@ -37,10 +37,10 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return base.VisitAsync(node, context);
     }
 
-    public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
+    public static async Task<string?> RunAsync(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
     {
         context ??= new QueryVisitorContext();
-        var result = await new RemoveFieldsQueryVisitor(nonInvertedFields ?? []).AcceptAsync(node, context).AnyContext();
+        var result = await new RemoveFieldsQueryVisitor(fieldsToRemove ?? []).AcceptAsync(node, context).AnyContext();
         return result?.ToString();
     }
 
@@ -51,9 +51,9 @@ public class RemoveFieldsQueryVisitor : ChainableQueryVisitor
         return result?.ToString();
     }
 
-    public static string? Run(IQueryNode node, IEnumerable<string>? nonInvertedFields = null, IQueryVisitorContext? context = null)
+    public static string? Run(IQueryNode node, IEnumerable<string>? fieldsToRemove = null, IQueryVisitorContext? context = null)
     {
-        return RunAsync(node, nonInvertedFields ?? [], context).GetAwaiter().GetResult();
+        return RunAsync(node, fieldsToRemove ?? [], context).GetAwaiter().GetResult();
     }
 
     public static string? Run(IQueryNode node, Func<string, bool> shouldRemoveFieldFunc, IQueryVisitorContext? context = null)

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/TermToFieldVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/TermToFieldVisitor.cs
@@ -15,12 +15,13 @@ public class TermToFieldVisitor : ChainableQueryVisitor
         node.Term = null;
     }
 
-    public static Task RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new QueryVisitorContext();
         return new TermToFieldVisitor().AcceptAsync(node, context);
     }
 
-    public static void Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static void Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -68,11 +68,13 @@ public class ValidationVisitor : ChainableQueryVisitor
             if (node.Field.StartsWith("@"))
                 return;
 
-            validationResult.ReferencedFields.Add(node.GetOriginalField());
+            var originalField = node.GetOriginalField();
+            if (originalField is not null)
+                validationResult.ReferencedFields.Add(originalField);
         }
         else
         {
-            string[] fields = node.GetDefaultFields(context.DefaultFields);
+            string[]? fields = node.GetDefaultFields(context.DefaultFields);
             if (fields == null || fields.Length == 0)
                 validationResult.ReferencedFields.Add("");
             else
@@ -81,7 +83,7 @@ public class ValidationVisitor : ChainableQueryVisitor
         }
     }
 
-    private void AddOperation(QueryValidationResult info, string operation, string field)
+    private void AddOperation(QueryValidationResult info, string? operation, string? field)
     {
         if (String.IsNullOrEmpty(operation))
             return;
@@ -89,7 +91,7 @@ public class ValidationVisitor : ChainableQueryVisitor
         info.AddOperation(operation, field);
     }
 
-    public override async Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
         await node.AcceptAsync(this, context).ConfigureAwait(false);
         var validationResult = context.GetValidationResult();
@@ -110,8 +112,8 @@ public class ValidationVisitor : ChainableQueryVisitor
             var restrictedFields = new List<string>();
             foreach (string field in options.RestrictedFields)
             {
-                string resolvedField = fieldResolver == null ? field : await fieldResolver(field, context);
-                if (result.ReferencedFields.Any(f => !String.IsNullOrEmpty(f) && (resolvedField.Equals(f) || field.Equals(f))))
+                string? resolvedField = fieldResolver is null ? field : await fieldResolver(field, context);
+                if (result.ReferencedFields.Any(f => !String.IsNullOrEmpty(f) && (resolvedField?.Equals(f) is true || field.Equals(f))))
                     restrictedFields.Add(field);
             }
             if (restrictedFields.Count > 0)
@@ -160,7 +162,7 @@ public class ValidationVisitor : ChainableQueryVisitor
             throw new QueryValidationException($"Invalid query: {result.Message}", result);
     }
 
-    public static async Task<QueryValidationResult> RunAsync(IQueryNode node, IQueryVisitorContextWithValidation context = null)
+    public static async Task<QueryValidationResult> RunAsync(IQueryNode node, IQueryVisitorContextWithValidation? context = null)
     {
         context ??= new QueryVisitorContext();
 
@@ -175,12 +177,12 @@ public class ValidationVisitor : ChainableQueryVisitor
         return context.GetValidationResult();
     }
 
-    public static QueryValidationResult Run(IQueryNode node, IQueryVisitorContextWithValidation context = null)
+    public static QueryValidationResult Run(IQueryNode node, IQueryVisitorContextWithValidation? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }
 
-    public static async Task<QueryValidationResult> RunAsync(IQueryNode node, QueryValidationOptions options, IQueryVisitorContextWithValidation context = null)
+    public static async Task<QueryValidationResult> RunAsync(IQueryNode node, QueryValidationOptions options, IQueryVisitorContextWithValidation? context = null)
     {
         context ??= new QueryVisitorContext();
 
@@ -192,7 +194,7 @@ public class ValidationVisitor : ChainableQueryVisitor
         return validationResult;
     }
 
-    public static Task<QueryValidationResult> RunAsync(IQueryNode node, IEnumerable<string> allowedFields, IQueryVisitorContextWithValidation context = null)
+    public static Task<QueryValidationResult> RunAsync(IQueryNode node, IEnumerable<string> allowedFields, IQueryVisitorContextWithValidation? context = null)
     {
         var options = new QueryValidationOptions();
         foreach (string field in allowedFields)
@@ -200,7 +202,7 @@ public class ValidationVisitor : ChainableQueryVisitor
         return RunAsync(node, options, context);
     }
 
-    public static QueryValidationResult Run(IQueryNode node, IEnumerable<string> allowedFields, IQueryVisitorContextWithValidation context = null)
+    public static QueryValidationResult Run(IQueryNode node, IEnumerable<string> allowedFields, IQueryVisitorContextWithValidation? context = null)
     {
         return RunAsync(node, allowedFields, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/ValidationVisitor.cs
@@ -112,7 +112,7 @@ public class ValidationVisitor : ChainableQueryVisitor
             var restrictedFields = new List<string>();
             foreach (string field in options.RestrictedFields)
             {
-                string? resolvedField = fieldResolver is null ? field : await fieldResolver(field, context);
+                string? resolvedField = fieldResolver is null ? field : await fieldResolver(field, context).AnyContext();
                 if (result.ReferencedFields.Any(f => !String.IsNullOrEmpty(f) && (resolvedField?.Equals(f) is true || field.Equals(f))))
                     restrictedFields.Add(field);
             }

--- a/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Visitors/VisitorWithPriority.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
@@ -9,22 +9,31 @@ namespace Foundatio.Parsers.LuceneQueries.Visitors;
 public class QueryVisitorWithPriority : IChainableQueryVisitor
 {
     public int Priority { get; set; }
-    public IQueryNodeVisitorWithResult<IQueryNode> Visitor { get; set; }
+    public required IQueryNodeVisitorWithResult<IQueryNode?> Visitor { get; set; }
 
-    public Task<IQueryNode> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    public Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
         return Visitor.AcceptAsync(node, context);
     }
 
-    public Task<IQueryNode> VisitAsync(IQueryNode node, IQueryVisitorContext context)
+    public Task<IQueryNode?> VisitAsync(IQueryNode node, IQueryVisitorContext context)
     {
         return Visitor.VisitAsync(node, context);
     }
 
     public class PriorityComparer : IComparer<QueryVisitorWithPriority>
     {
-        public int Compare(QueryVisitorWithPriority x, QueryVisitorWithPriority y)
+        public int Compare(QueryVisitorWithPriority? x, QueryVisitorWithPriority? y)
         {
+            if (ReferenceEquals(x, y))
+                return 0;
+
+            if (x is null)
+                return -1;
+
+            if (y is null)
+                return 1;
+
             return x.Priority.CompareTo(y.Priority);
         }
 

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -294,7 +294,7 @@ public static class SqlNodeExtensions
                 builder.Append(argumentPrefix);
                 builder.Append(field.Name);
                 builder.Append(".Contains(");
-                AppendField(builder, field, node.Term, context);
+                AppendField(builder, field, node.Term.Trim('*'), context);
                 builder.Append(")");
             }
 
@@ -317,8 +317,8 @@ public static class SqlNodeExtensions
             {
                 builder.Append(argumentPrefix);
                 builder.Append(field.Name);
-                builder.Append(".Contains(");
-                AppendField(builder, field, node.Term, context);
+                builder.Append(".StartsWith(");
+                AppendField(builder, field, node.Term.TrimEnd('*'), context);
                 builder.Append(")");
             }
 

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Foundatio.Parsers.LuceneQueries.Extensions;
@@ -13,7 +14,7 @@ public static class SqlNodeExtensions
     public static string ToDynamicLinqString(this GroupNode node, ISqlQueryVisitorContext context)
     {
         // support overriding the generated query
-        if (node.TryGetQuery(out string query))
+        if (node.TryGetQuery(out string? query))
             return query;
 
         if (node.Left == null && node.Right == null)
@@ -67,7 +68,7 @@ public static class SqlNodeExtensions
             context.AddValidationError("Field is required for exists node queries.");
 
         // support overriding the generated query
-        if (node.TryGetQuery(out string query))
+        if (node.TryGetQuery(out string? query))
             return query;
 
         var field = GetFieldInfo(context.Fields, node.Field);
@@ -95,7 +96,7 @@ public static class SqlNodeExtensions
             context.AddValidationError("Prefix is not supported for term range queries.");
 
         // support overriding the generated query
-        if (node.TryGetQuery(out string query))
+        if (node.TryGetQuery(out string? query))
             return query;
 
         var field = GetFieldInfo(context.Fields, node.Field);
@@ -113,13 +114,16 @@ public static class SqlNodeExtensions
         return builder.ToString();
     }
 
-    public static string ToDynamicLinqString(this TermNode node, ISqlQueryVisitorContext context)
+    public static string? ToDynamicLinqString(this TermNode node, ISqlQueryVisitorContext context)
     {
         if (!String.IsNullOrEmpty(node.Prefix))
             context.AddValidationError("Prefix is not supported for term range queries.");
 
+        if (node.Term is null)
+            return null;
+
         // support overriding the generated query
-        if (node.TryGetQuery(out string query))
+        if (node.TryGetQuery(out string? query))
             return query;
 
         var builder = new StringBuilder();
@@ -147,7 +151,7 @@ public static class SqlNodeExtensions
                     fieldTerms[fieldInfo] = searchTerm;
                 }
 
-                context.SearchTokenizer.Invoke(searchTerm);
+                context.SearchTokenizer?.Invoke(searchTerm);
                 if (searchTerm.Tokens == null)
                     searchTerm.Tokens = [searchTerm.Term];
                 else
@@ -190,7 +194,7 @@ public static class SqlNodeExtensions
 
                         builder.Append(scopePrefix);
 
-                        if (context.FullTextFields.Contains(kvp.Key.FullName, StringComparer.OrdinalIgnoreCase))
+                        if (context.FullTextFields?.Contains(kvp.Key.FullName, StringComparer.OrdinalIgnoreCase) is true)
                         {
                             builder.Append("FTS.Contains(");
                             builder.Append(argumentPrefix);
@@ -220,7 +224,7 @@ public static class SqlNodeExtensions
                         builder.Append(i.IsFirst ? "(" : " OR ");
                         builder.Append(scopePrefix);
 
-                        if (context.FullTextFields.Contains(kvp.Key.FullName, StringComparer.OrdinalIgnoreCase))
+                        if (context.FullTextFields?.Contains(kvp.Key.FullName, StringComparer.OrdinalIgnoreCase) is true)
                         {
                             builder.Append("FTS.Contains(");
                             builder.Append(argumentPrefix);
@@ -276,7 +280,7 @@ public static class SqlNodeExtensions
         {
             builder.Append(scopePrefix);
 
-            if (context.FullTextFields.Contains(field.FullName, StringComparer.OrdinalIgnoreCase))
+            if (context.FullTextFields?.Contains(field.FullName, StringComparer.OrdinalIgnoreCase) is true)
             {
                 builder.Append("FTS.Contains(");
                 builder.Append(argumentPrefix);
@@ -300,7 +304,7 @@ public static class SqlNodeExtensions
         {
             builder.Append(scopePrefix);
 
-            if (context.FullTextFields.Contains(field.FullName, StringComparer.OrdinalIgnoreCase))
+            if (context.FullTextFields?.Contains(field.FullName, StringComparer.OrdinalIgnoreCase) is true)
             {
                 builder.Append("FTS.Contains(");
                 builder.Append(argumentPrefix);
@@ -334,7 +338,7 @@ public static class SqlNodeExtensions
             context.AddValidationError("Proximity is not supported for term range queries.");
 
         // support overriding the generated query
-        if (node.TryGetQuery(out string query))
+        if (node.TryGetQuery(out string? query))
             return query;
 
         var field = GetFieldInfo(context.Fields, node.Field);
@@ -357,7 +361,7 @@ public static class SqlNodeExtensions
             builder.Append(scopePrefix);
             builder.Append(argumentPrefix);
             builder.Append(field.Name);
-            builder.Append(node.MinInclusive == true ? " >= " : " > ");
+            builder.Append(node.MinInclusive is true ? " >= " : " > ");
             AppendField(builder, field, node.Min, context);
             builder.Append(fieldSuffix);
         }
@@ -370,7 +374,7 @@ public static class SqlNodeExtensions
             builder.Append(scopePrefix);
             builder.Append(argumentPrefix);
             builder.Append(field.Name);
-            builder.Append(node.MaxInclusive == true ? " <= " : " < ");
+            builder.Append(node.MaxInclusive is true ? " <= " : " < ");
             AppendField(builder, field, node.Max, context);
             builder.Append(fieldSuffix);
         }
@@ -381,7 +385,7 @@ public static class SqlNodeExtensions
         return builder.ToString();
     }
 
-    public static string ToDynamicLinqString(this IQueryNode node, ISqlQueryVisitorContext context)
+    public static string? ToDynamicLinqString(this IQueryNode node, ISqlQueryVisitorContext context)
     {
         return node switch
         {
@@ -394,12 +398,12 @@ public static class SqlNodeExtensions
         };
     }
 
-    public static EntityFieldInfo GetFieldInfo(List<EntityFieldInfo> fields, string field)
+    public static EntityFieldInfo GetFieldInfo(List<EntityFieldInfo>? fields, string? field)
     {
-        if (fields == null)
+        if (fields is null)
             return new EntityFieldInfo { Name = field, FullName = field };
 
-        return fields.FirstOrDefault(f => f.FullName.Equals(field, StringComparison.OrdinalIgnoreCase)) ??
+        return fields.FirstOrDefault(f => String.Equals(f.FullName, field, StringComparison.OrdinalIgnoreCase)) ??
                new EntityFieldInfo { Name = field, FullName = field };
     }
 
@@ -516,15 +520,21 @@ public static class SqlNodeExtensions
         node.Data[QueryKey] = query;
     }
 
-    public static string GetQuery(this IQueryNode node)
+    public static string? GetQuery(this IQueryNode node)
     {
-        return node.Data.TryGetValue(QueryKey, out object query) ? query as string : null;
+        return node.Data.TryGetValue(QueryKey, out object? query) ? query as string : null;
     }
 
-    public static bool TryGetQuery(this IQueryNode node, out string query)
+    public static bool TryGetQuery(this IQueryNode node, [NotNullWhen(true)] out string? query)
     {
+        if (node.Data.TryGetValue(QueryKey, out object? value) && value is string s)
+        {
+            query = s;
+            return true;
+        }
+
         query = null;
-        return node.Data.TryGetValue(QueryKey, out object value) && (query = value as string) != null;
+        return false;
     }
 
     public static void RemoveQuery(this IQueryNode node)

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/TypeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/TypeExtensions.cs
@@ -25,7 +25,7 @@ public static class TypeExtensions
         typeof (ulong?)
     };
 
-    public static Type UnwrapNullable(this Type type)
+    public static Type? UnwrapNullable(this Type type)
     {
         if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
             return Nullable.GetUnderlyingType(type);

--- a/src/Foundatio.Parsers.SqlQueries/Foundatio.Parsers.SqlQueries.csproj
+++ b/src/Foundatio.Parsers.SqlQueries/Foundatio.Parsers.SqlQueries.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
     <PackageReference Include="Exceptionless.DateTimeExtensions" Version="6.0.1" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.1" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.7.2" />
   </ItemGroup>
   <ItemGroup>
       <ProjectReference Include="..\..\src\Foundatio.Parsers.LuceneQueries\Foundatio.Parsers.LuceneQueries.csproj" />

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -20,7 +20,7 @@ namespace Foundatio.Parsers.SqlQueries;
 
 public class SqlQueryParser : LuceneQueryParser
 {
-    public SqlQueryParser(Action<SqlQueryParserConfiguration> configure = null)
+    public SqlQueryParser(Action<SqlQueryParserConfiguration>? configure = null)
     {
         var config = new SqlQueryParserConfiguration();
         configure?.Invoke(config);
@@ -33,7 +33,7 @@ public class SqlQueryParser : LuceneQueryParser
         CustomTypeProvider = new DynamicLinqTypeProvider()
     };
 
-    public override async Task<IQueryNode> ParseAsync(string query, IQueryVisitorContext context = null)
+    public override async Task<IQueryNode?> ParseAsync(string query, IQueryVisitorContext? context = null)
     {
         query ??= String.Empty;
         context ??= new SqlQueryVisitorContext();
@@ -42,6 +42,9 @@ public class SqlQueryParser : LuceneQueryParser
         try
         {
             var result = await base.ParseAsync(query, context).ConfigureAwait(false);
+            if (result is null)
+                return null;
+
             switch (context.QueryType)
             {
                 case QueryTypes.Aggregation:
@@ -61,7 +64,7 @@ public class SqlQueryParser : LuceneQueryParser
         {
             var cursor = ex.Data["cursor"] as Cursor;
             context.GetValidationResult().QueryType = context.QueryType;
-            context.AddValidationError(ex.Message, cursor.Column);
+            context.AddValidationError(ex.Message, cursor?.Column ?? 0);
 
             return null;
         }
@@ -70,18 +73,22 @@ public class SqlQueryParser : LuceneQueryParser
     private static readonly ConcurrentDictionary<IEntityType, List<EntityFieldInfo>> _entityFieldCache = new();
     public async Task<QueryValidationResult> ValidateAsync(string query, SqlQueryVisitorContext context)
     {
-        var node = await ParseAsync(query, context);
-        return await ValidationVisitor.RunAsync(node, context);
+        var node = await ParseAsync(query, context).ConfigureAwait(false);
+        var validationResult = context.GetValidationResult();
+        if (!validationResult.IsValid || node is null)
+            return validationResult;
+
+        return await ValidationVisitor.RunAsync(node, context).ConfigureAwait(false);
     }
 
     public async Task<string> ToDynamicLinqAsync(string query, SqlQueryVisitorContext context)
     {
-        var node = await ParseAsync(query, context);
+        var node = await ParseAsync(query, context).ConfigureAwait(false);
         var result = context.GetValidationResult();
-        if (!result.IsValid)
+        if (!result.IsValid || node is null)
             throw new ValidationException("Invalid query: " + result.Message);
 
-        return await GenerateSqlVisitor.RunAsync(node, context);
+        return await GenerateSqlVisitor.RunAsync(node, context).ConfigureAwait(false);
     }
 
     public SqlQueryVisitorContext GetContext(IEntityType entityType)
@@ -97,7 +104,7 @@ public class SqlQueryParser : LuceneQueryParser
         fields = fields.ToList();
 
         var validationOptions = new QueryValidationOptions();
-        foreach (string field in fields.Where(f => !f.IsNavigation).Select(f => f.FullName))
+        foreach (string field in fields.Where(f => !f.IsNavigation && f.FullName is not null).Select(f => f.FullName!))
             validationOptions.AllowedFields.Add(field);
 
         Configuration.SetValidationOptions(validationOptions);
@@ -108,7 +115,7 @@ public class SqlQueryParser : LuceneQueryParser
         };
     }
 
-    private void AddEntityFields(List<EntityFieldInfo> fields, EntityFieldInfo parent, IEntityType entityType, Stack<IEntityType> entityTypeStack = null, string prefix = null, int depth = 0)
+    private void AddEntityFields(List<EntityFieldInfo> fields, EntityFieldInfo? parent, IEntityType entityType, Stack<IEntityType>? entityTypeStack = null, string? prefix = null, int depth = 0)
     {
         entityTypeStack ??= new Stack<IEntityType>();
 
@@ -132,10 +139,10 @@ public class SqlQueryParser : LuceneQueryParser
             {
                 Name = property.Name,
                 FullName = propertyPath,
-                IsNumber = property.ClrType.UnwrapNullable().IsNumeric(),
-                IsDate = property.ClrType.UnwrapNullable().IsDateTime(),
-                IsDateOnly = property.ClrType.UnwrapNullable().IsDateOnly(),
-                IsBoolean = property.ClrType.UnwrapNullable().IsBoolean(),
+                IsNumber = property.ClrType.UnwrapNullable()?.IsNumeric() ?? false,
+                IsDate = property.ClrType.UnwrapNullable()?.IsDateTime() ?? false,
+                IsDateOnly = property.ClrType.UnwrapNullable()?.IsDateOnly() ?? false,
+                IsBoolean = property.ClrType.UnwrapNullable()?.IsBoolean() ?? false,
                 Parent = parent
             });
         }
@@ -187,21 +194,21 @@ public class SqlQueryParser : LuceneQueryParser
     private void SetupQueryVisitorContextDefaults(IQueryVisitorContext context)
     {
         if (!context.Data.ContainsKey("@OriginalContextResolver"))
-            context.SetValue("@OriginalContextResolver", context.GetFieldResolver());
+            context.SetValue("@OriginalContextResolver", context.GetFieldResolver()!);
 
         context.SetFieldResolver(async (field, context) =>
         {
-            string resolvedField = null;
-            if (context.Data.TryGetValue("@OriginalContextResolver", out object data) && data is QueryFieldResolver resolver)
+            string? resolvedField = null;
+            if (context?.Data.TryGetValue("@OriginalContextResolver", out object? data) is true && data is QueryFieldResolver resolver)
             {
-                string contextResolvedField = await resolver(field, context).ConfigureAwait(false);
+                string? contextResolvedField = await resolver(field, context).ConfigureAwait(false);
                 if (contextResolvedField != null)
                     resolvedField = contextResolvedField;
             }
 
             if (Configuration.FieldResolver != null)
             {
-                string configResolvedField = await Configuration.FieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
+                string? configResolvedField = await Configuration.FieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
                 if (configResolvedField != null)
                     resolvedField = configResolvedField;
             }
@@ -214,7 +221,8 @@ public class SqlQueryParser : LuceneQueryParser
 
         if (context.QueryType == QueryTypes.Query)
         {
-            context.SetDefaultFields(Configuration.DefaultFields);
+            if (Configuration.DefaultFields is not null)
+                context.SetDefaultFields(Configuration.DefaultFields);
             if (Configuration.IncludeResolver != null && context.GetIncludeResolver() == null)
                 context.SetIncludeResolver(Configuration.IncludeResolver);
         }
@@ -225,7 +233,7 @@ public class SqlQueryParser : LuceneQueryParser
             sqlContext.DateTimeParser = Configuration.DateTimeParser;
             sqlContext.DateOnlyParser = Configuration.DateOnlyParser;
             sqlContext.DefaultSearchOperator = Configuration.DefaultFieldsSearchOperator;
-            sqlContext.FullTextFields = Configuration.FullTextFields;
+            sqlContext.FullTextFields = Configuration.FullTextFields ?? [];
         }
     }
 }

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParser.cs
@@ -41,20 +41,20 @@ public class SqlQueryParser : LuceneQueryParser
         SetupQueryVisitorContextDefaults(context);
         try
         {
-            var result = await base.ParseAsync(query, context).ConfigureAwait(false);
+            var result = await base.ParseAsync(query, context).AnyContext();
             if (result is null)
                 return null;
 
             switch (context.QueryType)
             {
                 case QueryTypes.Aggregation:
-                    result = await Configuration.AggregationVisitor.AcceptAsync(result, context).ConfigureAwait(false);
+                    result = await Configuration.AggregationVisitor.AcceptAsync(result, context).AnyContext();
                     break;
                 case QueryTypes.Query:
-                    result = await Configuration.QueryVisitor.AcceptAsync(result, context).ConfigureAwait(false);
+                    result = await Configuration.QueryVisitor.AcceptAsync(result, context).AnyContext();
                     break;
                 case QueryTypes.Sort:
-                    result = await Configuration.SortVisitor.AcceptAsync(result, context).ConfigureAwait(false);
+                    result = await Configuration.SortVisitor.AcceptAsync(result, context).AnyContext();
                     break;
             }
 
@@ -73,22 +73,22 @@ public class SqlQueryParser : LuceneQueryParser
     private static readonly ConcurrentDictionary<IEntityType, List<EntityFieldInfo>> _entityFieldCache = new();
     public async Task<QueryValidationResult> ValidateAsync(string query, SqlQueryVisitorContext context)
     {
-        var node = await ParseAsync(query, context).ConfigureAwait(false);
+        var node = await ParseAsync(query, context).AnyContext();
         var validationResult = context.GetValidationResult();
         if (!validationResult.IsValid || node is null)
             return validationResult;
 
-        return await ValidationVisitor.RunAsync(node, context).ConfigureAwait(false);
+        return await ValidationVisitor.RunAsync(node, context).AnyContext();
     }
 
     public async Task<string> ToDynamicLinqAsync(string query, SqlQueryVisitorContext context)
     {
-        var node = await ParseAsync(query, context).ConfigureAwait(false);
+        var node = await ParseAsync(query, context).AnyContext();
         var result = context.GetValidationResult();
         if (!result.IsValid || node is null)
             throw new ValidationException("Invalid query: " + result.Message);
 
-        return await GenerateSqlVisitor.RunAsync(node, context).ConfigureAwait(false);
+        return await GenerateSqlVisitor.RunAsync(node, context).AnyContext();
     }
 
     public SqlQueryVisitorContext GetContext(IEntityType entityType)
@@ -201,14 +201,14 @@ public class SqlQueryParser : LuceneQueryParser
             string? resolvedField = null;
             if (context?.Data.TryGetValue("@OriginalContextResolver", out object? data) is true && data is QueryFieldResolver resolver)
             {
-                string? contextResolvedField = await resolver(field, context).ConfigureAwait(false);
+                string? contextResolvedField = await resolver(field, context).AnyContext();
                 if (contextResolvedField != null)
                     resolvedField = contextResolvedField;
             }
 
             if (Configuration.FieldResolver != null)
             {
-                string? configResolvedField = await Configuration.FieldResolver(resolvedField ?? field, context).ConfigureAwait(false);
+                string? configResolvedField = await Configuration.FieldResolver(resolvedField ?? field, context).AnyContext();
                 if (configResolvedField != null)
                     resolvedField = configResolvedField;
             }

--- a/src/Foundatio.Parsers.SqlQueries/SqlQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.SqlQueries/SqlQueryParserConfiguration.cs
@@ -17,24 +17,24 @@ public class SqlQueryParserConfiguration
     public SqlQueryParserConfiguration()
     {
         AddSortVisitor(new TermToFieldVisitor(), 0);
-        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver != null ? FieldResolver(field, context) : Task.FromResult<string>(null)), 10);
+        AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver is not null ? FieldResolver(field, context) : Task.FromResult<string?>(null)), 10);
         AddVisitor(new ValidationVisitor(), 30);
     }
 
     public ILoggerFactory LoggerFactory { get; private set; } = NullLoggerFactory.Instance;
-    public string[] DefaultFields { get; private set; }
+    public string[]? DefaultFields { get; private set; }
     public SqlSearchOperator DefaultFieldsSearchOperator { get; private set; } = SqlSearchOperator.StartsWith;
-    public string[] FullTextFields { get; private set; }
+    public string[]? FullTextFields { get; private set; }
     public int MaxFieldDepth { get; private set; } = 10;
-    public QueryFieldResolver FieldResolver { get; private set; }
+    public QueryFieldResolver? FieldResolver { get; private set; }
     public Action<SearchTerm> SearchTokenizer { get; set; } = static _ => { };
     public Func<string, string> DateTimeParser { get; set; } = DefaultTimeParser;
     public Func<string, string> DateOnlyParser { get; set; } = DefaultOnlyParser;
     public EntityTypePropertyFilter EntityTypePropertyFilter { get; private set; } = static _ => true;
     public EntityTypeNavigationFilter EntityTypeNavigationFilter { get; private set; } = static _ => true;
     public EntityTypeSkipNavigationFilter EntityTypeSkipNavigationFilter { get; private set; } = static _ => true;
-    public IncludeResolver IncludeResolver { get; private set; }
-    public QueryValidationOptions ValidationOptions { get; private set; }
+    public IncludeResolver? IncludeResolver { get; private set; }
+    public QueryValidationOptions? ValidationOptions { get; private set; }
     public ChainedQueryVisitor SortVisitor { get; } = new();
     public ChainedQueryVisitor QueryVisitor { get; } = new();
     public ChainedQueryVisitor AggregationVisitor { get; } = new();
@@ -42,7 +42,7 @@ public class SqlQueryParserConfiguration
     public SqlQueryParserConfiguration SetLoggerFactory(ILoggerFactory loggerFactory)
     {
         LoggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
-        _logger = loggerFactory!.CreateLogger<SqlQueryParserConfiguration>();
+        _logger = LoggerFactory.CreateLogger<SqlQueryParserConfiguration>();
 
         return this;
     }
@@ -102,7 +102,7 @@ public class SqlQueryParserConfiguration
         return this;
     }
 
-    public SqlQueryParserConfiguration UseFieldResolver(QueryFieldResolver resolver, int priority = 10)
+    public SqlQueryParserConfiguration UseFieldResolver(QueryFieldResolver? resolver, int priority = 10)
     {
         FieldResolver = resolver;
         ReplaceVisitor<FieldResolverQueryVisitor>(new FieldResolverQueryVisitor(resolver), priority);
@@ -118,19 +118,19 @@ public class SqlQueryParserConfiguration
         return UseFieldResolver(null);
     }
 
-    public SqlQueryParserConfiguration UseIncludes(IncludeResolver includeResolver, ShouldSkipIncludeFunc shouldSkipInclude = null, string includeName = "include", int priority = 0)
+    public SqlQueryParserConfiguration UseIncludes(IncludeResolver includeResolver, ShouldSkipIncludeFunc? shouldSkipInclude = null, string includeName = "include", int priority = 0)
     {
         IncludeResolver = includeResolver;
 
         return AddVisitor(new IncludeVisitor(shouldSkipInclude, includeName), priority);
     }
 
-    public SqlQueryParserConfiguration UseIncludes(Func<string, string> resolveInclude, ShouldSkipIncludeFunc shouldSkipInclude = null, string includeName = "include", int priority = 0)
+    public SqlQueryParserConfiguration UseIncludes(Func<string, string?> resolveInclude, ShouldSkipIncludeFunc? shouldSkipInclude = null, string includeName = "include", int priority = 0)
     {
         return UseIncludes(name => Task.FromResult(resolveInclude(name)), shouldSkipInclude, includeName, priority);
     }
 
-    public SqlQueryParserConfiguration UseIncludes(IDictionary<string, string> includes, ShouldSkipIncludeFunc shouldSkipInclude = null, string includeName = "include", int priority = 0)
+    public SqlQueryParserConfiguration UseIncludes(IDictionary<string, string> includes, ShouldSkipIncludeFunc? shouldSkipInclude = null, string includeName = "include", int priority = 0)
     {
         return UseIncludes(name => includes.ContainsKey(name) ? includes[name] : null, shouldSkipInclude, includeName, priority);
     }

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/GenerateSqlVisitor.cs
@@ -59,12 +59,13 @@ public class GenerateSqlVisitor : QueryNodeVisitorWithResultBase<string>
         return _builder.ToString();
     }
 
-    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext context = null)
+    public static Task<string> RunAsync(IQueryNode node, IQueryVisitorContext? context = null)
     {
+        context ??= new SqlQueryVisitorContext();
         return new GenerateSqlVisitor().AcceptAsync(node, context);
     }
 
-    public static string Run(IQueryNode node, IQueryVisitorContext context = null)
+    public static string Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
         return RunAsync(node, context).GetAwaiter().GetResult();
     }

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/ISqlQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/ISqlQueryVisitorContext.cs
@@ -12,7 +12,7 @@ public interface ISqlQueryVisitorContext : IQueryVisitorContext
     /// <summary>
     /// Metadata about available entity fields for query generation.
     /// </summary>
-    List<EntityFieldInfo> Fields { get; set; }
+    List<EntityFieldInfo>? Fields { get; set; }
 
     /// <summary>
     /// The default operator for text searches (Equals, Contains, StartsWith).
@@ -22,20 +22,20 @@ public interface ISqlQueryVisitorContext : IQueryVisitorContext
     /// <summary>
     /// Fields that support full-text search operations.
     /// </summary>
-    string[] FullTextFields { get; set; }
+    string[]? FullTextFields { get; set; }
 
     /// <summary>
     /// Tokenizes search terms for full-text search processing.
     /// </summary>
-    Action<SearchTerm> SearchTokenizer { get; set; }
+    Action<SearchTerm>? SearchTokenizer { get; set; }
 
     /// <summary>
     /// Converts date/time strings to SQL-compatible format.
     /// </summary>
-    Func<string, string> DateTimeParser { get; set; }
+    Func<string, string>? DateTimeParser { get; set; }
 
     /// <summary>
     /// Converts date-only strings to SQL-compatible format.
     /// </summary>
-    Func<string, string> DateOnlyParser { get; set; }
+    Func<string, string>? DateOnlyParser { get; set; }
 }

--- a/src/Foundatio.Parsers.SqlQueries/Visitors/SqlQueryVisitorContext.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Visitors/SqlQueryVisitorContext.cs
@@ -9,20 +9,20 @@ namespace Foundatio.Parsers.SqlQueries.Visitors;
 
 public class SqlQueryVisitorContext : QueryVisitorContext, ISqlQueryVisitorContext
 {
-    public List<EntityFieldInfo> Fields { get; set; }
+    public List<EntityFieldInfo>? Fields { get; set; }
     public SqlSearchOperator DefaultSearchOperator { get; set; } = SqlSearchOperator.StartsWith;
-    public string[] FullTextFields { get; set; } = [];
-    public Action<SearchTerm> SearchTokenizer { get; set; } = static _ => { };
-    public Func<string, string> DateTimeParser { get; set; }
-    public Func<string, string> DateOnlyParser { get; set; }
-    public IEntityType EntityType { get; set; }
+    public string[]? FullTextFields { get; set; }
+    public Action<SearchTerm>? SearchTokenizer { get; set; }
+    public Func<string, string>? DateTimeParser { get; set; }
+    public Func<string, string>? DateOnlyParser { get; set; }
+    public IEntityType? EntityType { get; set; }
 }
 
 [DebuggerDisplay("{FullName} IsNumber: {IsNumber} IsMoney: {IsMoney} IsDate: {IsDate} IsBoolean: {IsBoolean} IsCollection: {IsCollection}")]
 public class EntityFieldInfo
 {
-    public required string Name { get; init; }
-    public required string FullName { get; init; }
+    public string? Name { get; init; }
+    public string? FullName { get; init; }
     public bool IsNumber { get; set; }
     public bool IsMoney { get; set; }
     public bool IsDate { get; set; }
@@ -30,12 +30,12 @@ public class EntityFieldInfo
     public bool IsBoolean { get; set; }
     public bool IsCollection { get; set; }
     public bool IsNavigation { get; set; }
-    public EntityFieldInfo Parent { get; set; }
+    public EntityFieldInfo? Parent { get; set; }
     public IDictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
 
     protected bool Equals(EntityFieldInfo other) => Name == other.Name;
 
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
     {
         if (obj is null)
         {
@@ -60,7 +60,7 @@ public class EntityFieldInfo
     public (string fieldPrefix, string fieldSuffix) GetFieldPrefixAndSuffix()
     {
         var fieldTree = new List<EntityFieldInfo>();
-        EntityFieldInfo current = Parent;
+        EntityFieldInfo? current = Parent;
         while (current != null)
         {
             fieldTree.Add(current);
@@ -116,9 +116,9 @@ public class EntityFieldInfo
 
 public class SearchTerm
 {
-    public EntityFieldInfo FieldInfo { get; set; }
-    public string Term { get; set; }
-    public List<string> Tokens { get; set; }
+    public required EntityFieldInfo FieldInfo { get; set; }
+    public required string Term { get; set; }
+    public List<string>? Tokens { get; set; }
     public SqlSearchOperator Operator { get; set; } = SqlSearchOperator.Contains;
 }
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,12 +7,12 @@
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.1" PrivateAssets="All" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.13" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/AggregationParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/AggregationParserTests.cs
@@ -33,7 +33,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseGeo(_ => "51.5032520,-0.1278990"));
         var aggregations = await processor.BuildAggregationsAsync("min:field4");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -65,7 +65,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseFieldMap(fieldMap).UseGeo(_ => "51.5032520,-0.1278990"));
         var aggregations = await processor.BuildAggregationsAsync("min:heynow");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -101,7 +101,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseFieldMap(fieldMap));
         var aggregations = await processor.BuildAggregationsAsync("terms:heynow");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -132,7 +132,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseGeo(_ => "51.5032520,-0.1278990"));
         var aggregations = await processor.BuildAggregationsAsync("min:field4 max:field4 avg:field4 sum:field4 percentiles:field4~50,100 cardinality:field4 missing:field2 date:field5 histogram:field4 geogrid:field3 terms:field1");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -175,7 +175,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseFieldMap(aliasMap));
         var aggregations = await processor.BuildAggregationsAsync("terms:(alias1 cardinality:user)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -205,7 +205,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseFieldMap(aliasMap));
         var aggregations = await processor.BuildAggregationsAsync("missing:alias2");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -239,7 +239,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index).UseGeo(_ => "51.5032520,-0.1278990").UseFieldMap(aliasMap));
         var aggregations = await processor.BuildAggregationsAsync("min:alias4 max:alias4 avg:alias4 sum:alias4 percentiles:alias4 cardinality:user missing:alias2 date:alias5 histogram:alias4 geogrid:alias3 terms:alias1");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -275,7 +275,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("terms:(field1 @exclude:myexclude @include:myinclude @include:otherinclude @missing:mymissing @exclude:otherexclude @min:1)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -304,7 +304,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("terms:(field1 @exclude:/A.*/ @include:/B.*/)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -331,7 +331,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("histogram:(field1~0.1)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -358,7 +358,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("terms:(field1~1000^2 tophits:(_~1000 @include:myinclude))");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -386,7 +386,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("terms:(field1 -cardinality:field4)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -416,7 +416,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("date:(field5^1h @missing:\"0001-01-01T00:00:00\" min:field5^1h max:field5^1h)");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -450,7 +450,7 @@ public class AggregationParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var aggregations = await processor.BuildAggregationsAsync("min:field4~0 max:field4~0 avg:field4~0 sum:field4~0 cardinality:field4~0");
 
-        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations));
+        var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(aggregations!));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
@@ -497,40 +497,40 @@ public class AggregationParserTests : ElasticsearchTestBase
 
     public static IEnumerable<object[]> AggregationTestCases =>
     [
-        [null, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string>>()],
-        [String.Empty, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string>>()],
+        [null!, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string?>>()],
+        [String.Empty, true, 1, new HashSet<string>(), new Dictionary<string, ICollection<string?>>()],
         ["avg",
             false,
             1,
             new HashSet<string> { "" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { null } } }
+            new Dictionary<string, ICollection<string?>> { { "avg", new HashSet<string?> { null } } }
         ],
-        ["avg:", false, 1, new HashSet<string>(), new Dictionary<string, ICollection<string>>()],
+        ["avg:", false, 1, new HashSet<string>(), new Dictionary<string, ICollection<string?>>()],
         [
             "avg:value",
             true,
             1,
             new HashSet<string> { "value" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { "value" } } }
+            new Dictionary<string, ICollection<string?>> { { "avg", new HashSet<string?> { "value" } } }
         ],
         [
             "    avg    :    value",
             true,
             1,
             new HashSet<string> { "value" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { "value" } } }
+            new Dictionary<string, ICollection<string?>> { { "avg", new HashSet<string?> { "value" } } }
         ],
         [
             "avg:value cardinality:value sum:value min:value max:value",
             true,
             1,
             new HashSet<string> { "value" },
-            new Dictionary<string, ICollection<string>> {
-                    { "avg", new HashSet<string> { "value" } },
-                    { "cardinality", new HashSet<string> { "value" } },
-                    { "sum", new HashSet<string> { "value" } },
-                    { "min", new HashSet<string> { "value" } },
-                    { "max", new HashSet<string> { "value" } }
+            new Dictionary<string, ICollection<string?>> {
+                    { "avg", new HashSet<string?> { "value" } },
+                    { "cardinality", new HashSet<string?> { "value" } },
+                    { "sum", new HashSet<string?> { "value" } },
+                    { "min", new HashSet<string?> { "value" } },
+                    { "max", new HashSet<string?> { "value" } }
                 }
         ],
         [
@@ -538,26 +538,26 @@ public class AggregationParserTests : ElasticsearchTestBase
             true,
             1,
             new HashSet<string> { "value", "value2" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { "value", "value2" } } }
+            new Dictionary<string, ICollection<string?>> { { "avg", new HashSet<string?> { "value", "value2" } } }
         ],
         [
             "avg:value avg:value",
             true,
             1,
             new HashSet<string> { "value" },
-            new Dictionary<string, ICollection<string>> { { "avg", new HashSet<string> { "value" } } }
+            new Dictionary<string, ICollection<string?>> { { "avg", new HashSet<string?> { "value" } } }
         ]
     ];
 
     [Theory]
     [MemberData(nameof(AggregationTestCases))]
-    public Task GetElasticAggregationQueryInfoAsync(string query, bool isValid, int maxNodeDepth, HashSet<string> fields, Dictionary<string, ICollection<string>> operations)
+    public Task GetElasticAggregationQueryInfoAsync(string query, bool isValid, int maxNodeDepth, HashSet<string> fields, Dictionary<string, ICollection<string?>> operations)
     {
         var parser = new ElasticQueryParser(c => c.SetLoggerFactory(Log));
         return GetAggregationQueryInfoAsync(parser, query, isValid, maxNodeDepth, fields, operations);
     }
 
-    private async Task GetAggregationQueryInfoAsync(IQueryParser parser, string query, bool isValid, int maxNodeDepth = -1, HashSet<string> fields = null, Dictionary<string, ICollection<string>> operations = null)
+    private async Task GetAggregationQueryInfoAsync(IQueryParser parser, string query, bool isValid, int maxNodeDepth = -1, HashSet<string>? fields = null, Dictionary<string, ICollection<string?>>? operations = null)
     {
         var context = new ElasticQueryVisitorContext { QueryType = QueryTypes.Aggregation };
         var queryNode = await parser.ParseAsync(query, context);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/CustomVisitorTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/CustomVisitorTests.cs
@@ -110,10 +110,10 @@ public class CustomVisitorTests : ElasticsearchTestBase
         return false;
     }
 
-    private static Task<string> ResolveIncludeAsync(string expected, string actual, string resolvedFilterIfMatch)
+    private static Task<string?> ResolveIncludeAsync(string expected, string actual, string resolvedFilterIfMatch)
     {
         if (String.Equals(expected, actual))
-            return Task.FromResult(resolvedFilterIfMatch);
+            return Task.FromResult<string?>(resolvedFilterIfMatch);
 
         throw new ArgumentException(nameof(actual), $"Unable to resolve filter with id: {actual}");
     }
@@ -175,9 +175,9 @@ public sealed class CustomFilterVisitor : ChainableQueryVisitor
             string term = ToTerm(node);
             var ids = await GetIdsAsync(term);
             if (ids != null && ids.Count > 0)
-                node.Parent.SetQuery(new TermsQuery { Field = "id", Terms = ids });
+                node.Parent!.SetQuery(new TermsQuery { Field = "id", Terms = ids });
             else
-                node.Parent.SetQuery(new TermQuery { Field = "id", Value = "none" });
+                node.Parent!.SetQuery(new TermQuery { Field = "id", Value = "none" });
 
             node.Left = null;
             node.Right = null;

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
@@ -139,7 +139,8 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         var field4Property = resolver.GetMappingProperty("Field4");
         Assert.IsType<TextProperty>(field4Property);
 
-        var field4ReflectionProperty = resolver.GetMappingProperty(new Field(typeof(MyNestedType).GetProperty("Field4")!));
+        var field4ReflectionProperty = resolver.GetMappingProperty(new Field(typeof(MyNestedType).GetProperty("Field4")
+            ?? throw new InvalidOperationException("Field4 property not found on MyNestedType")));
         Assert.IsType<TextProperty>(field4ReflectionProperty);
 
         var field4ExpressionProperty = resolver.GetMappingProperty(new Field(GetObjectPath(p => p.Field4)));

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
@@ -91,65 +91,72 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
 
         var resolver = ElasticMappingResolver.Create<ElasticNestedQueryParserTests.MyNestedType>(MapMyNestedType, Client, index, _logger);
 
-        string dynamicTextAggregation = resolver.GetAggregationsFieldName("nested.data.text-0001");
+        string? dynamicTextAggregation = resolver.GetAggregationsFieldName("nested.data.text-0001");
+        Assert.NotNull(dynamicTextAggregation);
         Assert.Equal("nested.data.text-0001.keyword", dynamicTextAggregation);
 
-        string dynamicSpacedAggregation = resolver.GetAggregationsFieldName("nested.data.spaced field");
+        string? dynamicSpacedAggregation = resolver.GetAggregationsFieldName("nested.data.spaced field");
+        Assert.NotNull(dynamicSpacedAggregation);
         Assert.Equal("nested.data.spaced field.keyword", dynamicSpacedAggregation);
 
-        string dynamicSpacedSort = resolver.GetSortFieldName("nested.data.spaced field");
+        string? dynamicSpacedSort = resolver.GetSortFieldName("nested.data.spaced field");
+        Assert.NotNull(dynamicSpacedSort);
         Assert.Equal("nested.data.spaced field.keyword", dynamicSpacedSort);
 
-        string dynamicSpacedField = resolver.GetResolvedField("nested.data.spaced field");
+        string? dynamicSpacedField = resolver.GetResolvedField("nested.data.spaced field");
         Assert.Equal("nested.data.spaced field", dynamicSpacedField);
 
         var field1Property = resolver.GetMappingProperty("Field1");
         Assert.IsType<TextProperty>(field1Property);
 
-        string field5Property = resolver.GetAggregationsFieldName("Field5");
+        string? field5Property = resolver.GetAggregationsFieldName("Field5");
+        Assert.NotNull(field5Property);
         Assert.Equal("field5.keyword", field5Property);
 
         var unknownProperty = resolver.GetMappingProperty("UnknowN.test.doesNotExist");
         Assert.Null(unknownProperty);
 
-        string field1 = resolver.GetResolvedField("FielD1");
+        string? field1 = resolver.GetResolvedField("FielD1");
         Assert.Equal("field1", field1);
 
-        string emptyField = resolver.GetResolvedField(" ");
+        string? emptyField = resolver.GetResolvedField(" ");
         Assert.Equal(" ", emptyField);
 
-        string unknownField = resolver.GetResolvedField("UnknowN.test.doesNotExist");
+        string? unknownField = resolver.GetResolvedField("UnknowN.test.doesNotExist");
         Assert.Equal("UnknowN.test.doesNotExist", unknownField);
 
-        string unknownField2 = resolver.GetResolvedField("unknown.test.doesnotexist");
+        string? unknownField2 = resolver.GetResolvedField("unknown.test.doesnotexist");
         Assert.Equal("unknown.test.doesnotexist", unknownField2);
 
-        string unknownField3 = resolver.GetResolvedField("unknown");
+        string? unknownField3 = resolver.GetResolvedField("unknown");
         Assert.Equal("unknown", unknownField3);
 
         var field4Property = resolver.GetMappingProperty("Field4");
         Assert.IsType<TextProperty>(field4Property);
 
-        var field4ReflectionProperty = resolver.GetMappingProperty(new Field(typeof(ElasticNestedQueryParserTests.MyNestedType).GetProperty("Field4")));
+        var field4ReflectionProperty = resolver.GetMappingProperty(new Field(typeof(ElasticNestedQueryParserTests.MyNestedType).GetProperty("Field4")!));
         Assert.IsType<TextProperty>(field4ReflectionProperty);
 
         var field4ExpressionProperty = resolver.GetMappingProperty(new Field(GetObjectPath(p => p.Field4)));
         Assert.IsType<TextProperty>(field4ExpressionProperty);
 
         var field4AliasMapping = resolver.GetMapping("Field4Alias", true);
+        Assert.NotNull(field4AliasMapping);
         Assert.IsType<TextProperty>(field4AliasMapping.Property);
         Assert.Same(field4Property, field4AliasMapping.Property);
 
-        string field4sort = resolver.GetSortFieldName("Field4Alias");
+        string? field4sort = resolver.GetSortFieldName("Field4Alias");
+        Assert.NotNull(field4sort);
         Assert.Equal("field4.sort", field4sort);
 
-        string field4aggs = resolver.GetAggregationsFieldName("Field4Alias");
+        string? field4aggs = resolver.GetAggregationsFieldName("Field4Alias");
+        Assert.NotNull(field4aggs);
         Assert.Equal("field4.keyword", field4aggs);
 
         var nestedIdProperty = resolver.GetMappingProperty("Nested.Id");
         Assert.IsType<TextProperty>(nestedIdProperty);
 
-        string nestedId = resolver.GetResolvedField("Nested.Id");
+        string? nestedId = resolver.GetResolvedField("Nested.Id");
         Assert.Equal("nested.id", nestedId);
 
         nestedIdProperty = resolver.GetMappingProperty("nested.id");

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -34,9 +34,10 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextWithKeywordMapping("title"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("title", "keyword")!;
+        string? result = resolver.GetNonAnalyzedFieldName("title", "keyword");
 
         // Assert
+        Assert.NotNull(result);
         Assert.Equal("title.keyword", result);
     }
 
@@ -48,9 +49,10 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextWithKeywordMapping("title"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetAggregationsFieldName("title")!;
+        string? result = resolver.GetAggregationsFieldName("title");
 
         // Assert
+        Assert.NotNull(result);
         Assert.Equal("title.keyword", result);
     }
 
@@ -62,9 +64,10 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextWithKeywordAndSortMapping("title"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetSortFieldName("title")!;
+        string? result = resolver.GetSortFieldName("title");
 
         // Assert
+        Assert.NotNull(result);
         Assert.Equal("title.sort", result);
     }
 
@@ -78,9 +81,10 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var resolver = new ElasticMappingResolver(codeMapping, _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("status", "keyword")!;
+        string? result = resolver.GetNonAnalyzedFieldName("status", "keyword");
 
         // Assert
+        Assert.NotNull(result);
         Assert.Equal("status", result);
     }
 
@@ -92,9 +96,10 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextOnlyMapping("body"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("body", "keyword")!;
+        string? result = resolver.GetNonAnalyzedFieldName("body", "keyword");
 
         // Assert
+        Assert.NotNull(result);
         Assert.Equal("body", result);
     }
 
@@ -112,11 +117,13 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         }, _inferrer, logger: _logger);
 
         // Act
-        string beforeRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
+        string? beforeRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword");
         resolver.RefreshMapping();
-        string afterRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
+        string? afterRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword");
 
         // Assert
+        Assert.NotNull(beforeRefresh);
+        Assert.NotNull(afterRefresh);
         Assert.Equal("name", beforeRefresh);
         Assert.Equal("name.keyword", afterRefresh);
         Assert.True(serverFetchCount >= 2, "Server mapping should have been fetched at least twice");
@@ -136,11 +143,13 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         }, _inferrer, logger: _logger);
 
         // Act
-        string first = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
+        string? first = resolver.GetNonAnalyzedFieldName("name", "keyword");
         resolver.RefreshMapping();
-        string second = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
+        string? second = resolver.GetNonAnalyzedFieldName("name", "keyword");
 
         // Assert
+        Assert.NotNull(first);
+        Assert.NotNull(second);
         Assert.Equal("name", first);
         Assert.Equal("name.keyword", second);
     }
@@ -155,9 +164,10 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         resolver.RefreshMapping();
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
+        string? result = resolver.GetNonAnalyzedFieldName("name", "keyword");
 
         // Assert
+        Assert.NotNull(result);
         Assert.Equal("name.keyword", result);
     }
 
@@ -174,11 +184,13 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             }, logger: _logger);
 
         // Act
-        string initial = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
+        string? initial = resolver.GetNonAnalyzedFieldName("name", "keyword");
         resolver.RefreshMapping();
-        string updated = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
+        string? updated = resolver.GetNonAnalyzedFieldName("name", "keyword");
 
         // Assert
+        Assert.NotNull(initial);
+        Assert.NotNull(updated);
         Assert.Equal("name", initial);
         Assert.Equal("name.keyword", updated);
     }
@@ -202,7 +214,8 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             barrier.SignalAndWait(TestCancellationToken);
             for (int i = 0; i < iterations; i++)
             {
-                string result = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
+                string? result = resolver.GetNonAnalyzedFieldName("name", "keyword");
+                Assert.NotNull(result);
                 Assert.Equal("name.keyword", result);
             }
         }, TestCancellationToken);
@@ -212,7 +225,8 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             barrier.SignalAndWait(TestCancellationToken);
             for (int i = 0; i < iterations; i++)
             {
-                string result = resolver.GetAggregationsFieldName("name")!;
+                string? result = resolver.GetAggregationsFieldName("name");
+                Assert.NotNull(result);
                 Assert.Equal("name.keyword", result);
             }
         }, TestCancellationToken);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -33,7 +33,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextWithKeywordMapping("title"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("title", "keyword");
+        string result = resolver.GetNonAnalyzedFieldName("title", "keyword")!;
 
         // Assert
         Assert.Equal("title.keyword", result);
@@ -47,7 +47,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextWithKeywordMapping("title"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetAggregationsFieldName("title");
+        string result = resolver.GetAggregationsFieldName("title")!;
 
         // Assert
         Assert.Equal("title.keyword", result);
@@ -61,7 +61,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextWithKeywordAndSortMapping("title"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetSortFieldName("title");
+        string result = resolver.GetSortFieldName("title")!;
 
         // Assert
         Assert.Equal("title.sort", result);
@@ -81,7 +81,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var resolver = new ElasticMappingResolver(codeMapping, _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("status", "keyword");
+        string result = resolver.GetNonAnalyzedFieldName("status", "keyword")!;
 
         // Assert
         Assert.Equal("status", result);
@@ -95,7 +95,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             CreateTextOnlyMapping("body"), _inferrer, () => null, logger: _logger);
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("body", "keyword");
+        string result = resolver.GetNonAnalyzedFieldName("body", "keyword")!;
 
         // Assert
         Assert.Equal("body", result);
@@ -115,9 +115,9 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         }, _inferrer, logger: _logger);
 
         // Act
-        string beforeRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string beforeRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
         resolver.RefreshMapping();
-        string afterRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string afterRefresh = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
 
         // Assert
         Assert.Equal("name", beforeRefresh);
@@ -139,9 +139,9 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         }, _inferrer, logger: _logger);
 
         // Act
-        string first = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string first = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
         resolver.RefreshMapping();
-        string second = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string second = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
 
         // Assert
         Assert.Equal("name", first);
@@ -158,7 +158,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         resolver.RefreshMapping();
 
         // Act
-        string result = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string result = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
 
         // Assert
         Assert.Equal("name.keyword", result);
@@ -177,9 +177,9 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             }, logger: _logger);
 
         // Act
-        string initial = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string initial = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
         resolver.RefreshMapping();
-        string updated = resolver.GetNonAnalyzedFieldName("name", "keyword");
+        string updated = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
 
         // Assert
         Assert.Equal("name", initial);
@@ -205,7 +205,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             barrier.SignalAndWait(TestCancellationToken);
             for (int i = 0; i < iterations; i++)
             {
-                string result = resolver.GetNonAnalyzedFieldName("name", "keyword");
+                string result = resolver.GetNonAnalyzedFieldName("name", "keyword")!;
                 Assert.Equal("name.keyword", result);
             }
         }, TestCancellationToken);
@@ -215,7 +215,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             barrier.SignalAndWait(TestCancellationToken);
             for (int i = 0; i < iterations; i++)
             {
-                string result = resolver.GetAggregationsFieldName("name");
+                string result = resolver.GetAggregationsFieldName("name")!;
                 Assert.Equal("name.keyword", result);
             }
         }, TestCancellationToken);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
@@ -367,6 +367,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings<MyNestedType>(Client).UseNested());
 
         var result = await processor.BuildAggregationsAsync("terms:nested.field4");
+        Assert.NotNull(result);
 
         var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index).Aggregations(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
@@ -408,6 +409,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings<MyNestedType>(Client).UseNested());
 
         var result = await processor.BuildAggregationsAsync("terms:nested.field1 terms:nested.field4 max:nested.field4");
+        Assert.NotNull(result);
 
         var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index).Aggregations(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
@@ -457,6 +459,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings<MyNestedType>(Client).UseNested());
 
         var result = await processor.BuildAggregationsAsync("terms:(nested.field1 @include:apple @include:banana @include:cherry)");
+        Assert.NotNull(result);
 
         var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index).Aggregations(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
@@ -500,6 +503,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings<MyNestedType>(Client).UseNested());
 
         var result = await processor.BuildAggregationsAsync("terms:(nested.field1 @exclude:myexclude @include:myinclude @include:otherinclude @missing:mymissing @exclude:otherexclude @min:1)");
+        Assert.NotNull(result);
 
         var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index).Aggregations(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
@@ -1095,6 +1099,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
 
         var queryResult = await processor.BuildQueryAsync("nested.field4:>=5", new ElasticQueryVisitorContext { UseScoring = true });
         var aggResult = await processor.BuildAggregationsAsync("terms:nested.field1 max:nested.field4");
+        Assert.NotNull(aggResult);
 
         var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index).Query(queryResult).Aggregations(aggResult), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
@@ -1406,6 +1411,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("max:resellers.price");
 
         // Assert
+        Assert.NotNull(result);
         var actualResponse = await Client.SearchAsync<Product>(d => d.Indices(index).Aggregations(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -1682,6 +1688,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("max:resellers.price terms:resellers.name");
 
         // Assert
+        Assert.NotNull(result);
         var actualResponse = await Client.SearchAsync<Product>(d => d.Indices(index).Aggregations(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
@@ -388,6 +388,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:nested.field4");
 
         // Assert
+        Assert.NotNull(result);
         var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -431,6 +432,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         // Parse and examine the result after visitors have run
         var context = new ElasticQueryVisitorContext { QueryType = QueryTypes.Aggregation };
         var parsedNode = await processor.ParseAsync("terms:nested.field1 terms:nested.field4 max:nested.field4", context);
+        Assert.NotNull(parsedNode);
         _logger.LogInformation("Parsed node (after visitors): {Node}", await DebugQueryVisitor.RunAsync(parsedNode));
 
         // Check nested paths on term nodes
@@ -454,6 +456,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:nested.field1 terms:nested.field4 max:nested.field4");
 
         // Assert
+        Assert.NotNull(result);
         var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -509,6 +512,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:(nested.field1 @include:apple @include:banana @include:cherry)");
 
         // Assert
+        Assert.NotNull(result);
         var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -554,6 +558,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("terms:(nested.field1 @exclude:myexclude @include:myinclude @include:otherinclude @missing:mymissing @exclude:otherexclude @min:1)");
 
         // Assert
+        Assert.NotNull(result);
         var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -783,6 +788,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         // Act
         var queryResult = await processor.BuildQueryAsync("nested.field4:>=5", new ElasticQueryVisitorContext { UseScoring = true });
         var aggResult = await processor.BuildAggregationsAsync("terms:nested.field1 max:nested.field4");
+        Assert.NotNull(aggResult);
 
         // Assert
         var actualResponse = Client.Search<MyNestedType>(d => d.Index(index).Query(_ => queryResult).Aggregations(aggResult));
@@ -1355,24 +1361,24 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
 
     public class MyDeeplyNestedType
     {
-        public string Field1 { get; set; }
+        public string Field1 { get; set; } = null!;
         public IList<MyMiddleNestedType> Parent { get; set; } = new List<MyMiddleNestedType>();
     }
 
     public class MyMiddleNestedType
     {
-        public string Field1 { get; set; }
+        public string Field1 { get; set; } = null!;
         public IList<MyType> Child { get; set; } = new List<MyType>();
     }
 
     public class MyNestedType
     {
-        public string Field1 { get; set; }
-        public string Field2 { get; set; }
-        public string Field3 { get; set; }
+        public string Field1 { get; set; } = null!;
+        public string Field2 { get; set; } = null!;
+        public string Field3 { get; set; } = null!;
         public int Field4 { get; set; }
-        public string Field5 { get; set; }
-        public string Payload { get; set; }
+        public string Field5 { get; set; } = null!;
+        public string Payload { get; set; } = null!;
         public IList<MyType> Nested { get; set; } = new List<MyType>();
     }
 
@@ -1520,6 +1526,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("max:resellers.price");
 
         // Assert
+        Assert.NotNull(result);
         var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -1676,7 +1683,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c
             .SetLoggerFactory(Log)
             .UseMappings<Product>(Client)
-            .UseNestedFilter((path, orig, resolved, ctx) => (QueryContainer)null)
+            .UseNestedFilter((path, orig, resolved, ctx) => (QueryContainer?)null)
             .UseNested());
 
         // Act
@@ -1797,6 +1804,7 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildAggregationsAsync("max:resellers.price terms:resellers.name");
 
         // Assert
+        Assert.NotNull(result);
         var actualResponse = Client.Search<Product>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -1827,26 +1835,26 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
 
     public class Product
     {
-        public string Name { get; set; }
-        public string Category { get; set; }
+        public string Name { get; set; } = null!;
+        public string Category { get; set; } = null!;
         public IList<Reseller> Resellers { get; set; } = new List<Reseller>();
     }
 
     public class MultiNestedProduct
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public IList<Reseller> Resellers { get; set; } = new List<Reseller>();
         public IList<Tag> Tags { get; set; } = new List<Tag>();
     }
 
     public class Reseller
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         public double Price { get; set; }
     }
 
     public class Tag
     {
-        public string Label { get; set; }
+        public string Label { get; set; } = null!;
     }
 }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -28,19 +28,19 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var queryResult = await sut.BuildQueryAsync("");
         Assert.NotNull(queryResult);
 
-        queryResult = await sut.BuildQueryAsync((string)null);
+        queryResult = await sut.BuildQueryAsync((string)null!);
         Assert.NotNull(queryResult);
 
         var aggResult = await sut.BuildAggregationsAsync("");
         Assert.NotNull(aggResult);
 
-        aggResult = await sut.BuildAggregationsAsync((string)null);
+        aggResult = await sut.BuildAggregationsAsync((string)null!);
         Assert.NotNull(aggResult);
 
         var sortResult = await sut.BuildSortAsync("");
         Assert.NotNull(sortResult);
 
-        sortResult = await sut.BuildSortAsync((string)null);
+        sortResult = await sut.BuildSortAsync((string?)null);
         Assert.NotNull(sortResult);
     }
 
@@ -51,9 +51,9 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var result = sut.Parse("NOT (dog parrot)");
 
-        Assert.IsType<GroupNode>(result.Left);
-        Assert.True((result.Left as GroupNode).HasParens);
-        Assert.True((result.Left as GroupNode).IsNegated);
+        var leftGroup = Assert.IsType<GroupNode>(result.Left);
+        Assert.True(leftGroup.HasParens);
+        Assert.True(leftGroup.IsNegated);
     }
 
     [Fact]
@@ -63,12 +63,12 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var sut = new ElasticQueryParser(c => c.AddQueryVisitor(testQueryVisitor));
         var context = new ElasticQueryVisitorContext();
 
-        var result = sut.Parse("NOT (dog parrot)", context) as GroupNode;
+        var result = Assert.IsType<GroupNode>(sut.Parse("NOT (dog parrot)", context));
         Assert.Equal(2, testQueryVisitor.GroupNodeCount);
 
-        Assert.IsType<GroupNode>(result.Left);
-        Assert.True((result.Left as GroupNode).HasParens);
-        Assert.True((result.Left as GroupNode).IsNegated);
+        var leftGroup2 = Assert.IsType<GroupNode>(result.Left);
+        Assert.True(leftGroup2.HasParens);
+        Assert.True(leftGroup2.IsNegated);
     }
 
     [Fact]
@@ -289,10 +289,26 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var parser = new ElasticQueryParser(c => c.SetDefaultFields(["field1"]).UseMappings<MyType>(GetCodeMappings, Client, index));
 
-        var dynamicServerMappingProperty = parser.Configuration.MappingResolver.GetMapping("field5").Property;
-        var serverMappingProperty = parser.Configuration.MappingResolver.GetMapping("field2").Property;
-        var codeMappingProperty = parser.Configuration.MappingResolver.GetMapping("field1").Property;
-        var codeAndServerMappingProperty = parser.Configuration.MappingResolver.GetMapping("field3").Property;
+        Assert.NotNull(parser.Configuration.MappingResolver);
+        var field5Mapping = parser.Configuration.MappingResolver.GetMapping("field5");
+        Assert.NotNull(field5Mapping);
+        Assert.NotNull(field5Mapping.Property);
+        var dynamicServerMappingProperty = field5Mapping.Property;
+
+        var field2Mapping = parser.Configuration.MappingResolver.GetMapping("field2");
+        Assert.NotNull(field2Mapping);
+        Assert.NotNull(field2Mapping.Property);
+        var serverMappingProperty = field2Mapping.Property;
+
+        var field1Mapping = parser.Configuration.MappingResolver.GetMapping("field1");
+        Assert.NotNull(field1Mapping);
+        Assert.NotNull(field1Mapping.Property);
+        var codeMappingProperty = field1Mapping.Property;
+
+        var field3Mapping = parser.Configuration.MappingResolver.GetMapping("field3");
+        Assert.NotNull(field3Mapping);
+        Assert.NotNull(field3Mapping.Property);
+        var codeAndServerMappingProperty = field3Mapping.Property;
 
         Assert.Equal("date", dynamicServerMappingProperty.Type);
         Assert.Equal("keyword", serverMappingProperty.Type);
@@ -454,6 +470,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var result = await processor.BuildAggregationsAsync("min:field2 max:field2 date:(field5~1d^\"America/Chicago\" min:field2 max:field2 min:field1 @offset:-6h)");
+        Assert.NotNull(result);
         var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -513,7 +530,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
     [InlineData("1y", DateInterval.Year)]
     [InlineData("year", DateInterval.Year)]
     [Theory]
-    public async Task CanUseDateHistogramAggregationInterval(string interval, object expectedInterval = null)
+    public async Task CanUseDateHistogramAggregationInterval(string interval, object? expectedInterval = null)
     {
         string index = CreateRandomIndex<MyType>();
         await Client.IndexManyAsync([new MyType { Field5 = DateTime.Now }], index, TestCancellationToken);
@@ -522,6 +539,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
 
         var result = await processor.BuildAggregationsAsync($"date:(field5~{interval})");
+        Assert.NotNull(result);
         var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -578,6 +596,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log));
         var result = await processor.BuildAggregationsAsync("date:field5");
+        Assert.NotNull(result);
         var actualResponse = Client.Search<MyType>(d => d.Index(index).Aggregations(result));
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -1196,7 +1215,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         parser = new ElasticQueryParser(c => c.UseMappings(Client, index).SetValidationOptions(new QueryValidationOptions { AllowUnresolvedFields = false }));
         var ex = await Assert.ThrowsAsync<QueryValidationException>(() => parser.BuildQueryAsync("field2:value", context));
         Assert.Contains("resolved", ex.Message);
-        Assert.Contains("field2", ex.Result.ReferencedFields);
+        Assert.Contains("field2", ex.Result!.ReferencedFields);
         Assert.Contains("field2", ex.Result.UnresolvedFields);
         Assert.False(ex.Result.IsValid);
         Assert.NotNull(ex.Result.Message);
@@ -1426,7 +1445,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         Assert.Equal(expectedResponse.Total, actualResponse.Total);
     }
 
-    private async Task<string> GetIncludeAsync(string name)
+    private async Task<string?> GetIncludeAsync(string name)
     {
         await Task.Delay(150);
         return "included:value";
@@ -1443,7 +1462,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var parser = new ElasticQueryParser(c => c.UseMappings(Client, index).SetLoggerFactory(Log));
         var node = await parser.ParseAsync(aggregation, context);
 
-        var result = await ValidationVisitor.RunAsync(node, context);
+        var result = await ValidationVisitor.RunAsync(node!, context);
         Assert.True(result.IsValid, result.Message);
         Assert.Single(result.ReferencedFields, "field1");
         Assert.Empty(result.UnresolvedFields);
@@ -1452,13 +1471,13 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
 public class MyType
 {
-    public string Id { get; set; }
-    public string Field1 { get; set; }
-    public string Field2 { get; set; }
-    public string Field3 { get; set; }
+    public string Id { get; set; } = null!;
+    public string Field1 { get; set; } = null!;
+    public string Field2 { get; set; } = null!;
+    public string Field3 { get; set; } = null!;
     public int Field4 { get; set; }
     public DateTime Field5 { get; set; }
-    public string MultiWord { get; set; }
+    public string MultiWord { get; set; } = null!;
     public Dictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
 }
 

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -479,6 +479,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
         var result = await processor.BuildAggregationsAsync("min:field4 max:field4 date:(field5~1d^\"America/Chicago\" min:field4 max:field4 min:field5 @offset:-6h)");
+        Assert.NotNull(result);
         var actualResponse = await Client.SearchAsync<MyType>(d => d.Indices(index).Aggregations(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -547,6 +548,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
 
         var result = await processor.BuildAggregationsAsync($"date:(field5~{interval})");
+        Assert.NotNull(result);
         var actualResponse = await Client.SearchAsync<MyType>(d => d.Indices(index).Aggregations(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
@@ -601,6 +603,7 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log));
         var result = await processor.BuildAggregationsAsync("date:field5");
+        Assert.NotNull(result);
         var actualResponse = await Client.SearchAsync<MyType>(d => d.Indices(index).Aggregations(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/InvertQueryTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/InvertQueryTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries;
@@ -84,11 +84,11 @@ public class InvertQueryTests : ElasticsearchTestBase<SampleDataFixture>
         return InvertAndValidateQuery("(field1:value organizationId:value) field2:value", "((NOT field1:value) organizationId:value) (NOT field2:value)", null, true);
     }
 
-    private async Task InvertAndValidateQuery(string query, string expected, string alternateInvertedCriteria, bool isValid)
+    private async Task InvertAndValidateQuery(string query, string expected, string? alternateInvertedCriteria, bool isValid)
     {
         var parser = new LuceneQueryParser();
 
-        IQueryNode result;
+        IQueryNode? result;
         try
         {
             result = await parser.ParseAsync(query);
@@ -105,10 +105,13 @@ public class InvertQueryTests : ElasticsearchTestBase<SampleDataFixture>
         if (!String.IsNullOrWhiteSpace(alternateInvertedCriteria))
         {
             var invertedAlternate = await parser.ParseAsync(alternateInvertedCriteria);
+            Assert.NotNull(invertedAlternate);
             context.SetAlternateInvertedCriteria(invertedAlternate);
         }
 
+        Assert.NotNull(result);
         result = await invertQueryVisitor.AcceptAsync(result, context);
+        Assert.NotNull(result);
         string invertedQuery = result.ToString();
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);
@@ -127,9 +130,9 @@ public class InvertTest
     public const string OrgId = "1";
     public const string AltOrgId = "2";
 
-    public string Id { get; set; }
-    public string OrganizationId { get; set; }
-    public string Description { get; set; }
+    public string Id { get; set; } = null!;
+    public string OrganizationId { get; set; } = null!;
+    public string Description { get; set; } = null!;
     public string Status { get; set; } = "open";
     public bool IsDeleted { get; set; }
 }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/Utility/ElasticsearchTestBase.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/Utility/ElasticsearchTestBase.cs
@@ -27,17 +27,17 @@ public abstract class ElasticsearchTestBase<T> : TestWithLoggingBase, IAsyncLife
 
     protected IElasticClient Client => _fixture.Client;
 
-    protected void CreateNamedIndex<TModel>(string index, Func<TypeMappingDescriptor<TModel>, ITypeMapping> configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>> configureIndex = null) where TModel : class
+    protected void CreateNamedIndex<TModel>(string index, Func<TypeMappingDescriptor<TModel>, ITypeMapping>? configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>>? configureIndex = null) where TModel : class
     {
         _fixture.CreateNamedIndex(index, configureMappings, configureIndex);
     }
 
-    protected string CreateRandomIndex<TModel>(Func<TypeMappingDescriptor<TModel>, ITypeMapping> configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>> configureIndex = null) where TModel : class
+    protected string CreateRandomIndex<TModel>(Func<TypeMappingDescriptor<TModel>, ITypeMapping>? configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>>? configureIndex = null) where TModel : class
     {
         return _fixture.CreateRandomIndex(configureMappings, configureIndex);
     }
 
-    protected CreateIndexResponse CreateIndex(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest> configureIndex = null)
+    protected CreateIndexResponse CreateIndex(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest>? configureIndex = null)
     {
         return _fixture.CreateIndex(index, configureIndex);
     }
@@ -63,7 +63,7 @@ public class ElasticsearchFixture : IAsyncLifetime
 {
     private readonly List<IndexName> _createdIndexes = new();
     private static bool _elaticsearchReady;
-    protected readonly ILogger _logger;
+    protected readonly ILogger _logger = null!;
     private readonly Lazy<IElasticClient> _client;
 
     public ElasticsearchFixture()
@@ -71,10 +71,10 @@ public class ElasticsearchFixture : IAsyncLifetime
         _client = new Lazy<IElasticClient>(() => GetClient(ConfigureConnectionSettings));
     }
 
-    public TestLogger Log { get; set; }
+    public TestLogger Log { get; set; } = null!;
     public IElasticClient Client => _client.Value;
 
-    protected IElasticClient GetClient(Action<ConnectionSettings> configure = null)
+    protected IElasticClient GetClient(Action<ConnectionSettings>? configure = null)
     {
         string elasticsearchUrl = Environment.GetEnvironmentVariable("ELASTICSEARCH_URL") ?? "http://localhost:9200";
         var settings = new ConnectionSettings(new Uri(elasticsearchUrl));
@@ -95,7 +95,7 @@ public class ElasticsearchFixture : IAsyncLifetime
 
     protected virtual void ConfigureConnectionSettings(ConnectionSettings settings) { }
 
-    public void CreateNamedIndex<T>(string index, Func<TypeMappingDescriptor<T>, ITypeMapping> configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>> configureIndex = null) where T : class
+    public void CreateNamedIndex<T>(string index, Func<TypeMappingDescriptor<T>, ITypeMapping>? configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>>? configureIndex = null) where T : class
     {
         if (configureMappings == null)
             configureMappings = m => m.AutoMap<T>().Dynamic();
@@ -106,7 +106,7 @@ public class ElasticsearchFixture : IAsyncLifetime
         Client.ConnectionSettings.DefaultIndices[typeof(T)] = index;
     }
 
-    public string CreateRandomIndex<T>(Func<TypeMappingDescriptor<T>, ITypeMapping> configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>> configureIndex = null) where T : class
+    public string CreateRandomIndex<T>(Func<TypeMappingDescriptor<T>, ITypeMapping>? configureMappings = null, Func<IndexSettingsDescriptor, IPromise<IIndexSettings>>? configureIndex = null) where T : class
     {
         string index = "test_" + Guid.NewGuid().ToString("N");
         if (configureMappings == null)
@@ -120,7 +120,7 @@ public class ElasticsearchFixture : IAsyncLifetime
         return index;
     }
 
-    public CreateIndexResponse CreateIndex(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest> configureIndex = null)
+    public CreateIndexResponse CreateIndex(IndexName index, Func<CreateIndexDescriptor, ICreateIndexRequest>? configureIndex = null)
     {
         _createdIndexes.Add(index);
 

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/CleanupQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/CleanupQueryVisitorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -45,7 +45,7 @@ public class CleanupQueryVisitorTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        IQueryNode result;
+        IQueryNode? result;
         try
         {
             result = await parser.ParseAsync(query);
@@ -56,7 +56,8 @@ public class CleanupQueryVisitorTests : TestWithLoggingBase
             return;
         }
 
-        string cleanedQuery = await CleanupQueryVisitor.RunAsync(result);
+        Assert.NotNull(result);
+        string? cleanedQuery = await CleanupQueryVisitor.RunAsync(result);
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);
         Assert.Equal(expected, cleanedQuery);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/FieldResolverVisitorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
@@ -14,8 +14,10 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap { { "field1", "field2" } };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2:value", aliased.ToString());
     }
 
@@ -33,7 +35,7 @@ public class FieldResolverVisitorTests
             };
 
         var resolver = map.ToHierarchicalFieldResolver();
-        string resolvedField = await resolver(field, null);
+        string? resolvedField = await resolver(field, null);
         Assert.Equal(expected, resolvedField);
     }
 
@@ -42,10 +44,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "nested", "field2" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field1.nested:value", aliased.ToString());
     }
 
@@ -54,10 +58,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.other:value", aliased.ToString());
     }
 
@@ -66,10 +72,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.other:value", aliased.ToString());
     }
 
@@ -78,10 +86,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested.childproperty:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested.childproperty", "field2.other.childproperty" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.other.childproperty:value", aliased.ToString());
     }
 
@@ -90,10 +100,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested.childproperty:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested.childproperty", "field2.other.childproperty" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.other.childproperty:value", aliased.ToString());
     }
 
@@ -102,10 +114,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested.hey:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested.hey", "field2.other.blah" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.other.blah:value", aliased.ToString());
     }
 
@@ -114,10 +128,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("(field1.nested:value field1.another:blah)");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("(field2.other:value field1.another:blah)", aliased.ToString());
     }
 
@@ -126,10 +142,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("level1.level2.level3.level4:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "level1.level2.level3.level4", "alias1.alias2.level3.level4" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("alias1.alias2.level3.level4:value", aliased.ToString());
     }
 
@@ -138,10 +156,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.nested" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.nested:value", aliased.ToString());
     }
 
@@ -150,10 +170,12 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested.morenested:value");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested.morenested", "field2.nested.morenested" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.nested.morenested:value", aliased.ToString());
     }
 
@@ -162,11 +184,13 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("(field1.nested:value OR field1.thing:yep) another:works");
+        Assert.NotNull(result);
         var aliasMap = new FieldMap {
                 { "field1.nested", "field2.other" },
                 { "field1.thing", "field2.nice" }
             };
         var aliased = await FieldResolverQueryVisitor.RunAsync(result, aliasMap);
+        Assert.NotNull(aliased);
         Assert.Equal("(field2.other:value OR field2.nice:yep) another:works", aliased.ToString());
     }
 
@@ -175,7 +199,9 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, f => f == "field1.nested" ? "field2.nested" : null);
+        Assert.NotNull(result);
+        var aliased = await FieldResolverQueryVisitor.RunAsync(result, f => f == "field1.nested" ? "field2.nested" : null!);
+        Assert.NotNull(aliased);
         Assert.Equal("field2.nested:value", aliased.ToString());
     }
 
@@ -184,9 +210,10 @@ public class FieldResolverVisitorTests
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1.nested:value");
+        Assert.NotNull(result);
 
         var context = new QueryVisitorContext();
-        var aliased = await FieldResolverQueryVisitor.RunAsync(result, _ => throw new ApplicationException("Bam"), context);
+        await FieldResolverQueryVisitor.RunAsync(result, _ => throw new ApplicationException("Bam"), context);
         var validationResult = context.GetValidationResult();
 
         Assert.False(validationResult.IsValid);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/GenerateQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/GenerateQueryVisitorTests.cs
@@ -41,7 +41,8 @@ public class GenerateQueryVisitorTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        IQueryNode parsedQuery = await parser.ParseAsync(query);
+        var parsedQuery = await parser.ParseAsync(query);
+        Assert.NotNull(parsedQuery);
 
         var context = new QueryVisitorContext { DefaultOperator = defaultOperator };
         string result = await GenerateQueryVisitor.RunAsync(parsedQuery, context);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/IncludeQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/IncludeQueryVisitorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
@@ -22,7 +22,9 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("@include:other");
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
+        Assert.NotNull(result);
         var resolved = await IncludeVisitor.RunAsync(result, includes);
+        Assert.NotNull(resolved);
         Assert.Equal("(field:value)", resolved.ToString());
     }
 
@@ -35,17 +37,23 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
                 { "other", "field:value" },
                 { "nested", "field:value @include:other" }
             };
+        Assert.NotNull(result);
         var resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: (_, _) => true);
+        Assert.NotNull(resolved);
         Assert.Equal("outter @include:other @skipped:(other stuff @include:other)", resolved.ToString());
 
         resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: ShouldSkipInclude);
+        Assert.NotNull(resolved);
         Assert.Equal("outter (field:value) @skipped:(other stuff @include:other)", resolved.ToString());
 
         resolved = await IncludeVisitor.RunAsync(result, includes, shouldSkipInclude: (n, ctx) => !ShouldSkipInclude(n, ctx));
+        Assert.NotNull(resolved);
         Assert.Equal("outter (field:value) @skipped:(other stuff (field:value))", resolved.ToString());
 
         var nestedResult = await parser.ParseAsync("outter @skipped:(other stuff @include:nested)");
+        Assert.NotNull(nestedResult);
         resolved = await IncludeVisitor.RunAsync(nestedResult, includes, shouldSkipInclude: ShouldSkipInclude);
+        Assert.NotNull(resolved);
         Assert.Equal("outter @skipped:(other stuff @include:nested)", resolved.ToString());
     }
 
@@ -74,7 +82,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result, includes, context);
+        Assert.NotNull(result);
+        await IncludeVisitor.RunAsync(result, includes, context);
         var validationResult = context.GetValidationResult();
         Assert.False(validationResult.IsValid);
         Assert.Contains("Recursive", validationResult.Message);
@@ -91,7 +100,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result, includes, context);
+        Assert.NotNull(result);
+        await IncludeVisitor.RunAsync(result, includes, context);
         var validationResult = context.GetValidationResult();
         Assert.Contains("include1", validationResult.UnresolvedIncludes);
         Assert.False(validationResult.IsValid);
@@ -106,7 +116,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var result = await parser.ParseAsync("field1:value1 @include:include1");
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result, _ => throw new ApplicationException("Bam"), context);
+        Assert.NotNull(result);
+        await IncludeVisitor.RunAsync(result, _ => throw new ApplicationException("Bam"), context);
         var validationResult = context.GetValidationResult();
         Assert.Contains("include1", validationResult.UnresolvedIncludes);
         Assert.False(validationResult.IsValid);
@@ -124,7 +135,8 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         };
 
         var context = new QueryVisitorContext();
-        var resolved = await IncludeVisitor.RunAsync(result, includes, context);
+        Assert.NotNull(result);
+        await IncludeVisitor.RunAsync(result, includes, context);
         Assert.True(context.IsValid());
     }
 
@@ -134,7 +146,9 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value1 @include:other");
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
+        Assert.NotNull(result);
         var resolved = await IncludeVisitor.RunAsync(result, includes);
+        Assert.NotNull(resolved);
         Assert.Equal("field1:value1 (field:value)", resolved.ToString());
     }
 
@@ -144,7 +158,9 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value1 OR (@include:other field2:value2)");
         var includes = new Dictionary<string, string> { { "other", "field:value" } };
+        Assert.NotNull(result);
         var resolved = await IncludeVisitor.RunAsync(result, includes);
+        Assert.NotNull(resolved);
         Assert.Equal("field1:value1 OR ((field:value) field2:value2)", resolved.ToString());
     }
 
@@ -157,7 +173,9 @@ public class IncludeQueryVisitorTests : TestWithLoggingBase
                 { "other", "@include:other2" },
                 { "other2", "field2:value2" }
             };
+        Assert.NotNull(result);
         var resolved = await IncludeVisitor.RunAsync(result, includes);
+        Assert.NotNull(resolved);
         Assert.Equal("((field2:value2))", resolved.ToString());
     }
 }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/InvertQueryVisitorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/InvertQueryVisitorTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
 using Foundatio.Parsers.LuceneQueries.Nodes;
@@ -99,12 +99,12 @@ public class InvertQueryVisitorTests : TestWithLoggingBase
     [InlineData("noninvertedfield1:value field1:value field2:value field3:value", "noninvertedfield1:value (is_deleted:true OR (NOT (field1:value field2:value field3:value)))", "is_deleted:true")]
     [InlineData("noninvertedfield1:123 (status:open OR status:regressed) noninvertedfield1:234", "noninvertedfield1:123 (NOT (status:open OR status:regressed)) noninvertedfield1:234")]
     [InlineData("first_occurrence:[1609459200000 TO 1609730450521] (noninvertedfield1:537650f3b77efe23a47914f4 (status:open OR status:regressed))", "(NOT first_occurrence:[1609459200000 TO 1609730450521]) (noninvertedfield1:537650f3b77efe23a47914f4 (NOT (status:open OR status:regressed)))")]
-    public Task CanInvertQuery(string query, string expected, string alternateInvertedCriteria = null)
+    public Task CanInvertQuery(string query, string expected, string? alternateInvertedCriteria = null)
     {
         return InvertAndValidateQuery(query, expected, alternateInvertedCriteria, true);
     }
 
-    private async Task InvertAndValidateQuery(string query, string expected, string alternateInvertedCriteria, bool isValid)
+    private async Task InvertAndValidateQuery(string query, string expected, string? alternateInvertedCriteria, bool isValid)
     {
 #if ENABLE_TRACING
             var tracer = new LoggingTracer(_logger, reportPerformance: true);
@@ -116,7 +116,7 @@ public class InvertQueryVisitorTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        IQueryNode result;
+        IQueryNode? result;
         try
         {
             result = await parser.ParseAsync(query);
@@ -133,10 +133,13 @@ public class InvertQueryVisitorTests : TestWithLoggingBase
         if (!String.IsNullOrWhiteSpace(alternateInvertedCriteria))
         {
             var invertedAlternate = await parser.ParseAsync(alternateInvertedCriteria);
+            Assert.NotNull(invertedAlternate);
             context.SetAlternateInvertedCriteria(invertedAlternate);
         }
 
+        Assert.NotNull(result);
         result = await invertQueryVisitor.AcceptAsync(result, context);
+        Assert.NotNull(result);
         string invertedQuery = result.ToString();
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -38,6 +38,7 @@ public class QueryParserTests : TestWithLoggingBase
         try
         {
             var result = await parser.ParseAsync(query);
+            Assert.NotNull(result);
 
             _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
             string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
@@ -73,6 +74,7 @@ public class QueryParserTests : TestWithLoggingBase
         try
         {
             var result = await parser.ParseAsync(query);
+            Assert.NotNull(result);
 
             _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
             string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
@@ -114,6 +116,7 @@ public class QueryParserTests : TestWithLoggingBase
         try
         {
             var result = await parser.ParseAsync(query);
+            Assert.NotNull(result);
 
             _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
             string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
@@ -159,6 +162,7 @@ public class QueryParserTests : TestWithLoggingBase
         };
         string query = "mydate:[now/d TO now/d+30d/d]";
         var result = sut.Parse(query);
+        Assert.NotNull(result);
         _logger.LogInformation(DebugQueryVisitor.Run(result));
 
         string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
@@ -216,6 +220,7 @@ public class QueryParserTests : TestWithLoggingBase
         try
         {
             var result = await parser.ParseAsync(query);
+            Assert.NotNull(result);
 
             _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
             string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
@@ -260,8 +265,8 @@ public class QueryParserTests : TestWithLoggingBase
         string ast = DebugQueryVisitor.Run(result);
 
         Assert.IsType<GroupNode>(result.Left);
-        Assert.True((result.Left as GroupNode).HasParens);
-        Assert.True((result.Left as GroupNode).IsNegated);
+        Assert.True((result.Left as GroupNode)!.HasParens);
+        Assert.True((result.Left as GroupNode)!.IsNegated);
     }
 
     [Fact]
@@ -438,7 +443,7 @@ public class QueryParserTests : TestWithLoggingBase
 
         Assert.IsType<TermNode>(result.Left);
         Assert.True(((TermNode)result.Left).IsQuotedTerm);
-        Assert.Empty(((TermNode)result.Left).Term);
+        Assert.Empty(((TermNode)result.Left).Term!);
     }
 
     [Fact]
@@ -508,12 +513,13 @@ public class QueryParserTests : TestWithLoggingBase
         var parser = new LuceneQueryParser();
 
         var result = await parser.ParseAsync(query);
+        Assert.NotNull(result);
 
         _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
         string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
         Assert.Equal(expected, generatedQuery);
 
-        await new AssignOperationTypeVisitor().AcceptAsync(result, null);
+        await new AssignOperationTypeVisitor().AcceptAsync(result, new QueryVisitorContext());
         _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
     }
 
@@ -524,7 +530,7 @@ public class QueryParserTests : TestWithLoggingBase
     [InlineData("\"phrase query\"~2", null, true, "2")]
     [InlineData("field:term~", "field", false, "")]
     [InlineData("field:\"phrase\"~3", "field", true, "3")]
-    public void Parse_WithProximityModifier_SetsProximityOnTermNode(string query, string expectedField, bool expectedQuoted, string expectedProximity)
+    public void Parse_WithProximityModifier_SetsProximityOnTermNode(string query, string? expectedField, bool expectedQuoted, string expectedProximity)
     {
         var parser = new LuceneQueryParser();
         var result = parser.Parse(query);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserValidationTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserValidationTests.cs
@@ -177,7 +177,7 @@ public class QueryParserValidationTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        IQueryNode result;
+        IQueryNode? result;
         try
         {
             result = await parser.ParseAsync(query);
@@ -188,6 +188,7 @@ public class QueryParserValidationTests : TestWithLoggingBase
             return;
         }
 
+        Assert.NotNull(result);
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Result}", nodes);
         string generatedQuery = await GenerateQueryVisitor.RunAsync(result);
@@ -231,6 +232,7 @@ public class QueryParserValidationTests : TestWithLoggingBase
         {
             _logger.LogInformation("Attempting: {Escaped}", escaped);
             var result = await parser.ParseAsync(query);
+            Assert.NotNull(result);
 
             _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
             string generatedQuery = await GenerateQueryVisitor.RunAsync(result);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryValidatorTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryValidatorTests.cs
@@ -29,6 +29,7 @@ public class QueryValidatorTests : TestWithLoggingBase
     {
         var ex = await Assert.ThrowsAsync<QueryValidationException>(() => QueryValidator.ValidateQueryAndThrowAsync(@":"));
         Assert.Contains("Unexpected", ex.Message);
+        Assert.NotNull(ex.Result);
         Assert.False(ex.Result.IsValid);
         Assert.NotNull(ex.Result.Message);
         Assert.Contains("Unexpected", ex.Result.Message);
@@ -158,7 +159,7 @@ public class QueryValidatorTests : TestWithLoggingBase
         context.SetFieldResolver(f => f == "field1" ? f : null);
         var info = await QueryValidator.ValidateQueryAsync(@"field1:blah field2:blah", options, context);
         Assert.False(info.IsValid);
-        Assert.Contains("field2", info.UnresolvedFields);
+        Assert.Contains("field2", info.UnresolvedFields!);
     }
 
     [Fact]
@@ -172,10 +173,12 @@ public class QueryValidatorTests : TestWithLoggingBase
         context.SetFieldResolver(f => f == "field1" ? f : null);
         var ex = await Assert.ThrowsAsync<QueryValidationException>(() => QueryValidator.ValidateQueryAndThrowAsync(@"field1:blah field2:blah", options, context));
         Assert.Contains("resolved", ex.Message);
+        Assert.NotNull(ex.Result);
+        Assert.NotNull(ex.Result.UnresolvedFields);
         Assert.Contains("field2", ex.Result.UnresolvedFields);
         Assert.False(ex.Result.IsValid);
         Assert.NotNull(ex.Result.Message);
-        Assert.Contains("resolved", ex.Result.Message);
+        Assert.Contains("resolved", ex.Result.Message!);
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/ReferencedFieldsTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/ReferencedFieldsTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Extensions;
 using Foundatio.Xunit;
 using Xunit;
@@ -17,6 +17,7 @@ public class ReferencedFieldsTests : TestWithLoggingBase
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
+        Assert.NotNull(result);
         var fields = result.GetReferencedFields();
 
         Assert.Equal(6, fields.Count);
@@ -44,6 +45,7 @@ public class ReferencedFieldsTests : TestWithLoggingBase
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
+        Assert.NotNull(result);
         var fields = result.GetReferencedFields(currentGroupOnly: true);
 
         Assert.Equal(3, fields.Count);

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/RemoveFieldsQueryVisitor.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/RemoveFieldsQueryVisitor.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Visitors;
 using Foundatio.Xunit;
 using Xunit;
@@ -17,7 +17,8 @@ public class RemoveFieldsQueryVisitorTests : TestWithLoggingBase
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
-        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, ["field1"]);
+        Assert.NotNull(result);
+        string? queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, ["field1"]);
 
         Assert.Equal("field2:value (field3:value OR field4:value (field5:value)) field6:value", queryResult);
     }
@@ -27,7 +28,8 @@ public class RemoveFieldsQueryVisitorTests : TestWithLoggingBase
     {
         var parser = new LuceneQueryParser();
         var result = await parser.ParseAsync("field1:value field2:value (field3:value OR field4:value (field5:value)) field6:value");
-        string queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, f => f == "field3");
+        Assert.NotNull(result);
+        string? queryResult = await RemoveFieldsQueryVisitor.RunAsync(result, f => f == "field3");
 
         Assert.Equal("field1:value field2:value (field4:value (field5:value)) field6:value", queryResult);
     }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/UnescapeTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/UnescapeTests.cs
@@ -21,7 +21,7 @@ public sealed class UnescapeTests : TestWithLoggingBase
     [InlineData(@"At end \", @"At end \")]
     public void UnescapingWorks(string test, string expected)
     {
-        string result = test.Unescape();
+        string? result = test.Unescape();
         Assert.Equal(expected, result);
     }
 }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/Utility/LoggingTracer.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/Utility/LoggingTracer.cs
@@ -197,18 +197,18 @@ public class LoggingTracer : ITracer
         /// <summary>
         /// Gets the name of the rule.
         /// </summary>
-        public string Name { get; internal set; }
+        public string Name { get; internal set; } = null!;
     }
 
     private class RuleStackEntry
     {
         public bool? CacheHit { get; set; }
 
-        public Cursor Cursor { get; set; }
+        public Cursor Cursor { get; set; } = null!;
 
-        public string RuleName { get; set; }
+        public string RuleName { get; set; } = null!;
 
-        public Stopwatch Stopwatch { get; set; }
+        public Stopwatch Stopwatch { get; set; } = null!;
     }
 
     private class RuleStats

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/DynamicFieldVisitor.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/DynamicFieldVisitor.cs
@@ -15,7 +15,7 @@ public class DynamicFieldVisitor : ChainableMutatingQueryVisitor
 
         var field = SqlNodeExtensions.GetFieldInfo(sqlContext.Fields, node.Field);
 
-        if (field == null || !field.Data.TryGetValue("DataDefinitionId", out object value) ||
+        if (field is null || !field.Data.TryGetValue("DataDefinitionId", out object? value) ||
             value is not int dataDefinitionId)
         {
             return node;

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/Foundatio.Parsers.SqlQueries.Tests.csproj
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/Foundatio.Parsers.SqlQueries.Tests.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
-      <PackageReference Include="libphonenumber-csharp" Version="9.0.26" />
+      <PackageReference Include="libphonenumber-csharp" Version="9.0.27" />
     </ItemGroup>
 
 </Project>

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SampleContext.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SampleContext.cs
@@ -58,15 +58,15 @@ public class SampleContext : DbContext
 public class Employee
 {
     public int Id { get; set; }
-    public string FullName { get; set; }
-    public string PhoneNumber { get; set; }
-    public string NationalPhoneNumber { get; set; }
-    public string Title { get; set; }
+    public string FullName { get; set; } = null!;
+    public string PhoneNumber { get; set; } = null!;
+    public string NationalPhoneNumber { get; set; } = null!;
+    public string Title { get; set; } = null!;
     public int Salary { get; set; }
     public int? CurrentCompanyId { get; set; }
-    public Company CurrentCompany { get; set; }
-    public List<Company> Companies { get; set; }
-    public List<DataValue> DataValues { get; set; }
+    public Company? CurrentCompany { get; set; }
+    public List<Company> Companies { get; set; } = null!;
+    public List<DataValue> DataValues { get; set; } = null!;
     public TimeOnly HappyHour { get; set; }
     public DateOnly Birthday { get; set; }
 
@@ -76,11 +76,11 @@ public class Employee
 public class Company
 {
     public int Id { get; set; }
-    public string Name { get; set; }
-    public string Description { get; set; }
-    public string Location { get; set; }
-    public List<Employee> Employees { get; set; }
-    public List<DataDefinition> DataDefinitions { get; set; }
+    public string Name { get; set; } = null!;
+    public string? Description { get; set; }
+    public string? Location { get; set; }
+    public List<Employee> Employees { get; set; } = null!;
+    public List<DataDefinition> DataDefinitions { get; set; } = null!;
 }
 
 public class DataValue
@@ -91,16 +91,16 @@ public class DataValue
     public int EmployeeId { get; set; }
 
     // store the values separately as sparse columns for querying purposes
-    public string StringValue { get; set; }
+    public string? StringValue { get; set; }
     public DateTime? DateValue { get; set; }
     public DateOnly? DateOnlyValue { get; set; }
     public decimal? MoneyValue { get; set; }
     public bool? BooleanValue { get; set; }
     public decimal? NumberValue { get; set; }
 
-    public DataDefinition Definition { get; set; } = null;
+    public DataDefinition? Definition { get; set; } = null;
 
-    public object GetValue(DataType? dataType = null)
+    public object? GetValue(DataType? dataType = null)
     {
         if (!dataType.HasValue && Definition != null)
             dataType = Definition.DataType;
@@ -136,6 +136,7 @@ public class DataValue
     {
         StringValue = null;
         DateValue = null;
+        DateOnlyValue = null;
         NumberValue = null;
         BooleanValue = null;
         MoneyValue = null;
@@ -175,7 +176,7 @@ public class DataValue
 
     // relationships
     [DeleteBehavior(DeleteBehavior.NoAction)]
-    public Employee Employee { get; set; } = null;
+    public Employee? Employee { get; set; } = null;
 }
 
 public class DataDefinition
@@ -188,7 +189,7 @@ public class DataDefinition
 
     // relationships
     [DeleteBehavior(DeleteBehavior.Cascade)]
-    public Company Company { get; set; } = null;
+    public Company? Company { get; set; } = null;
 }
 
 public enum DataType

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -97,7 +97,11 @@ public class SqlQueryParserTests : TestWithLoggingBase
             if (s.FieldInfo.FullName != "NationalPhoneNumber")
                 return;
 
-            s.Tokens = [TryGetNationalNumber(s.Term)!];
+            var nationalNumber = TryGetNationalNumber(s.Term);
+            if (nationalNumber is null)
+                return;
+
+            s.Tokens = [nationalNumber];
             s.Operator = SqlSearchOperator.StartsWith;
         });
 

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -97,7 +97,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
             if (s.FieldInfo.FullName != "NationalPhoneNumber")
                 return;
 
-            s.Tokens = [TryGetNationalNumber(s.Term)];
+            s.Tokens = [TryGetNationalNumber(s.Term)!];
             s.Operator = SqlSearchOperator.StartsWith;
         });
 
@@ -344,7 +344,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
 
         var context = parser.GetContext(db.Employees.EntityType);
 
-        string sqlExpected = db.Employees.Where(e => EF.Functions.Contains(e.CurrentCompany.Name, "\"acme*\"") || EF.Functions.Contains(e.CurrentCompany.Location, "\"acme*\"")).ToQueryString();
+        string sqlExpected = db.Employees.Where(e => EF.Functions.Contains(e.CurrentCompany!.Name, "\"acme*\"") || EF.Functions.Contains(e.CurrentCompany!.Location!, "\"acme*\"")).ToQueryString();
 
         await SqlWaiter.WaitForFullTextIndexAsync(db, "ftCatalog");
 
@@ -430,7 +430,9 @@ public class SqlQueryParserTests : TestWithLoggingBase
         var parser = sp.GetRequiredService<SqlQueryParser>();
 
         var context = parser.GetContext(db.Employees.EntityType);
+        context.Fields ??= [];
         context.Fields.Add(new EntityFieldInfo { Name = "age", FullName = "age", IsNumber = true, Data = { { "DataDefinitionId", 1 } } });
+        Assert.NotNull(context.ValidationOptions);
         context.ValidationOptions.AllowedFields.Add("age");
 
         string sqlExpected = db.Employees.Where(e => e.Companies.Any(c => c.Name == "acme") && e.DataValues.Any(dv => dv.DataDefinitionId == 1 && dv.NumberValue == 30)).ToQueryString();
@@ -455,7 +457,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
         Assert.Equal("John Doe", employee.FullName);
     }
 
-    public static string TryGetNationalNumber(string phoneNumber, string regionCode = "US")
+    public static string? TryGetNationalNumber(string phoneNumber, string regionCode = "US")
     {
         var phoneNumberUtil = PhoneNumberUtil.GetInstance();
         try
@@ -584,7 +586,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
             Tracer = tracer
         };
 
-        IQueryNode result;
+        IQueryNode? result;
         try
         {
             result = await parser.ParseAsync(query);
@@ -595,6 +597,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
             return;
         }
 
+        Assert.NotNull(result);
         string nodes = await DebugQueryVisitor.RunAsync(result);
         _logger.LogInformation("{Nodes}", nodes);
         var context = new SqlQueryVisitorContext


### PR DESCRIPTION
## Summary
- Merged origin/main into feature/elastic-client-nrt to bring in NRT (Nullable Reference Types) commits
- Resolved 31 merge conflicts by keeping the new ES 8.x client code while incorporating NRT annotations
- Fixed all NRT compilation errors across LuceneQueries, ElasticQueries, SqlQueries, and test projects
- Build passes with 0 warnings and 0 errors

## Conflict Resolution Strategy
- **LuceneQueries/SqlQueries** (client-agnostic): Accepted main's NRT version directly
- **ElasticQueries** (ES client files): Kept feature branch ES 8.x types, applied nullable annotations and is-null patterns from main
- **Tests**: Kept new ES client assertions, replaced null-forgiving operators with Assert.NotNull where appropriate

## Test plan
- [x] dotnet build Foundatio.Parsers.slnx (0 errors, 0 warnings)
- [ ] dotnet test Foundatio.Parsers.slnx (requires Elasticsearch)