### PR TITLE
Fix grouped range queries dropping field from parent GroupNode

### DIFF
--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -345,7 +345,12 @@ public static class DefaultQueryNodeExtensions
 
         string? field = node.UnescapedField;
         if (String.IsNullOrEmpty(field))
-            return null;
+        {
+            if (node.Parent is GroupNode parentGroup && !String.IsNullOrEmpty(parentGroup.UnescapedField))
+                field = parentGroup.UnescapedField;
+            else
+                return null;
+        }
 
         if (elasticContext.MappingResolver.IsDatePropertyType(field))
         {

--- a/src/Foundatio.Parsers.ElasticQueries/Foundatio.Parsers.ElasticQueries.csproj
+++ b/src/Foundatio.Parsers.ElasticQueries/Foundatio.Parsers.ElasticQueries.csproj
@@ -4,7 +4,7 @@
     <Compile Include="..\Foundatio.Parsers.LuceneQueries\Extensions\TaskExtensions.cs" Link="Extensions\TaskExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.19.21" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.19.22" />
     <PackageReference Include="Exceptionless.DateTimeExtensions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -1694,13 +1694,14 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         Assert.NotNull(clauses);
         Assert.Equal(2, clauses.Count);
 
-        var termRange1 = Assert.IsType<TermRangeQuery>(clauses.ElementAt(0).Range);
-        Assert.Equal("field", termRange1.Field.ToString());
-        Assert.Equal("30", termRange1.Gt);
+        var ranges = clauses.Select(c => c.Range).OfType<TermRangeQuery>().ToList();
+        Assert.Equal(2, ranges.Count);
 
-        var termRange2 = Assert.IsType<TermRangeQuery>(clauses.ElementAt(1).Range);
-        Assert.Equal("field", termRange2.Field.ToString());
-        Assert.Equal("40", termRange2.Lte);
+        var gtRange = ranges.First(r => r.Gt is not null && r.Gt == "30");
+        Assert.Equal("field", gtRange.Field.ToString());
+
+        var lteRange = ranges.First(r => r.Lte is not null && r.Lte == "40");
+        Assert.Equal("field", lteRange.Field.ToString());
     }
 
     [Fact]
@@ -1720,13 +1721,14 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         Assert.NotNull(clauses);
         Assert.Equal(2, clauses.Count);
 
-        var termRange1 = Assert.IsType<TermRangeQuery>(clauses.ElementAt(0).Range);
-        Assert.Equal("field", termRange1.Field.ToString());
-        Assert.Equal("10", termRange1.Gte);
+        var ranges = clauses.Select(c => c.Range).OfType<TermRangeQuery>().ToList();
+        Assert.Equal(2, ranges.Count);
 
-        var termRange2 = Assert.IsType<TermRangeQuery>(clauses.ElementAt(1).Range);
-        Assert.Equal("field", termRange2.Field.ToString());
-        Assert.Equal("20", termRange2.Lt);
+        var gteRange = ranges.First(r => r.Gte is not null && r.Gte == "10");
+        Assert.Equal("field", gteRange.Field.ToString());
+
+        var ltRange = ranges.First(r => r.Lt is not null && r.Lt == "20");
+        Assert.Equal("field", ltRange.Field.ToString());
     }
 
     [Fact]
@@ -1748,11 +1750,11 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
 
         var rangeQueries = clauses.Where(c => c.Range is TermRangeQuery).ToList();
         Assert.Equal(2, rangeQueries.Count);
-        foreach (var rq in rangeQueries)
+        Assert.All(rangeQueries, rq =>
         {
             var termRange = Assert.IsType<TermRangeQuery>(rq.Range);
             Assert.Equal("field", termRange.Field.ToString());
-        }
+        });
 
         var termQueries = clauses.Where(c => c.Term is not null).ToList();
         Assert.Single(termQueries);

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Aggregations;
@@ -1713,6 +1714,78 @@ public class UpdateFixedTermFieldToDateFixedExistsQueryVisitor : ChainableQueryV
         var query = new Query { Exists = new ExistsQuery { Field = "date_fixed" } };
         node.SetQuery(isFixed ? query : !query);
     }
+
+    [Fact]
+    public async Task BuildQueryAsync_GroupedRangeWithExclusiveBounds_PropagatesFieldToTermRangeNodes()
+    {
+        // Arrange
+        var sut = new ElasticQueryParser();
+
+        // Act
+        var result = await sut.BuildQueryAsync("field:(>30 AND <=40)");
+
+        // Assert
+        Assert.NotNull(result);
+        var boolQuery = result.Bool;
+        Assert.NotNull(boolQuery);
+        var clauses = boolQuery.Filter ?? boolQuery.Must;
+        Assert.NotNull(clauses);
+        Assert.Equal(2, clauses.Count);
+
+        var termRange1 = clauses.ElementAt(0).Range as TermRangeQuery;
+        Assert.NotNull(termRange1);
+        Assert.Equal("field", termRange1.Field.ToString());
+        Assert.Equal("30", termRange1.Gt);
+
+        var termRange2 = clauses.ElementAt(1).Range as TermRangeQuery;
+        Assert.NotNull(termRange2);
+        Assert.Equal("field", termRange2.Field.ToString());
+        Assert.Equal("40", termRange2.Lte);
+    }
+
+    [Fact]
+    public async Task BuildQueryAsync_GroupedRangeWithInclusiveBounds_PropagatesFieldToTermRangeNodes()
+    {
+        // Arrange
+        var sut = new ElasticQueryParser();
+
+        // Act
+        var result = await sut.BuildQueryAsync("field:(>=10 AND <20)");
+
+        // Assert
+        Assert.NotNull(result);
+        var boolQuery = result.Bool;
+        Assert.NotNull(boolQuery);
+        var clauses = boolQuery.Filter ?? boolQuery.Must;
+        Assert.NotNull(clauses);
+        Assert.Equal(2, clauses.Count);
+
+        var termRange1 = clauses.ElementAt(0).Range as TermRangeQuery;
+        Assert.NotNull(termRange1);
+        Assert.Equal("field", termRange1.Field.ToString());
+        Assert.Equal("10", termRange1.Gte);
+
+        var termRange2 = clauses.ElementAt(1).Range as TermRangeQuery;
+        Assert.NotNull(termRange2);
+        Assert.Equal("field", termRange2.Field.ToString());
+        Assert.Equal("20", termRange2.Lt);
+    }
+
+    [Fact]
+    public async Task BuildQueryAsync_GroupedRangeWithOtherTerms_ProducesBoolQueryWithAllClauses()
+    {
+        // Arrange
+        var sut = new ElasticQueryParser();
+
+        // Act
+        var result = await sut.BuildQueryAsync("field:(>30 AND <=40) AND other:value");
+
+        // Assert
+        Assert.NotNull(result);
+        var boolQuery = result.Bool;
+        Assert.NotNull(boolQuery);
+    }
+
 }
 
 public class TestQueryVisitor : ChainableQueryVisitor

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -1676,6 +1676,88 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         Assert.Single(result.ReferencedFields, "field1");
         Assert.Empty(result.UnresolvedFields);
     }
+
+    [Fact]
+    public async Task BuildQueryAsync_GroupedRangeWithExclusiveBounds_PropagatesFieldToTermRangeNodes()
+    {
+        // Arrange
+        var sut = new ElasticQueryParser();
+
+        // Act
+        var result = await sut.BuildQueryAsync("field:(>30 AND <=40)");
+
+        // Assert
+        Assert.NotNull(result);
+        var boolQuery = result.Bool;
+        Assert.NotNull(boolQuery);
+        var clauses = boolQuery.Filter ?? boolQuery.Must;
+        Assert.NotNull(clauses);
+        Assert.Equal(2, clauses.Count);
+
+        var termRange1 = Assert.IsType<TermRangeQuery>(clauses.ElementAt(0).Range);
+        Assert.Equal("field", termRange1.Field.ToString());
+        Assert.Equal("30", termRange1.Gt);
+
+        var termRange2 = Assert.IsType<TermRangeQuery>(clauses.ElementAt(1).Range);
+        Assert.Equal("field", termRange2.Field.ToString());
+        Assert.Equal("40", termRange2.Lte);
+    }
+
+    [Fact]
+    public async Task BuildQueryAsync_GroupedRangeWithInclusiveBounds_PropagatesFieldToTermRangeNodes()
+    {
+        // Arrange
+        var sut = new ElasticQueryParser();
+
+        // Act
+        var result = await sut.BuildQueryAsync("field:(>=10 AND <20)");
+
+        // Assert
+        Assert.NotNull(result);
+        var boolQuery = result.Bool;
+        Assert.NotNull(boolQuery);
+        var clauses = boolQuery.Filter ?? boolQuery.Must;
+        Assert.NotNull(clauses);
+        Assert.Equal(2, clauses.Count);
+
+        var termRange1 = Assert.IsType<TermRangeQuery>(clauses.ElementAt(0).Range);
+        Assert.Equal("field", termRange1.Field.ToString());
+        Assert.Equal("10", termRange1.Gte);
+
+        var termRange2 = Assert.IsType<TermRangeQuery>(clauses.ElementAt(1).Range);
+        Assert.Equal("field", termRange2.Field.ToString());
+        Assert.Equal("20", termRange2.Lt);
+    }
+
+    [Fact]
+    public async Task BuildQueryAsync_GroupedRangeWithOtherTerms_ProducesBoolQueryWithAllClauses()
+    {
+        // Arrange
+        var sut = new ElasticQueryParser();
+
+        // Act
+        var result = await sut.BuildQueryAsync("field:(>30 AND <=40) AND other:value");
+
+        // Assert
+        Assert.NotNull(result);
+        var boolQuery = result.Bool;
+        Assert.NotNull(boolQuery);
+        var clauses = boolQuery.Filter ?? boolQuery.Must;
+        Assert.NotNull(clauses);
+        Assert.True(clauses.Count >= 3, $"Expected at least 3 clauses but found {clauses.Count}");
+
+        var rangeQueries = clauses.Where(c => c.Range is TermRangeQuery).ToList();
+        Assert.Equal(2, rangeQueries.Count);
+        foreach (var rq in rangeQueries)
+        {
+            var termRange = Assert.IsType<TermRangeQuery>(rq.Range);
+            Assert.Equal("field", termRange.Field.ToString());
+        }
+
+        var termQueries = clauses.Where(c => c.Term is not null).ToList();
+        Assert.Single(termQueries);
+        Assert.Equal("other", termQueries[0].Term!.Field.ToString());
+    }
 }
 
 public record MyType
@@ -1714,78 +1796,6 @@ public class UpdateFixedTermFieldToDateFixedExistsQueryVisitor : ChainableQueryV
         var query = new Query { Exists = new ExistsQuery { Field = "date_fixed" } };
         node.SetQuery(isFixed ? query : !query);
     }
-
-    [Fact]
-    public async Task BuildQueryAsync_GroupedRangeWithExclusiveBounds_PropagatesFieldToTermRangeNodes()
-    {
-        // Arrange
-        var sut = new ElasticQueryParser();
-
-        // Act
-        var result = await sut.BuildQueryAsync("field:(>30 AND <=40)");
-
-        // Assert
-        Assert.NotNull(result);
-        var boolQuery = result.Bool;
-        Assert.NotNull(boolQuery);
-        var clauses = boolQuery.Filter ?? boolQuery.Must;
-        Assert.NotNull(clauses);
-        Assert.Equal(2, clauses.Count);
-
-        var termRange1 = clauses.ElementAt(0).Range as TermRangeQuery;
-        Assert.NotNull(termRange1);
-        Assert.Equal("field", termRange1.Field.ToString());
-        Assert.Equal("30", termRange1.Gt);
-
-        var termRange2 = clauses.ElementAt(1).Range as TermRangeQuery;
-        Assert.NotNull(termRange2);
-        Assert.Equal("field", termRange2.Field.ToString());
-        Assert.Equal("40", termRange2.Lte);
-    }
-
-    [Fact]
-    public async Task BuildQueryAsync_GroupedRangeWithInclusiveBounds_PropagatesFieldToTermRangeNodes()
-    {
-        // Arrange
-        var sut = new ElasticQueryParser();
-
-        // Act
-        var result = await sut.BuildQueryAsync("field:(>=10 AND <20)");
-
-        // Assert
-        Assert.NotNull(result);
-        var boolQuery = result.Bool;
-        Assert.NotNull(boolQuery);
-        var clauses = boolQuery.Filter ?? boolQuery.Must;
-        Assert.NotNull(clauses);
-        Assert.Equal(2, clauses.Count);
-
-        var termRange1 = clauses.ElementAt(0).Range as TermRangeQuery;
-        Assert.NotNull(termRange1);
-        Assert.Equal("field", termRange1.Field.ToString());
-        Assert.Equal("10", termRange1.Gte);
-
-        var termRange2 = clauses.ElementAt(1).Range as TermRangeQuery;
-        Assert.NotNull(termRange2);
-        Assert.Equal("field", termRange2.Field.ToString());
-        Assert.Equal("20", termRange2.Lt);
-    }
-
-    [Fact]
-    public async Task BuildQueryAsync_GroupedRangeWithOtherTerms_ProducesBoolQueryWithAllClauses()
-    {
-        // Arrange
-        var sut = new ElasticQueryParser();
-
-        // Act
-        var result = await sut.BuildQueryAsync("field:(>30 AND <=40) AND other:value");
-
-        // Assert
-        Assert.NotNull(result);
-        var boolQuery = result.Bool;
-        Assert.NotNull(boolQuery);
-    }
-
 }
 
 public class TestQueryVisitor : ChainableQueryVisitor


### PR DESCRIPTION
## Summary

- Fix \TermRangeNode\s inside a \GroupNode\ (e.g., \ield:(>30 AND <=40)\) having their range clauses silently dropped because they had no explicit field set
- Propagate the parent \GroupNode\'s field to child \TermRangeNode\s when the child has no field
- Add 3 new tests validating grouped range query generation
- Bump \Elastic.Clients.Elasticsearch\ from 8.19.21 to 8.19.22

## Root Cause

The Lucene query parser has always created \TermRangeNode\s without their own \Field\ when inside a \GroupNode\ (e.g., \ield:(>30 AND <=40)\ produces a \GroupNode\ with field=\ield\ containing two \TermRangeNode\s with field=null).

In the v7/NEST era, \GetDefaultQueryAsync\ would still create a \TermRangeQuery { Field = null }\, and NEST would silently drop it during serialization — so the query was always broken, but it didn't throw.

After the v8 upgrade (d91818b), the \Elastic.Clients.Elasticsearch\ \TermRangeQuery\ constructor requires a non-null field, so \GetDefaultQueryAsync\ was changed to \eturn null\ when the field is empty. This made the bug explicit: range clauses inside grouped fields were now completely dropped.

## Fix

In \DefaultQueryNodeExtensions.GetDefaultQueryAsync(TermRangeNode)\, when \
ode.UnescapedField\ is empty, we now check if the parent is a \GroupNode\ with a field and propagate it before falling through to the existing \eturn null\ path.

## Test plan

- [x] \GroupedRangeQueryPropagatesToChildTermRangeNodes\ - verifies \ield:(>30 AND <=40)\ produces two \TermRangeQuery\s with correct field and bounds  
- [x] \GroupedRangeQueryWithInclusiveBoundaries\ - verifies \ield:(>=10 AND <20)\ with gte/lt operators
- [x] \GroupedRangeQueryCombinedWithOtherTerms\ - verifies combined query \ield:(>30 AND <=40) AND other:value\ produces a valid bool query