### PR TITLE
Fix dynamically created fields resolving as unmapped

### DIFF
--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -288,15 +288,15 @@ dynamically created fields become visible quickly without turning every query in
 | Trigger | Setting | Default | Behavior |
 | --- | --- | --- | --- |
 | The loaded mapping is stale | `MappingRefreshInterval` | 1 minute | Maximum age of the loaded mapping before an ordinary resolution reloads it. |
-| A field could not be resolved | `UnmappedFieldRefreshInterval` | 1 second | A resolution failure is the strongest signal the index mapping changed, so it reloads on a much shorter interval. |
-| A reload is already running | `FetchJoinTimeout` | 30 seconds | How long a resolution waits to join an in-flight reload instead of issuing its own. |
+| A field could not be resolved | `UnmappedFieldRefreshInterval` | 5 seconds | A resolution failure is the strongest signal the index mapping changed, so it reloads on a much shorter interval. |
+| A reload is already running | `MappingRefreshWaitTimeout` | 30 seconds | How long a resolution waits to join an in-flight reload instead of issuing its own. |
 
 A field that cannot be resolved is the normal outcome for fields created at runtime — dynamic templates
 (including the `idx.*` custom field templates used by Foundatio.Repositories) only add a field to the index
 mapping after the first document that uses it is indexed. Because of that, an unresolved field reloads the
 server mapping on its own short interval and is never blocked by the mapping having been loaded at startup.
 
-Reloads that still do not resolve the field back off exponentially (1s, 2s, 4s, 8s, up to
+Reloads that still do not resolve the field back off exponentially (5s, 10s, 20s, 40s, up to
 `MappingRefreshInterval`), so a flood of queries against fields that genuinely do not exist cannot hammer the
 cluster. The interval resets to the base value as soon as a reload does resolve a field. Concurrent lookups of
 an unmapped field are coalesced into a single `GetMapping` call, so the worst case reload rate is one per
@@ -314,15 +314,19 @@ resolver.MappingRefreshInterval = TimeSpan.FromMinutes(5);
 
 Only one mapping reload runs at a time. Other resolutions that need a fresh mapping wait for that reload
 rather than issuing their own, because waiting is never more expensive than performing the fetch. If the wait
-exceeds `FetchJoinTimeout`, the resolution gives up and treats the field as unmapped, and a warning is logged.
+exceeds `MappingRefreshWaitTimeout`, the resolution gives up and treats the field as unmapped, and a warning is logged.
 
-`FetchJoinTimeout` must therefore comfortably exceed how long your `GetMapping` call takes. It defaults to 30
+`MappingRefreshWaitTimeout` must therefore comfortably exceed how long your `GetMapping` call takes. It defaults to 30
 seconds, which is far above a normal round trip, but the Elasticsearch client permits a request to run for up
 to its own request timeout (10 minutes by default). Raise it if your mapping fetch can legitimately run
 longer, or set it to a negative value to wait indefinitely:
 
 ```csharp
-resolver.FetchJoinTimeout = TimeSpan.FromMinutes(2);
+resolver.MappingRefreshWaitTimeout = TimeSpan.FromMinutes(2);
+
+// Wait as long as the fetch takes. Safe when the callback enforces its own timeout, which the
+// Elasticsearch client does by default.
+resolver.MappingRefreshWaitTimeout = Timeout.InfiniteTimeSpan;
 ```
 
 ### Residual Staleness
@@ -356,12 +360,20 @@ resolver.RefreshMapping();
 
 ### Bounding Cache Memory
 
-Field names come from user supplied queries, so the resolved field cache is bounded. Once
-`MaxCachedFields` (default 10,000) is exceeded the cache is cleared and a warning is logged.
-`CachedFieldCount` reports the approximate current size.
+Field names come from user supplied queries, so the resolved field cache is bounded by `MaxCachedFields`
+(default 10,000). `CachedFieldCount` reports the approximate current size.
+
+When the bound is reached, cached *misses* are evicted first. Misses are the only entries an untrusted
+caller can create without limit, so shedding them means a query referencing thousands of non-existent
+fields cannot displace the resolutions your real queries depend on. If every entry is a resolved field the
+mapping genuinely has more fields than the cache allows: further fields still resolve correctly, just
+without being cached, and a warning names the setting to raise.
 
 ```csharp
 resolver.MaxCachedFields = 50_000;
+
+// Setting it to zero or less disables caching entirely.
+resolver.MaxCachedFields = 0;
 ```
 
 ## Custom Mapping Resolver

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -288,25 +288,50 @@ dynamically created fields become visible quickly without turning every query in
 | Trigger | Setting | Default | Behavior |
 | --- | --- | --- | --- |
 | The loaded mapping is stale | `MappingRefreshInterval` | 1 minute | Maximum age of the loaded mapping before an ordinary resolution reloads it. |
-| A field could not be resolved | `UnmappedFieldRefreshInterval` | 5 seconds | A resolution failure is the strongest signal the index mapping changed, so it reloads on a much shorter interval. |
+| A field could not be resolved | `UnmappedFieldRefreshInterval` | 1 second | A resolution failure is the strongest signal the index mapping changed, so it reloads on a much shorter interval. |
+| A reload is already running | `FetchJoinTimeout` | 30 seconds | How long a resolution waits to join an in-flight reload instead of issuing its own. |
 
 A field that cannot be resolved is the normal outcome for fields created at runtime — dynamic templates
 (including the `idx.*` custom field templates used by Foundatio.Repositories) only add a field to the index
 mapping after the first document that uses it is indexed. Because of that, an unresolved field reloads the
 server mapping on its own short interval and is never blocked by the mapping having been loaded at startup.
 
-Reloads that still do not resolve the field back off exponentially (5s, 10s, 20s, 40s, up to
+Reloads that still do not resolve the field back off exponentially (1s, 2s, 4s, 8s, up to
 `MappingRefreshInterval`), so a flood of queries against fields that genuinely do not exist cannot hammer the
 cluster. The interval resets to the base value as soon as a reload does resolve a field. Concurrent lookups of
-an unmapped field are coalesced into a single `GetMapping` call.
+an unmapped field are coalesced into a single `GetMapping` call, so the worst case reload rate is one per
+`UnmappedFieldRefreshInterval` per resolver, and only while unresolved fields are actually being queried.
 
 ```csharp
 var resolver = parser.Configuration.MappingResolver;
 
 // Reload sooner (or set to TimeSpan.Zero to always reload when a field cannot be resolved)
-resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(1);
+resolver.UnmappedFieldRefreshInterval = TimeSpan.FromMilliseconds(250);
 resolver.MappingRefreshInterval = TimeSpan.FromMinutes(5);
 ```
+
+### Waiting For An In-Flight Reload
+
+Only one mapping reload runs at a time. Other resolutions that need a fresh mapping wait for that reload
+rather than issuing their own, because waiting is never more expensive than performing the fetch. If the wait
+exceeds `FetchJoinTimeout`, the resolution gives up and treats the field as unmapped, and a warning is logged.
+
+`FetchJoinTimeout` must therefore comfortably exceed how long your `GetMapping` call takes. It defaults to 30
+seconds, which is far above a normal round trip, but the Elasticsearch client permits a request to run for up
+to its own request timeout (10 minutes by default). Raise it if your mapping fetch can legitimately run
+longer, or set it to a negative value to wait indefinitely:
+
+```csharp
+resolver.FetchJoinTimeout = TimeSpan.FromMinutes(2);
+```
+
+### Residual Staleness
+
+Elasticsearch does not expose a cheap way to ask whether an index mapping has changed, so the resolver cannot
+detect a schema change without fetching the whole mapping. That means a field created between reloads can
+still resolve as unmapped for up to `UnmappedFieldRefreshInterval`. If your workload cannot tolerate any
+window, use `InvalidateFieldMapping` at the point the field is created (see below) or set
+`UnmappedFieldRefreshInterval` to `TimeSpan.Zero` to reload on every unresolved field.
 
 ### Invalidating a Single Field
 

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -282,15 +282,61 @@ var createIndexResponse = await client.Indices.CreateAsync("my-index", c => c
 
 ## Refreshing Mappings
 
-Mappings are automatically refreshed from Elasticsearch at most once per minute. In most production scenarios, this automatic refresh is sufficient.
+Mappings are reloaded from Elasticsearch automatically. The resolver uses two independent throttles so that
+dynamically created fields become visible quickly without turning every query into a `GetMapping` call:
 
-For unit tests where you're creating or modifying indices and need immediate visibility of changes, you can force a refresh:
+| Trigger | Setting | Default | Behavior |
+| --- | --- | --- | --- |
+| The loaded mapping is stale | `MappingRefreshInterval` | 1 minute | Maximum age of the loaded mapping before an ordinary resolution reloads it. |
+| A field could not be resolved | `UnmappedFieldRefreshInterval` | 5 seconds | A resolution failure is the strongest signal the index mapping changed, so it reloads on a much shorter interval. |
+
+A field that cannot be resolved is the normal outcome for fields created at runtime — dynamic templates
+(including the `idx.*` custom field templates used by Foundatio.Repositories) only add a field to the index
+mapping after the first document that uses it is indexed. Because of that, an unresolved field reloads the
+server mapping on its own short interval and is never blocked by the mapping having been loaded at startup.
+
+Reloads that still do not resolve the field back off exponentially (5s, 10s, 20s, 40s, up to
+`MappingRefreshInterval`), so a flood of queries against fields that genuinely do not exist cannot hammer the
+cluster. The interval resets to the base value as soon as a reload does resolve a field. Concurrent lookups of
+an unmapped field are coalesced into a single `GetMapping` call.
 
 ```csharp
 var resolver = parser.Configuration.MappingResolver;
 
+// Reload sooner (or set to TimeSpan.Zero to always reload when a field cannot be resolved)
+resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(1);
+resolver.MappingRefreshInterval = TimeSpan.FromMinutes(5);
+```
+
+### Invalidating a Single Field
+
+When you know a specific field was just created, invalidate only that field instead of discarding the whole
+cache. This drops the cached resolution for the field and allows the next resolution to reload the mapping
+immediately:
+
+```csharp
+resolver.InvalidateFieldMapping("idx.string-000001");
+```
+
+### Forcing a Full Refresh
+
+`RefreshMapping()` bypasses both throttles and discards the entire field cache. It is intended for unit tests
+that create or modify indices and need immediate visibility of the change. Prefer `InvalidateFieldMapping` in
+production code — clearing the whole cache re-resolves and re-merges every field on a large mapping.
+
+```csharp
 // Force refresh from Elasticsearch (primarily for unit tests)
 resolver.RefreshMapping();
+```
+
+### Bounding Cache Memory
+
+Field names come from user supplied queries, so the resolved field cache is bounded. Once
+`MaxCachedFields` (default 10,000) is exceeded the cache is cleared and a warning is logged.
+`CachedFieldCount` reports the approximate current size.
+
+```csharp
+resolver.MaxCachedFields = 50_000;
 ```
 
 ## Custom Mapping Resolver

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -391,9 +391,10 @@ Synchronous loader overloads remain available for compatibility. An asynchronous
 with a synchronous loader must invoke that loader synchronously, and an explicit synchronous resolver call
 configured with only an asynchronous loader waits synchronously for it. That compatibility path dispatches
 the single shared load to the thread pool to avoid synchronization-context deadlocks, but the caller still
-blocks; server request paths should use the asynchronous resolver and parser APIs. The built-in Elasticsearch
-client factories supply both forms: asynchronous parser paths call `Indices.GetMappingAsync`, while
-synchronous resolver calls retain `Indices.GetMapping`.
+blocks. A synchronous `Parse` call made under a custom synchronization context or task scheduler similarly
+isolates the compatibility call; server request paths should use the asynchronous resolver and parser APIs.
+The built-in Elasticsearch client factories supply both forms: asynchronous parser paths call
+`Indices.GetMappingAsync`, while synchronous resolver calls retain `Indices.GetMapping`.
 
 The loaded mapping and its successful field memoization belong to an immutable resolver-local snapshot; an
 external cache client is neither required nor used. `RefreshMapping()` remains synchronous because it only

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -343,7 +343,9 @@ is safer than generating a query from incomplete mapping information. This catch
 including default fields actually used by unfielded terms and included queries. Unused default fields and
 configured restricted fields are not treated as query references. Mapping validation runs after field
 resolution and reports original query names, including aliases, even when a visitor context is reused.
-Runtime fields defined in the context or discovered by its runtime-field resolver remain valid. The
+Runtime fields defined in the context or discovered by its runtime-field resolver remain valid. Each
+operation reuses runtime lookup results, including misses and failures, so field resolution and validation
+do not invoke the callback twice for the same field. A later operation can retry the callback. The
 resolver's boolean type checks do not expose a separate "mapping unknown" state, so use explicit
 refresh for application-controlled changes that require immediate correctness.
 
@@ -407,8 +409,8 @@ Synchronous loader overloads remain available for compatibility. An asynchronous
 with a synchronous loader must invoke that loader synchronously, and an explicit synchronous resolver call
 configured with only an asynchronous loader waits synchronously for it. That compatibility path dispatches
 the single shared load to the thread pool to avoid synchronization-context deadlocks, but the caller still
-blocks. A synchronous `Parse` call made under a custom synchronization context or task scheduler similarly
-isolates the compatibility call; server request paths should use the asynchronous resolver and parser APIs.
+blocks. Synchronous `Parse` preserves the caller thread for synchronous visitors; server request paths
+should use the asynchronous resolver and parser APIs.
 The built-in Elasticsearch client factories supply both forms: asynchronous parser paths call
 `Indices.GetMappingAsync`, while synchronous resolver calls retain `Indices.GetMapping`.
 

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -299,7 +299,8 @@ Concurrent reload attempts are coalesced into a single server mapping fetch per 
 local to the resolver instance, so create one long-lived resolver per concrete index and process. Creating a
 resolver per request defeats both caching and request coalescing. With the five-second default, each resolver
 that is continuously receiving misses can make up to about 12 reload attempts per minute, excluding cold
-starts and explicit refreshes.
+starts and explicit refreshes. There is no distributed cache or cross-process coordination, so this ceiling
+applies independently to each resolver in each process.
 
 Before this miss-specific cooldown, successful and null mapping fetches were normally limited by the
 one-minute mapping refresh interval, while a callback exception could be retried by every sequential miss.
@@ -370,7 +371,29 @@ They do not merge heterogeneous mappings from rollover aliases or data streams.
 
 ## Custom Mapping Resolver
 
-Create a custom resolver for special cases:
+Use an asynchronous loader when obtaining the mapping requires network I/O. The parser's asynchronous query,
+sort, and aggregation paths await this loader without blocking a request thread. Cancelling one resolver
+lookup cancels only that caller's wait; the shared fetch continues for other callers and is bounded by the
+resolver lifetime and the loader's transport timeout.
+
+```csharp
+var customResolver = ElasticMappingResolver.Create(
+    getMappingAsync: cancellationToken => LoadMappingAsync(cancellationToken),
+    inferrer: client.Infer,
+    logger: logger);
+```
+
+Synchronous loader overloads remain available for compatibility. An asynchronous parser call configured
+with a synchronous loader must invoke that loader synchronously, and an explicit synchronous resolver call
+configured with only an asynchronous loader waits synchronously for it. The built-in Elasticsearch client
+factories supply both forms: asynchronous parser paths call `Indices.GetMappingAsync`, while synchronous
+resolver calls retain `Indices.GetMapping`.
+
+The loaded mapping and its successful field memoization belong to an immutable resolver-local snapshot; an
+external cache client is neither required nor used. `RefreshMapping()` remains synchronous because it only
+invalidates that local snapshot and performs no I/O.
+
+For an already synchronous or in-memory source, use the compatibility overload:
 
 ```csharp
 var customResolver = ElasticMappingResolver.Create(

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -304,8 +304,8 @@ starts and explicit refreshes.
 ```csharp
 var resolver = parser.Configuration.MappingResolver;
 
-// Reload sooner when a field cannot be resolved. The value must remain greater than zero.
-resolver.UnmappedFieldRefreshInterval = TimeSpan.FromMilliseconds(250);
+// Reduce reload pressure for typo-heavy workloads.
+resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(30);
 ```
 
 ### Waiting For An In-Flight Reload

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -377,7 +377,32 @@ process state. A parser operation remembers its own positive and negative resolu
 finishes, preventing downstream visitors from repeating the same network-backed lookup. Direct query, sort,
 and aggregation helpers also release their temporary results on return or failure, so reusing a visitor context
 does not retain stale mappings across operations. Cache keys preserve exact field-name casing. Reloading the mapping
-publishes a new snapshot and atomically discards resolutions derived from the old one.
+publishes a new snapshot and atomically discards resolutions derived from the old one, unless the optional
+revision check below confirms that the mapping is unchanged. The operation's runtime-field result dictionary
+is allocated only when a runtime-field resolver is actually used.
+
+### Reusing Unchanged Mappings
+
+If your mapping owner provides a cheap, reliable revision for the complete mapping, set
+`ServerMappingRevisionResolver` before sharing the resolver:
+
+```csharp
+resolver.ServerMappingRevisionResolver = mapping =>
+    mapping.Meta?.TryGetValue("resolver_revision", out var revision) == true
+        ? revision?.ToString()
+        : null;
+```
+
+Equal, nonempty revisions allow automatic reloads to reuse the merged property tree and successful field
+resolutions. The reload still fetches the mapping and observes the normal miss cooldown; this saves local
+rebuilding and allocations, not HTTP requests or deserialization. No mapping serialization is performed
+to compare revisions. `RefreshMapping()` always discards the cached state, even if the revision is unchanged.
+
+The revision must identify the concrete index and change whenever any mapping detail changes, including
+fields added dynamically. Elasticsearch does not maintain this custom `_meta` value for you. Use it only
+when your mapping owner guarantees that contract; a deployment schema version or latest partition name
+alone is insufficient. Leave the callback unset if you do not have such a revision. Null or empty revisions
+also retain the default behavior of rebuilding after every successful reload.
 
 The built-in client factories expect one concrete index, or a target whose indices have equivalent mappings.
 They do not merge heterogeneous mappings from rollover aliases or data streams.

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -316,8 +316,11 @@ resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(30);
 
 ### Waiting For An In-Flight Reload
 
-Only one mapping reload runs at a time. Other resolutions that need a fresh mapping wait for that reload
-rather than issuing their own. If the wait exceeds `MappingRefreshWaitTimeout`, the resolution gives up and
+Only one automatic mapping reload runs at a time. Other resolutions that need a fresh mapping wait for that
+reload rather than issuing their own. An explicit `RefreshMapping()` supersedes an obsolete in-flight load,
+so the next resolution can fetch the replacement mapping without waiting for the old callback to drain. That
+hard-invalidation case can temporarily overlap the obsolete physical callback. If the wait exceeds
+`MappingRefreshWaitTimeout`, the resolution gives up and
 treats the field as unmapped, and a warning is logged. A single resolution joins at most once; it does not
 repeat the same wait as both an initial load and a miss-driven reload.
 
@@ -363,8 +366,10 @@ that path for ordinary custom-field saves.
 
 Successful resolutions are cached by canonical field path for the lifetime of the mapping snapshot, which
 keeps the cache bounded by the mapping itself no matter how many distinct spellings callers ask for.
-Unknown field names are not cached, so caller-controlled misses cannot grow process state. Reloading the
-mapping publishes a new snapshot and atomically discards resolutions derived from the old one.
+Unknown field names are not cached in the long-lived snapshot, so caller-controlled misses cannot grow
+process state. A parser operation remembers its own positive and negative resolutions only until that parse
+finishes, preventing downstream visitors from repeating the same network-backed lookup. Reloading the mapping
+publishes a new snapshot and atomically discards resolutions derived from the old one.
 
 The built-in client factories expect one concrete index, or a target whose indices have equivalent mappings.
 They do not merge heterogeneous mappings from rollover aliases or data streams.
@@ -395,6 +400,11 @@ blocks. A synchronous `Parse` call made under a custom synchronization context o
 isolates the compatibility call; server request paths should use the asynchronous resolver and parser APIs.
 The built-in Elasticsearch client factories supply both forms: asynchronous parser paths call
 `Indices.GetMappingAsync`, while synchronous resolver calls retain `Indices.GetMapping`.
+
+On the default task scheduler, the asynchronous loader starts inline and does not use `Task.Run`. When a
+custom synchronization context or task scheduler is active, only the loader boundary is dispatched to the
+thread pool so a synchronous caller joining the same shared fetch cannot block the loader's captured
+continuation. Library-owned awaits still use `AnyContext()`.
 
 The loaded mapping and its successful field memoization belong to an immutable resolver-local snapshot; an
 external cache client is neither required nor used. `RefreshMapping()` remains synchronous because it only

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -312,11 +312,13 @@ resolver.UnmappedFieldRefreshInterval = TimeSpan.FromMilliseconds(250);
 
 Only one mapping reload runs at a time. Other resolutions that need a fresh mapping wait for that reload
 rather than issuing their own. If the wait exceeds `MappingRefreshWaitTimeout`, the resolution gives up and
-treats the field as unmapped, and a warning is logged.
+treats the field as unmapped, and a warning is logged. A single resolution joins at most once; it does not
+repeat the same wait as both an initial load and a miss-driven reload.
 
-The mapping callback must have its own finite timeout shorter than `MappingRefreshWaitTimeout`, and it must
-not call back into the same resolver. Infinite waits are rejected because a slow or reentrant callback could
-otherwise pin request threads indefinitely.
+The mapping callback must have its own finite timeout and must not call back into the same resolver. The
+built-in client factories use the Elasticsearch client's configured request timeout. Configure that timeout
+below `MappingRefreshWaitTimeout` if every joining resolution must observe the fetch result; otherwise a
+joining resolution can time out while the single fetch continues.
 
 ```csharp
 resolver.MappingRefreshWaitTimeout = TimeSpan.FromMinutes(2);
@@ -345,6 +347,11 @@ the new mapping.
 ```csharp
 resolver.RefreshMapping();
 ```
+
+Do not call `RefreshMapping()` after every indexed document. Dynamically materialized fields already use the
+miss-driven reload path, while repeated full invalidation discards useful caches and can continually
+supersede in-flight fetches. Foundatio.Repositories should keep its long-lived per-index resolver and rely on
+that path for ordinary custom-field saves.
 
 ### Cache Memory
 
@@ -417,14 +424,14 @@ var parser2 = new ElasticQueryParser(c => c.UseMappings(resolver));
 
 ### 3. Handle Dynamic Mappings
 
-For indices with dynamic mappings:
+For correctness-sensitive indices with dynamic mappings, fail validation if a field is still unresolved
+after the bounded reload attempt rather than generating a query from incomplete mapping information:
 
 ```csharp
 var parser = new ElasticQueryParser(c => c
     .UseMappings(client, "my-index")
     .SetValidationOptions(new QueryValidationOptions {
-        // Allow fields not in current mapping
-        AllowUnresolvedFields = true
+        AllowUnresolvedFields = false
     }));
 ```
 

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -301,6 +301,11 @@ resolver per request defeats both caching and request coalescing. With the five-
 that is continuously receiving misses can make up to about 12 reload attempts per minute, excluding cold
 starts and explicit refreshes.
 
+Before this miss-specific cooldown, successful and null mapping fetches were normally limited by the
+one-minute mapping refresh interval, while a callback exception could be retried by every sequential miss.
+The five-second default therefore improves dynamic-field discovery while placing the same finite ceiling on
+successful, null, and exceptional automatic reloads.
+
 ```csharp
 var resolver = parser.Configuration.MappingResolver;
 

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -376,8 +376,12 @@ sort, and aggregation paths await this loader without blocking a request thread.
 lookup cancels only that caller's wait; the shared fetch continues for other callers and is bounded by the
 resolver lifetime and the loader's transport timeout.
 
+Custom asynchronous loaders use the named `CreateWithAsyncLoader` and `UseMappingsWithAsyncLoader` entry
+points. Keeping them separate from the synchronous delegate overloads preserves source compatibility for
+existing callers.
+
 ```csharp
-var customResolver = ElasticMappingResolver.Create(
+var customResolver = ElasticMappingResolver.CreateWithAsyncLoader(
     getMappingAsync: cancellationToken => LoadMappingAsync(cancellationToken),
     inferrer: client.Infer,
     logger: logger);
@@ -385,9 +389,11 @@ var customResolver = ElasticMappingResolver.Create(
 
 Synchronous loader overloads remain available for compatibility. An asynchronous parser call configured
 with a synchronous loader must invoke that loader synchronously, and an explicit synchronous resolver call
-configured with only an asynchronous loader waits synchronously for it. The built-in Elasticsearch client
-factories supply both forms: asynchronous parser paths call `Indices.GetMappingAsync`, while synchronous
-resolver calls retain `Indices.GetMapping`.
+configured with only an asynchronous loader waits synchronously for it. That compatibility path dispatches
+the single shared load to the thread pool to avoid synchronization-context deadlocks, but the caller still
+blocks; server request paths should use the asynchronous resolver and parser APIs. The built-in Elasticsearch
+client factories supply both forms: asynchronous parser paths call `Indices.GetMappingAsync`, while
+synchronous resolver calls retain `Indices.GetMapping`.
 
 The loaded mapping and its successful field memoization belong to an immutable resolver-local snapshot; an
 external cache client is neither required nor used. `RefreshMapping()` remains synchronous because it only

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -367,8 +367,10 @@ that path for ordinary custom-field saves.
 Successful resolutions are cached by canonical field path for the lifetime of the mapping snapshot, which
 keeps the cache bounded by the mapping itself no matter how many distinct spellings callers ask for.
 Unknown field names are not cached in the long-lived snapshot, so caller-controlled misses cannot grow
-process state. A parser operation remembers its own positive and negative resolutions only until that parse
-finishes, preventing downstream visitors from repeating the same network-backed lookup. Reloading the mapping
+process state. A parser operation remembers its own positive and negative resolutions only until that operation
+finishes, preventing downstream visitors from repeating the same network-backed lookup. Direct query, sort,
+and aggregation helpers also release their temporary results on return or failure, so reusing a visitor context
+does not retain stale mappings across operations. Cache keys preserve exact field-name casing. Reloading the mapping
 publishes a new snapshot and atomically discards resolutions derived from the old one.
 
 The built-in client factories expect one concrete index, or a target whose indices have equivalent mappings.

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -355,9 +355,10 @@ that path for ordinary custom-field saves.
 
 ### Cache Memory
 
-Successful resolutions are cached by canonical field path for the lifetime of the mapping snapshot. Unknown
-field names are not cached, so caller-controlled misses cannot grow process state. Reloading the mapping
-publishes a new snapshot and atomically discards resolutions derived from the old one.
+Successful resolutions are cached by canonical field path for the lifetime of the mapping snapshot, which
+keeps the cache bounded by the mapping itself no matter how many distinct spellings callers ask for.
+Unknown field names are not cached, so caller-controlled misses cannot grow process state. Reloading the
+mapping publishes a new snapshot and atomically discards resolutions derived from the old one.
 
 The built-in client factories expect one concrete index, or a target whose indices have equivalent mappings.
 They do not merge heterogeneous mappings from rollover aliases or data streams.

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -282,13 +282,12 @@ var createIndexResponse = await client.Indices.CreateAsync("my-index", c => c
 
 ## Refreshing Mappings
 
-Mappings are reloaded from Elasticsearch automatically. The resolver uses two independent throttles so that
-dynamically created fields become visible quickly without turning every query into a `GetMapping` call:
+The resolver loads the server mapping on first use. After that, an unresolved field is the signal that the
+mapping may have changed, so it can trigger a rate-limited reload:
 
 | Trigger | Setting | Default | Behavior |
 | --- | --- | --- | --- |
-| The loaded mapping is stale | `MappingRefreshInterval` | 1 minute | Maximum age of the loaded mapping before an ordinary resolution reloads it. |
-| A field could not be resolved | `UnmappedFieldRefreshInterval` | 5 seconds | A resolution failure is the strongest signal the index mapping changed, so it reloads on a much shorter interval. |
+| A field could not be resolved | `UnmappedFieldRefreshInterval` | 5 seconds | Minimum time between completed miss-driven reload attempts. Must be greater than zero. |
 | A reload is already running | `MappingRefreshWaitTimeout` | 30 seconds | How long a resolution waits to join an in-flight reload instead of issuing its own. |
 
 A field that cannot be resolved is the normal outcome for fields created at runtime — dynamic templates
@@ -296,85 +295,65 @@ A field that cannot be resolved is the normal outcome for fields created at runt
 mapping after the first document that uses it is indexed. Because of that, an unresolved field reloads the
 server mapping on its own short interval and is never blocked by the mapping having been loaded at startup.
 
-Reloads that still do not resolve the field back off exponentially (5s, 10s, 20s, 40s, up to
-`MappingRefreshInterval`), so a flood of queries against fields that genuinely do not exist cannot hammer the
-cluster. The interval resets to the base value as soon as a reload does resolve a field. Concurrent lookups of
-an unmapped field are coalesced into a single `GetMapping` call, so the worst case reload rate is one per
-`UnmappedFieldRefreshInterval` per resolver, and only while unresolved fields are actually being queried.
+Concurrent reload attempts are coalesced into a single server mapping fetch per resolver. This protection is
+local to the resolver instance, so create one long-lived resolver per concrete index and process. Creating a
+resolver per request defeats both caching and request coalescing. With the five-second default, each resolver
+that is continuously receiving misses can make up to about 12 reload attempts per minute, excluding cold
+starts and explicit refreshes.
 
 ```csharp
 var resolver = parser.Configuration.MappingResolver;
 
-// Reload sooner (or set to TimeSpan.Zero to always reload when a field cannot be resolved)
+// Reload sooner when a field cannot be resolved. The value must remain greater than zero.
 resolver.UnmappedFieldRefreshInterval = TimeSpan.FromMilliseconds(250);
-resolver.MappingRefreshInterval = TimeSpan.FromMinutes(5);
 ```
 
 ### Waiting For An In-Flight Reload
 
 Only one mapping reload runs at a time. Other resolutions that need a fresh mapping wait for that reload
-rather than issuing their own, because waiting is never more expensive than performing the fetch. If the wait
-exceeds `MappingRefreshWaitTimeout`, the resolution gives up and treats the field as unmapped, and a warning is logged.
+rather than issuing their own. If the wait exceeds `MappingRefreshWaitTimeout`, the resolution gives up and
+treats the field as unmapped, and a warning is logged.
 
-`MappingRefreshWaitTimeout` must therefore comfortably exceed how long your `GetMapping` call takes. It defaults to 30
-seconds, which is far above a normal round trip, but the Elasticsearch client permits a request to run for up
-to its own request timeout (10 minutes by default). Raise it if your mapping fetch can legitimately run
-longer, or set it to a negative value to wait indefinitely:
+The mapping callback must have its own finite timeout shorter than `MappingRefreshWaitTimeout`, and it must
+not call back into the same resolver. Infinite waits are rejected because a slow or reentrant callback could
+otherwise pin request threads indefinitely.
 
 ```csharp
 resolver.MappingRefreshWaitTimeout = TimeSpan.FromMinutes(2);
-
-// Wait as long as the fetch takes. Safe when the callback enforces its own timeout, which the
-// Elasticsearch client does by default.
-resolver.MappingRefreshWaitTimeout = Timeout.InfiniteTimeSpan;
 ```
 
 ### Residual Staleness
 
-Elasticsearch does not expose a cheap way to ask whether an index mapping has changed, so the resolver cannot
-detect a schema change without fetching the whole mapping. That means a field created between reloads can
-still resolve as unmapped for up to `UnmappedFieldRefreshInterval`. If your workload cannot tolerate any
-window, use `InvalidateFieldMapping` at the point the field is created (see below) or set
-`UnmappedFieldRefreshInterval` to `TimeSpan.Zero` to reload on every unresolved field.
+The five-second default is a cooldown, not a correctness deadline. Callback latency, failures, and a reload
+that began before the field was created can extend the stale window. If an automatic reload fails or returns
+no mapping, the resolver retains its last known mapping and throttles the next attempt. During that window an
+unresolved field is still treated as unmapped. Set `AllowUnresolvedFields` to `false` when failing validation
+is safer than generating a query from incomplete mapping information. This catches unresolved query fields,
+but the resolver's boolean type checks do not expose a separate "mapping unknown" state, so use explicit
+refresh for application-controlled changes that require immediate correctness.
 
-### Invalidating a Single Field
-
-When you know a specific field was just created, invalidate only that field instead of discarding the whole
-cache. This drops the cached resolution for the field and allows the next resolution to reload the mapping
-immediately:
-
-```csharp
-resolver.InvalidateFieldMapping("idx.string-000001");
-```
+Successful field resolutions do not trigger periodic reloads. New fields and sub-fields create misses and
+are discovered automatically, but changes to an already resolved alias or runtime-field definition require
+an explicit refresh.
 
 ### Forcing a Full Refresh
 
-`RefreshMapping()` bypasses both throttles and discards the entire field cache. It is intended for unit tests
-that create or modify indices and need immediate visibility of the change. Prefer `InvalidateFieldMapping` in
-production code — clearing the whole cache re-resolves and re-merges every field on a large mapping.
+`RefreshMapping()` bypasses the miss throttle and discards the current mapping snapshot. Call it after
+Elasticsearch acknowledges an application-controlled mapping change; the next resolution fetches or joins
+the new mapping.
 
 ```csharp
-// Force refresh from Elasticsearch (primarily for unit tests)
 resolver.RefreshMapping();
 ```
 
-### Bounding Cache Memory
+### Cache Memory
 
-Field names come from user supplied queries, so the resolved field cache is bounded by `MaxCachedFields`
-(default 10,000). `CachedFieldCount` reports the approximate current size.
+Successful resolutions are cached by canonical field path for the lifetime of the mapping snapshot. Unknown
+field names are not cached, so caller-controlled misses cannot grow process state. Reloading the mapping
+publishes a new snapshot and atomically discards resolutions derived from the old one.
 
-When the bound is reached, cached *misses* are evicted first. Misses are the only entries an untrusted
-caller can create without limit, so shedding them means a query referencing thousands of non-existent
-fields cannot displace the resolutions your real queries depend on. If every entry is a resolved field the
-mapping genuinely has more fields than the cache allows: further fields still resolve correctly, just
-without being cached, and a warning names the setting to raise.
-
-```csharp
-resolver.MaxCachedFields = 50_000;
-
-// Setting it to zero or less disables caching entirely.
-resolver.MaxCachedFields = 0;
-```
+The built-in client factories expect one concrete index, or a target whose indices have equivalent mappings.
+They do not merge heterogeneous mappings from rollover aliases or data streams.
 
 ## Custom Mapping Resolver
 

--- a/docs/guide/elastic-mappings.md
+++ b/docs/guide/elastic-mappings.md
@@ -340,7 +340,11 @@ that began before the field was created can extend the stale window. If an autom
 no mapping, the resolver retains its last known mapping and throttles the next attempt. During that window an
 unresolved field is still treated as unmapped. Set `AllowUnresolvedFields` to `false` when failing validation
 is safer than generating a query from incomplete mapping information. This catches unresolved query fields,
-but the resolver's boolean type checks do not expose a separate "mapping unknown" state, so use explicit
+including default fields actually used by unfielded terms and included queries. Unused default fields and
+configured restricted fields are not treated as query references. Mapping validation runs after field
+resolution and reports original query names, including aliases, even when a visitor context is reused.
+Runtime fields defined in the context or discovered by its runtime-field resolver remain valid. The
+resolver's boolean type checks do not expose a separate "mapping unknown" state, so use explicit
 refresh for application-controlled changes that require immediate correctness.
 
 Successful field resolutions do not trigger periodic reloads. New fields and sub-fields create misses and
@@ -382,6 +386,11 @@ Use an asynchronous loader when obtaining the mapping requires network I/O. The 
 sort, and aggregation paths await this loader without blocking a request thread. Cancelling one resolver
 lookup cancels only that caller's wait; the shared fetch continues for other callers and is bounded by the
 resolver lifetime and the loader's transport timeout.
+
+The application owns the resolver, including one created by `UseMappingsWithAsyncLoader`: dispose
+`parser.Configuration.MappingResolver` when the parser is no longer in use. Do not dispose it per request
+when it is shared. Configure refresh settings before sharing the resolver. Typed `Field` helpers preserve
+inferred canonical names while using the same single-load budget as string helpers.
 
 Custom asynchronous loaders use the named `CreateWithAsyncLoader` and `UseMappingsWithAsyncLoader` entry
 points. Keeping them separate from the synchronous delegate overloads preserves source compatibility for

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -144,8 +144,9 @@ var parser = new ElasticQueryParser(c => c
         { "user_field", "actual.field.path" }
     }));
 
-// Option 3: Refresh mappings (if recently added field, wait for auto-refresh or force it)
-parser.Configuration.MappingResolver.RefreshMapping();
+// Option 3: Refresh mappings. Recently added fields are picked up automatically within
+// UnmappedFieldRefreshInterval (default 5 seconds); invalidate a single field to pick it up immediately.
+parser.Configuration.MappingResolver.InvalidateFieldMapping("user_field");
 ```
 
 ## Elasticsearch Issues
@@ -364,14 +365,47 @@ public MyService()
 **Solution:**
 
 ```csharp
-// Mappings are cached by default (auto-refresh at most once per minute)
-// Manual refresh is typically only needed in unit tests:
+// Resolved fields are cached, and the server mapping is reloaded at most once per
+// MappingRefreshInterval (default 1 minute). Manual refresh is typically only needed in unit tests:
 parser.Configuration.MappingResolver.RefreshMapping();
 
 // For production, create resolver once and share
 var resolver = ElasticMappingResolver.Create(client, "my-index");
 var parser1 = new ElasticQueryParser(c => c.UseMappings(resolver));
 var parser2 = new ElasticQueryParser(c => c.UseMappings(resolver));
+```
+
+**Cause:** Queries reference fields that do not exist, so every one of them triggers a mapping reload.
+
+Fields that cannot be resolved reload the mapping on their own short interval
+(`UnmappedFieldRefreshInterval`, default 5 seconds) because that is how dynamically created fields become
+visible. Reloads that do not resolve the field back off exponentially up to `MappingRefreshInterval`, and
+concurrent lookups of the same unmapped field are coalesced into a single `GetMapping` call. Raise the base
+interval if a workload legitimately queries many non-existent fields:
+
+```csharp
+resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(30);
+```
+
+Look for the `Unable to resolve mapping for field {Field}` warning: it means a reload was suppressed by the
+throttle and the field is being treated as unmapped.
+
+### Recently Created Field Resolves As Unmapped
+
+**Cause:** The field was created after the resolver loaded the index mapping — for example by a dynamic
+template, which only adds the field to the mapping once the first document using it has been indexed.
+
+**Symptoms:**
+
+- A `nested` field is queried as a flat field, so the query succeeds but returns no results.
+- Sorting fails with `Fielddata is disabled on [field] in [index]`, because the resolver could not find the
+  `.keyword` / `.sort` sub-field and fell back to the analyzed field.
+
+**Solution:** the resolver reloads automatically within `UnmappedFieldRefreshInterval`. To pick the field up
+immediately after creating it, invalidate just that field:
+
+```csharp
+resolver.InvalidateFieldMapping("idx.string-000001");
 ```
 
 ## Debugging
@@ -382,7 +416,7 @@ var parser2 = new ElasticQueryParser(c => c.UseMappings(resolver));
 var parser = new ElasticQueryParser(c => c
     .SetLoggerFactory(loggerFactory));
 
-// Or for LuceneQueryParser, use ILogger directly 
+// Or for LuceneQueryParser, use ILogger directly
 var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
 ```
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -145,7 +145,7 @@ var parser = new ElasticQueryParser(c => c
     }));
 
 // Option 3: Refresh mappings. Recently added fields are picked up automatically within
-// UnmappedFieldRefreshInterval (default 5 seconds); invalidate a single field to pick it up immediately.
+// UnmappedFieldRefreshInterval (default 1 second); invalidate a single field to pick it up immediately.
 parser.Configuration.MappingResolver.InvalidateFieldMapping("user_field");
 ```
 
@@ -378,7 +378,7 @@ var parser2 = new ElasticQueryParser(c => c.UseMappings(resolver));
 **Cause:** Queries reference fields that do not exist, so every one of them triggers a mapping reload.
 
 Fields that cannot be resolved reload the mapping on their own short interval
-(`UnmappedFieldRefreshInterval`, default 5 seconds) because that is how dynamically created fields become
+(`UnmappedFieldRefreshInterval`, default 1 second) because that is how dynamically created fields become
 visible. Reloads that do not resolve the field back off exponentially up to `MappingRefreshInterval`, and
 concurrent lookups of the same unmapped field are coalesced into a single `GetMapping` call. Raise the base
 interval if a workload legitimately queries many non-existent fields:
@@ -406,6 +406,15 @@ immediately after creating it, invalidate just that field:
 
 ```csharp
 resolver.InvalidateFieldMapping("idx.string-000001");
+```
+
+If the field stays unmapped for much longer than `UnmappedFieldRefreshInterval`, look for the
+`did not complete within` warning. It means a mapping reload was already running but took longer than
+`FetchJoinTimeout` (default 30 seconds), so resolutions gave up waiting for it. Raise `FetchJoinTimeout` to
+match how long your `GetMapping` call actually takes:
+
+```csharp
+resolver.FetchJoinTimeout = TimeSpan.FromMinutes(2);
 ```
 
 ## Debugging

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -145,7 +145,7 @@ var parser = new ElasticQueryParser(c => c
     }));
 
 // Option 3: Refresh mappings. Recently added fields are picked up automatically within
-// UnmappedFieldRefreshInterval (default 1 second); invalidate a single field to pick it up immediately.
+// UnmappedFieldRefreshInterval (default 5 seconds); invalidate a single field to pick it up immediately.
 parser.Configuration.MappingResolver.InvalidateFieldMapping("user_field");
 ```
 
@@ -378,7 +378,7 @@ var parser2 = new ElasticQueryParser(c => c.UseMappings(resolver));
 **Cause:** Queries reference fields that do not exist, so every one of them triggers a mapping reload.
 
 Fields that cannot be resolved reload the mapping on their own short interval
-(`UnmappedFieldRefreshInterval`, default 1 second) because that is how dynamically created fields become
+(`UnmappedFieldRefreshInterval`, default 5 seconds) because that is how dynamically created fields become
 visible. Reloads that do not resolve the field back off exponentially up to `MappingRefreshInterval`, and
 concurrent lookups of the same unmapped field are coalesced into a single `GetMapping` call. Raise the base
 interval if a workload legitimately queries many non-existent fields:
@@ -410,11 +410,11 @@ resolver.InvalidateFieldMapping("idx.string-000001");
 
 If the field stays unmapped for much longer than `UnmappedFieldRefreshInterval`, look for the
 `did not complete within` warning. It means a mapping reload was already running but took longer than
-`FetchJoinTimeout` (default 30 seconds), so resolutions gave up waiting for it. Raise `FetchJoinTimeout` to
+`MappingRefreshWaitTimeout` (default 30 seconds), so resolutions gave up waiting for it. Raise `MappingRefreshWaitTimeout` to
 match how long your `GetMapping` call actually takes:
 
 ```csharp
-resolver.FetchJoinTimeout = TimeSpan.FromMinutes(2);
+resolver.MappingRefreshWaitTimeout = TimeSpan.FromMinutes(2);
 ```
 
 ## Debugging

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -144,9 +144,8 @@ var parser = new ElasticQueryParser(c => c
         { "user_field", "actual.field.path" }
     }));
 
-// Option 3: Refresh mappings. Recently added fields are picked up automatically within
-// UnmappedFieldRefreshInterval (default 5 seconds); invalidate a single field to pick it up immediately.
-parser.Configuration.MappingResolver.InvalidateFieldMapping("user_field");
+// Option 3: Force the next resolution to reload the server mapping.
+parser.Configuration.MappingResolver.RefreshMapping();
 ```
 
 ## Elasticsearch Issues
@@ -365,8 +364,7 @@ public MyService()
 **Solution:**
 
 ```csharp
-// Resolved fields are cached, and the server mapping is reloaded at most once per
-// MappingRefreshInterval (default 1 minute). Manual refresh is typically only needed in unit tests:
+// Resolved fields are cached. Manual refresh is only needed after a known change to an already resolved field:
 parser.Configuration.MappingResolver.RefreshMapping();
 
 // For production, create resolver once and share
@@ -375,20 +373,22 @@ var parser1 = new ElasticQueryParser(c => c.UseMappings(resolver));
 var parser2 = new ElasticQueryParser(c => c.UseMappings(resolver));
 ```
 
-**Cause:** Queries reference fields that do not exist, so every one of them triggers a mapping reload.
+**Cause:** Queries continually reference fields that do not exist, making the resolver repeatedly eligible
+to reload the mapping.
 
 Fields that cannot be resolved reload the mapping on their own short interval
 (`UnmappedFieldRefreshInterval`, default 5 seconds) because that is how dynamically created fields become
-visible. Reloads that do not resolve the field back off exponentially up to `MappingRefreshInterval`, and
-concurrent lookups of the same unmapped field are coalesced into a single `GetMapping` call. Raise the base
+visible. Concurrent reload attempts are coalesced into a single server mapping fetch per resolver. Raise the
 interval if a workload legitimately queries many non-existent fields:
 
 ```csharp
 resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(30);
 ```
 
-Look for the `Unable to resolve mapping for field {Field}` warning: it means a reload was suppressed by the
-throttle and the field is being treated as unmapped.
+Reuse one resolver per concrete index and process. A resolver created for every request has its own cache,
+throttle, and in-flight request, so it defeats this protection. Look for the
+`Unable to resolve mapping for field {Field}` warning: it means a reload was suppressed by the throttle and
+the field is being treated as unmapped.
 
 ### Recently Created Field Resolves As Unmapped
 
@@ -401,11 +401,12 @@ template, which only adds the field to the mapping once the first document using
 - Sorting fails with `Fielddata is disabled on [field] in [index]`, because the resolver could not find the
   `.keyword` / `.sort` sub-field and fell back to the analyzed field.
 
-**Solution:** the resolver reloads automatically within `UnmappedFieldRefreshInterval`. To pick the field up
-immediately after creating it, invalidate just that field:
+**Solution:** the resolver becomes eligible to reload after `UnmappedFieldRefreshInterval`. This is a cooldown
+after a completed attempt, not a five-second correctness deadline. To pick up an application-controlled
+change immediately, call `RefreshMapping()` after Elasticsearch acknowledges it:
 
 ```csharp
-resolver.InvalidateFieldMapping("idx.string-000001");
+resolver.RefreshMapping();
 ```
 
 If the field stays unmapped for much longer than `UnmappedFieldRefreshInterval`, look for the
@@ -416,6 +417,10 @@ match how long your `GetMapping` call actually takes:
 ```csharp
 resolver.MappingRefreshWaitTimeout = TimeSpan.FromMinutes(2);
 ```
+
+The mapping callback must enforce a shorter finite timeout and must not call the same resolver. If treating
+an unresolved field as unmapped could generate an incorrect query, configure validation with
+`AllowUnresolvedFields = false` so the request fails instead.
 
 ## Debugging
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -418,9 +418,11 @@ match how long your `GetMapping` call actually takes:
 resolver.MappingRefreshWaitTimeout = TimeSpan.FromMinutes(2);
 ```
 
-The mapping callback must enforce a shorter finite timeout and must not call the same resolver. If treating
-an unresolved field as unmapped could generate an incorrect query, configure validation with
-`AllowUnresolvedFields = false` so the request fails instead.
+The mapping callback must enforce a finite timeout and must not call the same resolver. The built-in client
+factories use the Elasticsearch client's configured request timeout; keep it below
+`MappingRefreshWaitTimeout` if joining resolutions must wait for the result. If treating an unresolved field
+as unmapped could generate an incorrect query, configure validation with `AllowUnresolvedFields = false` so
+the request fails instead.
 
 ## Debugging
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -378,8 +378,10 @@ to reload the mapping.
 
 Fields that cannot be resolved reload the mapping on their own short interval
 (`UnmappedFieldRefreshInterval`, default 5 seconds) because that is how dynamically created fields become
-visible. Concurrent reload attempts are coalesced into a single server mapping fetch per resolver. Raise the
-interval if a workload legitimately queries many non-existent fields:
+visible. Concurrent reload attempts are coalesced into a single server mapping fetch per resolver. Under
+continuous misses, the default permits about 12 automatic attempts per minute for each resolver in each
+process; cold starts and explicit `RefreshMapping()` calls are outside that ceiling. Raise the interval if a
+workload legitimately queries many non-existent fields:
 
 ```csharp
 resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(30);

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -19,34 +19,21 @@ public class ElasticMappingResolver : IDisposable
     private readonly TypeMapping? _codeMapping;
     private readonly Lazy<Properties?> _inferredCodeProperties;
     private readonly Inferrer? _inferrer;
-    private readonly ConcurrentDictionary<string, FieldMapping> _mappingCache = new(StringComparer.Ordinal);
-    private readonly SemaphoreSlim _fetchSemaphore = new(1, 1);
-    private readonly object _publishLock = new();
-    private readonly TimeProvider _timeProvider;
+    private readonly MappingCache _cache;
     private readonly ConditionalWeakTable<IProperty, ConcurrentDictionary<string, object>> _propertyMetadata = new();
+    private readonly ConditionalWeakTable<IProperty, Properties> _mergedChildProperties = new();
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger _logger;
-
-    private MappingSnapshot _snapshot;
-    private long _snapshotVersion;
-    private long _refreshVersion;
-    private long _cachedFieldCount;
-    private long _lastFetchTimestamp;
-    private long _lastUnmappedFetchTimestamp;
-    private long _unmappedRefreshBackoffTicks;
-    private long _backoffAppliedForVersion;
-    private long _lastSuppressedReloadWarningTimestamp;
-    private volatile bool _disposed;
 
     public static readonly ElasticMappingResolver NullInstance = new(() => null);
 
     public ElasticMappingResolver(Func<TypeMapping?> getMapping, Inferrer? inferrer = null, TimeProvider? timeProvider = null, ILogger? logger = null)
     {
-        GetServerMappingFunc = getMapping;
         _inferrer = inferrer;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _logger = logger ?? NullLogger.Instance;
         _inferredCodeProperties = new Lazy<Properties?>(() => InferCodeProperties(_codeMapping?.Properties), LazyThreadSafetyMode.ExecutionAndPublication);
-        _snapshot = CreateSnapshot(null, fetched: false);
+        _cache = new MappingCache(getMapping, serverMapping => MergeProperties(_inferredCodeProperties.Value, serverMapping?.Properties), _timeProvider, _logger);
     }
 
     public ElasticMappingResolver(TypeMapping codeMapping, Inferrer inferrer, Func<TypeMapping?> getMapping, TimeProvider? timeProvider = null, ILogger? logger = null)
@@ -56,46 +43,92 @@ public class ElasticMappingResolver : IDisposable
     }
 
     /// <summary>
-    /// Maximum age of the loaded server mapping before an ordinary resolution will reload it. This also
-    /// acts as the ceiling when backing off repeated reloads triggered by fields that cannot be resolved.
+    /// Maximum age of the loaded server mapping before an ordinary resolution will reload it. This also acts
+    /// as the ceiling when backing off repeated reloads triggered by fields that cannot be resolved.
     /// </summary>
-    public TimeSpan MappingRefreshInterval { get; set; } = TimeSpan.FromMinutes(1);
+    /// <exception cref="ArgumentOutOfRangeException">The value is negative.</exception>
+    public TimeSpan MappingRefreshInterval
+    {
+        get => _cache.RefreshInterval;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, TimeSpan.Zero);
+            _cache.RefreshInterval = value;
+        }
+    }
 
     /// <summary>
     /// Minimum interval between server mapping reloads that are triggered by a field which could not be
     /// resolved from the loaded mapping. A resolution failure is the strongest available signal that the
-    /// index mapping changed (fields created by dynamic templates only exist after the first document
-    /// that uses them is indexed), so this is intentionally much shorter than <see cref="MappingRefreshInterval"/>.
+    /// index mapping changed (fields created by dynamic templates only exist after the first document that
+    /// uses them is indexed), so this is intentionally much shorter than <see cref="MappingRefreshInterval"/>.
     /// Reloads that do not resolve the field back off exponentially up to <see cref="MappingRefreshInterval"/>.
+    /// </summary>
+    /// <remarks>
+    /// A reload walks and merges the whole property tree, which on a large mapping costs several milliseconds
+    /// and allocates megabytes, so this trades staleness against that cost rather than against network time.
     /// Set to <see cref="TimeSpan.Zero"/> to always reload on an unresolved field.
-    /// </summary>
-    public TimeSpan UnmappedFieldRefreshInterval { get; set; } = TimeSpan.FromSeconds(1);
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The value is negative.</exception>
+    public TimeSpan UnmappedFieldRefreshInterval
+    {
+        get => _cache.UnmappedFieldRefreshInterval;
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(value, TimeSpan.Zero);
+            _cache.UnmappedFieldRefreshInterval = value;
+        }
+    }
 
     /// <summary>
-    /// Maximum time a resolution will wait to join a server mapping fetch that is already in flight. Only one
-    /// fetch runs at a time, so concurrent lookups of a field that is missing from the loaded mapping wait for
-    /// that fetch instead of issuing their own. Waiting is never more expensive than performing the fetch, so
-    /// this must comfortably exceed the latency of the configured mapping fetch; giving up early would resolve
-    /// the field as unmapped even though a fetch that could have resolved it was already running. It is bounded
-    /// rather than infinite so that an unresponsive cluster cannot pin request threads indefinitely.
-    /// Set to a negative value to wait indefinitely.
+    /// Maximum time a resolution will wait for a server mapping reload that is already in flight. Only one
+    /// reload runs at a time, so concurrent lookups of a field that is missing from the loaded mapping wait
+    /// for that reload instead of issuing their own.
     /// </summary>
-    public TimeSpan FetchJoinTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    /// <remarks>
+    /// Waiting is never more expensive than performing the reload, so this must comfortably exceed the
+    /// latency of the configured mapping fetch; giving up early resolves the field as unmapped even though a
+    /// reload that could have resolved it was already running. It is bounded rather than infinite so an
+    /// unresponsive cluster cannot pin request threads. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait
+    /// indefinitely, which is safe when the fetch callback has its own timeout (the Elasticsearch client
+    /// applies one by default).
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The value is negative or zero and is not <see cref="Timeout.InfiniteTimeSpan"/>.
+    /// </exception>
+    public TimeSpan MappingRefreshWaitTimeout
+    {
+        get => _cache.RefreshWaitTimeout;
+        set
+        {
+            if (value != Timeout.InfiniteTimeSpan)
+                ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, TimeSpan.Zero);
+
+            _cache.RefreshWaitTimeout = value;
+        }
+    }
 
     /// <summary>
-    /// Approximate upper bound on the number of resolved field mappings held in memory. Field names come
-    /// from user supplied queries, so this bounds memory usage when queries reference many distinct
-    /// (often non-existent) fields. The cache is cleared once the bound is exceeded. Set to zero or less
-    /// to disable caching entirely.
+    /// Approximate upper bound on the number of resolved field mappings held in memory. Field names come from
+    /// user supplied queries, so this bounds memory usage when queries reference many distinct (often
+    /// non-existent) fields.
     /// </summary>
-    public int MaxCachedFields { get; set; } = 10000;
+    /// <remarks>
+    /// When the bound is reached, cached misses are evicted first so that an abusive caller sending many
+    /// unknown field names cannot displace the resolutions real queries depend on. Set to zero or less to
+    /// disable caching entirely.
+    /// </remarks>
+    public int MaxCachedFields
+    {
+        get => _cache.MaxCachedFields;
+        set => _cache.MaxCachedFields = value;
+    }
 
     /// <summary>
     /// Approximate number of field names currently held in the resolved mapping cache.
     /// </summary>
-    public long CachedFieldCount => Interlocked.Read(ref _cachedFieldCount);
+    public long CachedFieldCount => _cache.CachedFieldCount;
 
-    private MappingSnapshot Snapshot => Volatile.Read(ref _snapshot);
 
     /// <summary>
     /// Clears the cached mapping, forcing a fresh fetch from the server on the next access.
@@ -109,16 +142,7 @@ public class ElasticMappingResolver : IDisposable
     /// </remarks>
     public void RefreshMapping()
     {
-        lock (_publishLock)
-        {
-            Interlocked.Increment(ref _refreshVersion);
-            ClearCache();
-            Volatile.Write(ref _snapshot, CreateSnapshot(null, fetched: false));
-            Interlocked.Exchange(ref _lastFetchTimestamp, 0);
-            Interlocked.Exchange(ref _lastUnmappedFetchTimestamp, 0);
-            Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
-        }
-
+        _cache.Reset();
         _logger.LogInformation("Mapping refresh triggered");
     }
 
@@ -132,12 +156,7 @@ public class ElasticMappingResolver : IDisposable
         if (String.IsNullOrWhiteSpace(field))
             return;
 
-        if (_mappingCache.TryRemove(field!, out _))
-            Interlocked.Decrement(ref _cachedFieldCount);
-
-        Interlocked.Exchange(ref _lastUnmappedFetchTimestamp, 0);
-        Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
-
+        _cache.InvalidateField(field!);
         _logger.LogTrace("Invalidated field mapping: {Field}", field);
     }
 
@@ -146,12 +165,12 @@ public class ElasticMappingResolver : IDisposable
         if (String.IsNullOrWhiteSpace(field))
             return null;
 
-        if (GetServerMappingFunc is null && _codeMapping is null)
+        if (!_cache.HasServerMappingFunc && _codeMapping is null)
             throw new InvalidOperationException("No mappings are available.");
 
-        var snapshot = Snapshot;
+        var snapshot = _cache.Current;
 
-        if (_mappingCache.TryGetValue(field!, out var cached) && cached.Epoch == snapshot.Version)
+        if (_cache.TryGetField(field!, snapshot, out var cached))
         {
             if (cached.Found)
             {
@@ -171,7 +190,7 @@ public class ElasticMappingResolver : IDisposable
 
             // A cached miss is the strongest available signal that the server mapping may have changed,
             // so attempt a rate limited reload before trusting it.
-            if (ReloadServerMapping(unmappedField: true) != MappingFetchResult.Updated)
+            if (_cache.Refresh(triggeredByUnmappedField: true) != MappingRefreshResult.Updated)
             {
                 if (_logger.IsEnabled(LogLevel.Trace))
                     _logger.LogTrace("Cached mapping (not found): {Field}=<null>", field);
@@ -179,7 +198,7 @@ public class ElasticMappingResolver : IDisposable
                 return cached;
             }
 
-            return ResolveMapping(field!, followAlias, Snapshot, reloadedForUnmappedField: true);
+            return ResolveMapping(field!, followAlias, _cache.Current, reloadedForUnmappedField: true);
         }
 
         return ResolveMapping(field!, followAlias, snapshot, reloadedForUnmappedField: false);
@@ -187,7 +206,7 @@ public class ElasticMappingResolver : IDisposable
 
     private FieldMapping ResolveMapping(string field, bool followAlias, MappingSnapshot snapshot, bool reloadedForUnmappedField)
     {
-        var lastFetchResult = MappingFetchResult.Skipped;
+        var lastRefreshResult = MappingRefreshResult.Skipped;
         bool reloaded = reloadedForUnmappedField;
         bool reloadedForMiss = reloadedForUnmappedField;
 
@@ -196,10 +215,10 @@ public class ElasticMappingResolver : IDisposable
         // otherwise fields created after startup resolve as unmapped until the throttle expires.
         if (!snapshot.Fetched && !reloaded)
         {
-            lastFetchResult = ReloadServerMapping(unmappedField: false);
-            if (lastFetchResult == MappingFetchResult.Updated)
+            lastRefreshResult = _cache.Refresh(triggeredByUnmappedField: false);
+            if (lastRefreshResult == MappingRefreshResult.Updated)
             {
-                snapshot = Snapshot;
+                snapshot = _cache.Current;
                 reloaded = true;
             }
         }
@@ -242,14 +261,14 @@ public class ElasticMappingResolver : IDisposable
                 // mapping was loaded, then start over from the top against the new mapping.
                 if (fieldMapping is null && !reloaded)
                 {
-                    lastFetchResult = ReloadServerMapping(unmappedField: true);
-                    if (lastFetchResult == MappingFetchResult.Updated)
+                    lastRefreshResult = _cache.Refresh(triggeredByUnmappedField: true);
+                    if (lastRefreshResult == MappingRefreshResult.Updated)
                     {
                         reloaded = true;
                         reloadedForMiss = true;
                         depth = -1;
                         resolvedFieldName.Clear();
-                        snapshot = Snapshot;
+                        snapshot = _cache.Current;
                         currentProperties = snapshot.Properties;
                         continue;
                     }
@@ -279,12 +298,12 @@ public class ElasticMappingResolver : IDisposable
             if (depth == fieldParts.Length - 1)
             {
                 var resolvedMapping = new FieldMapping(resolvedFieldName.ToString(), fieldMapping, snapshot.CreatedUtc, snapshot.Version);
-                CacheFieldMapping(field, resolvedMapping, snapshot.Version);
+                _cache.CacheField(field, resolvedMapping, snapshot.Version);
 
                 // A miss driven reload that resolved the field is proof the mapping really had changed:
                 // return to the fast base interval so the next schema change is picked up quickly.
                 if (reloadedForMiss)
-                    Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
+                    _cache.ResetUnmappedRefreshBackoff();
 
                 if (_logger.IsEnabled(LogLevel.Trace))
                     _logger.LogTrace("Resolved mapping: {Field}={FieldPath}:{FieldType}", field, resolvedMapping.FullPath, resolvedMapping.Property?.Type);
@@ -295,15 +314,7 @@ public class ElasticMappingResolver : IDisposable
                 return resolvedMapping;
             }
 
-            // Object and nested properties hold sub-objects in Properties; every other property type can
-            // only hold multi-fields. GetFields() covers all property types, so a multi-field on a keyword,
-            // date or numeric property resolves the same way one on a text property does.
-            currentProperties = fieldMapping switch
-            {
-                ObjectProperty objectProperty => objectProperty.Properties ?? objectProperty.Fields,
-                NestedProperty nestedProperty => nestedProperty.Properties ?? nestedProperty.Fields,
-                _ => fieldMapping.GetFields()
-            };
+            currentProperties = GetChildProperties(fieldMapping);
 
             if (currentProperties is null)
                 break;
@@ -313,13 +324,13 @@ public class ElasticMappingResolver : IDisposable
         // exist at all (a typo or a query against a field that was never indexed). Back off so a flood of
         // bogus field names cannot turn every query into a mapping fetch.
         if (reloadedForMiss)
-            IncreaseUnmappedRefreshBackoff(snapshot.Version);
-        else if (lastFetchResult == MappingFetchResult.JoinTimedOut && ShouldLogSuppressedReload())
-            _logger.LogWarning("Unable to resolve mapping for field {Field}. A server mapping reload was already in flight but did not complete within {JoinTimeout}, so this field is being treated as unmapped. Increase {Property} if the mapping fetch is expected to take longer than this", field,
-                FetchJoinTimeout, nameof(FetchJoinTimeout));
-        else if (lastFetchResult == MappingFetchResult.Throttled && snapshot.HasServerMapping && ShouldLogSuppressedReload())
+            _cache.RecordUnresolvedAfterRefresh(snapshot.Version);
+        else if (lastRefreshResult == MappingRefreshResult.WaitTimedOut && _cache.ShouldLogSuppressedRefresh())
+            _logger.LogWarning("Unable to resolve mapping for field {Field}. A server mapping reload was already in flight but did not complete within {WaitTimeout}, so this field is being treated as unmapped. Increase {Property} if the mapping fetch is expected to take longer than this", field,
+                MappingRefreshWaitTimeout, nameof(MappingRefreshWaitTimeout));
+        else if (lastRefreshResult == MappingRefreshResult.Throttled && snapshot.HasServerMapping && _cache.ShouldLogSuppressedRefresh())
             _logger.LogWarning("Unable to resolve mapping for field {Field}. The loaded server mapping is {MappingAge} old and a reload was suppressed by the {RefreshInterval} unmapped field refresh throttle, so this field is being treated as unmapped", field,
-                _timeProvider.GetUtcNow().UtcDateTime - snapshot.CreatedUtc, new TimeSpan(GetUnmappedRefreshIntervalTicks()));
+                _timeProvider.GetUtcNow().UtcDateTime - snapshot.CreatedUtc, _cache.CurrentUnmappedRefreshInterval);
 
         if (_logger.IsEnabled(LogLevel.Trace))
             _logger.LogTrace("Mapping not found: {Field}", field);
@@ -327,25 +338,9 @@ public class ElasticMappingResolver : IDisposable
         // A cached miss is always revalidated against an in-flight or throttled reload before it is trusted
         // (see GetMapping), so caching this result cannot pin a stale answer.
         var notFoundMapping = new FieldMapping(resolvedFieldName.ToString(), null, snapshot.CreatedUtc, snapshot.Version);
-        CacheFieldMapping(field, notFoundMapping, snapshot.Version);
+        _cache.CacheField(field, notFoundMapping, snapshot.Version);
 
         return notFoundMapping;
-    }
-
-    /// <summary>
-    /// Rate limits the suppressed reload warning so a flood of queries against non-existent fields cannot
-    /// flood the log. At most one warning is emitted per <see cref="MappingRefreshInterval"/>.
-    /// </summary>
-    private bool ShouldLogSuppressedReload()
-    {
-        if (!_logger.IsEnabled(LogLevel.Warning))
-            return false;
-
-        long last = Interlocked.Read(ref _lastSuppressedReloadWarningTimestamp);
-        if (last != 0 && _timeProvider.GetElapsedTime(last) < MappingRefreshInterval)
-            return false;
-
-        return Interlocked.CompareExchange(ref _lastSuppressedReloadWarningTimestamp, _timeProvider.GetTimestamp(), last) == last;
     }
 
     private string? ResolvePropertyName(PropertyName? key)
@@ -354,37 +349,6 @@ public class ElasticMappingResolver : IDisposable
             return null;
 
         return _inferrer is not null ? _inferrer.PropertyName(key) : key.Name;
-    }
-
-    private void CacheFieldMapping(string field, FieldMapping mapping, long snapshotVersion)
-    {
-        int maxCachedFields = MaxCachedFields;
-        if (maxCachedFields <= 0)
-            return;
-
-        // Do not publish a resolution that was made against a mapping which has already been replaced.
-        if (Snapshot.Version != snapshotVersion)
-            return;
-
-        if (Interlocked.Read(ref _cachedFieldCount) >= maxCachedFields && !_mappingCache.ContainsKey(field))
-        {
-            _logger.LogWarning("Field mapping cache exceeded {MaxCachedFields} entries and was cleared", maxCachedFields);
-            ClearCache();
-        }
-
-        if (_mappingCache.TryAdd(field, mapping))
-        {
-            Interlocked.Increment(ref _cachedFieldCount);
-            return;
-        }
-
-        _mappingCache.AddOrUpdate(field, mapping, (_, existing) => existing.Epoch > mapping.Epoch ? existing : mapping);
-    }
-
-    private void ClearCache()
-    {
-        _mappingCache.Clear();
-        Interlocked.Exchange(ref _cachedFieldCount, 0);
     }
 
     public FieldMapping? GetMapping(Field field, bool followAlias = false)
@@ -455,7 +419,7 @@ public class ElasticMappingResolver : IDisposable
             return field;
 
         var multiFieldProperty = mapping.Property;
-        var fields = multiFieldProperty.GetFields();
+        var fields = GetChildProperties(multiFieldProperty);
         if (fields is null || (IDictionary<PropertyName, IProperty>)fields is not { Count: > 0 })
             return mapping.FullPath;
 
@@ -653,11 +617,45 @@ public class ElasticMappingResolver : IDisposable
         return MergeProperties(InferCodeProperties(codeProperties), serverProperties);
     }
 
+    /// <summary>
+    /// Returns the child properties a field name can descend into. Object and nested properties hold
+    /// sub-objects in <c>Properties</c>; every other property type can only hold multi-fields. Using one
+    /// accessor for every property type keeps resolution and merging symmetric, so a multi-field on a
+    /// keyword, date or numeric property behaves exactly like one on a text property.
+    /// </summary>
+    private static Properties? GetOwnChildProperties(IProperty property)
+    {
+        return property switch
+        {
+            ObjectProperty objectProperty => objectProperty.Properties ?? objectProperty.Fields,
+            NestedProperty nestedProperty => nestedProperty.Properties ?? nestedProperty.Fields,
+            _ => property.GetFields()
+        };
+    }
+
+    /// <summary>
+    /// Returns the child properties of a property, preferring the merged view recorded while combining the
+    /// code mapping with the server mapping.
+    /// </summary>
+    private Properties? GetChildProperties(IProperty property)
+    {
+        // Merged children only exist when a code mapping was supplied, so resolvers backed purely by the
+        // server mapping never pay for the lookup.
+        if (_codeMapping is not null && _mergedChildProperties.TryGetValue(property, out var mergedChildren))
+            return mergedChildren;
+
+        return GetOwnChildProperties(property);
+    }
+
+    /// <summary>
+    /// Combines the properties declared in code with the properties reported by the server, preferring the
+    /// server definition and layering code-only properties on top.
+    /// </summary>
     /// <remarks>
-    /// Merging mutates the sub-property collections of the server property objects, so the
-    /// <c>getMapping</c> callback must return a mapping instance the resolver can take ownership of
-    /// (a freshly deserialized <c>GetMapping</c> response, not a cached shared instance). Merging is done
-    /// exactly once per snapshot, so a single mapping instance is never merged concurrently.
+    /// Merging never mutates the server mapping. Where a property is declared in both mappings its combined
+    /// children are recorded in a side table keyed by the server property instance, which keeps the mapping
+    /// returned by the <c>getMapping</c> callback safe to share and makes merging work identically for every
+    /// property type rather than only the handful that expose settable sub-property collections.
     /// </remarks>
     private Properties? MergeProperties(Properties? inferredCodeProperties, Properties? serverProperties)
     {
@@ -675,19 +673,13 @@ public class ElasticMappingResolver : IDisposable
                 // Copy local metadata from code property to merged property
                 CopyPropertyMetadata(codeProperty, merged);
 
-                switch (merged)
+                var codeChildren = GetOwnChildProperties(codeProperty);
+                if (codeChildren is not null)
                 {
-                    case ObjectProperty objectProperty:
-                        objectProperty.Properties =
-                            MergeCodeAndServerProperties((codeProperty as ObjectProperty)?.Properties, objectProperty.Properties);
-                        break;
-                    case NestedProperty nestedProperty:
-                        nestedProperty.Properties =
-                            MergeCodeAndServerProperties((codeProperty as NestedProperty)?.Properties, nestedProperty.Properties);
-                        break;
-                    case TextProperty textProperty:
-                        textProperty.Fields = MergeCodeAndServerProperties((codeProperty as TextProperty)?.Fields, textProperty.Fields);
-                        break;
+                    var serverChildren = GetOwnChildProperties(merged);
+                    var mergedChildren = MergeCodeAndServerProperties(codeChildren, serverChildren);
+                    if (mergedChildren is not null && !ReferenceEquals(mergedChildren, serverChildren))
+                        _mergedChildProperties.AddOrUpdate(merged, mergedChildren);
                 }
             }
 
@@ -703,192 +695,6 @@ public class ElasticMappingResolver : IDisposable
         }
 
         return properties;
-    }
-
-    private Func<TypeMapping?>? GetServerMappingFunc { get; set; }
-
-    private MappingSnapshot CreateSnapshot(TypeMapping? serverMapping, bool fetched)
-    {
-        long version = Interlocked.Increment(ref _snapshotVersion);
-
-        // Properties are merged lazily and exactly once per snapshot: merging walks (and mutates) the
-        // whole property tree, which is far too expensive to repeat for every field resolution.
-        return new MappingSnapshot(version, serverMapping is not null, fetched,
-            () => MergeProperties(_inferredCodeProperties.Value, serverMapping?.Properties),
-            _timeProvider.GetUtcNow().UtcDateTime);
-    }
-
-    private long GetUnmappedRefreshIntervalTicks()
-    {
-        long baseTicks = Math.Max(UnmappedFieldRefreshInterval.Ticks, 0);
-        long maxTicks = Math.Max(MappingRefreshInterval.Ticks, baseTicks);
-        long backoffTicks = Interlocked.Read(ref _unmappedRefreshBackoffTicks);
-
-        return Math.Min(Math.Max(baseTicks, backoffTicks), maxTicks);
-    }
-
-    private void IncreaseUnmappedRefreshBackoff()
-    {
-        long baseTicks = Math.Max(UnmappedFieldRefreshInterval.Ticks, 0);
-        long maxTicks = Math.Max(MappingRefreshInterval.Ticks, baseTicks);
-        long current = Interlocked.Read(ref _unmappedRefreshBackoffTicks);
-        if (current >= maxTicks)
-            return;
-
-        long next = Math.Min(Math.Max(current, baseTicks) * 2, maxTicks);
-        Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, next);
-    }
-
-    /// <summary>
-    /// Backs off at most once per mapping reload. Many concurrent lookups adopt the result of a single
-    /// reload, and without this guard one reload would ratchet the interval all the way to the ceiling.
-    /// </summary>
-    private void IncreaseUnmappedRefreshBackoff(long snapshotVersion)
-    {
-        long applied = Interlocked.Read(ref _backoffAppliedForVersion);
-        if (applied == snapshotVersion || Interlocked.CompareExchange(ref _backoffAppliedForVersion, snapshotVersion, applied) != applied)
-            return;
-
-        IncreaseUnmappedRefreshBackoff();
-    }
-
-    private bool IsReloadAllowed(bool unmappedField)
-    {
-        if (unmappedField)
-        {
-            long lastUnmappedFetch = Interlocked.Read(ref _lastUnmappedFetchTimestamp);
-            return lastUnmappedFetch == 0 || _timeProvider.GetElapsedTime(lastUnmappedFetch) >= new TimeSpan(GetUnmappedRefreshIntervalTicks());
-        }
-
-        long lastFetch = Interlocked.Read(ref _lastFetchTimestamp);
-        return lastFetch == 0 || _timeProvider.GetElapsedTime(lastFetch) >= MappingRefreshInterval;
-    }
-
-    private void RecordReloadAttempt(bool unmappedField)
-    {
-        long timestamp = _timeProvider.GetTimestamp();
-        Interlocked.Exchange(ref _lastFetchTimestamp, timestamp);
-        if (unmappedField)
-            Interlocked.Exchange(ref _lastUnmappedFetchTimestamp, timestamp);
-    }
-
-    /// <summary>
-    /// Reloads the server mapping, publishing a new snapshot when it succeeds.
-    /// </summary>
-    /// <param name="unmappedField">
-    /// True when the reload was triggered by a field that could not be resolved. Miss driven reloads use
-    /// their own (much shorter, self backing off) throttle so that a cold start fetch cannot suppress them.
-    /// </param>
-    private MappingFetchResult ReloadServerMapping(bool unmappedField)
-    {
-        var getServerMapping = GetServerMappingFunc;
-        if (getServerMapping is null || _disposed)
-            return MappingFetchResult.Skipped;
-
-        if (!IsReloadAllowed(unmappedField))
-            return MappingFetchResult.Throttled;
-
-        long versionBeforeWait = Snapshot.Version;
-
-        var joinTimeout = FetchJoinTimeout;
-        if (joinTimeout < TimeSpan.Zero)
-            joinTimeout = Timeout.InfiniteTimeSpan;
-        else if (joinTimeout.TotalMilliseconds > Int32.MaxValue)
-            joinTimeout = TimeSpan.FromMilliseconds(Int32.MaxValue);
-
-        bool acquired;
-        try
-        {
-            // Join an in-flight fetch instead of silently continuing with a stale mapping. That fetch is
-            // exactly the work this resolution needs, so waiting for it is never more expensive than doing
-            // it ourselves. The wait is bounded because the fetch callback is user supplied and does
-            // blocking network I/O, and an unresponsive cluster must not pin request threads forever.
-            acquired = _fetchSemaphore.Wait(joinTimeout);
-        }
-        catch (ObjectDisposedException)
-        {
-            return MappingFetchResult.Skipped;
-        }
-
-        if (!acquired)
-        {
-            // The in-flight fetch may have published while we were giving up.
-            var snapshotAfterTimeout = Snapshot;
-            if (snapshotAfterTimeout.Version != versionBeforeWait && snapshotAfterTimeout.Fetched)
-                return MappingFetchResult.Updated;
-
-            return MappingFetchResult.JoinTimedOut;
-        }
-
-        try
-        {
-            // Another caller finished a fetch while we waited, so adopt its result rather than refetching.
-            // A snapshot that has not been fetched means RefreshMapping() ran while we waited, in which case
-            // we still have to do the fetch ourselves.
-            var snapshotAfterWait = Snapshot;
-            if (snapshotAfterWait.Version != versionBeforeWait && snapshotAfterWait.Fetched)
-                return MappingFetchResult.Updated;
-
-            if (!IsReloadAllowed(unmappedField))
-                return MappingFetchResult.Throttled;
-
-            long refreshVersion = Interlocked.Read(ref _refreshVersion);
-
-            TypeMapping? newMapping;
-            try
-            {
-                newMapping = getServerMapping();
-            }
-            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
-            {
-                // Record the attempt so a failing cluster is not retried for every unresolved field.
-                RecordReloadAttempt(unmappedField);
-                if (unmappedField)
-                    IncreaseUnmappedRefreshBackoff();
-
-                _logger.LogError(ex, "Error getting server mapping: {Message}", ex.Message);
-                return MappingFetchResult.Failed;
-            }
-
-            var current = Snapshot;
-            if (newMapping is null && current.Fetched && !current.HasServerMapping)
-            {
-                // Nothing changed, so keep the current snapshot (and its resolved field cache) intact.
-                RecordReloadAttempt(unmappedField);
-                if (unmappedField)
-                    IncreaseUnmappedRefreshBackoff();
-
-                return MappingFetchResult.Failed;
-            }
-
-            lock (_publishLock)
-            {
-                // A RefreshMapping() during the fetch means this result may predate the schema change the
-                // caller knows about, so discard it and let the next resolution fetch again.
-                if (Interlocked.Read(ref _refreshVersion) != refreshVersion)
-                    return MappingFetchResult.Failed;
-
-                // Clear before publishing so resolutions made against the new snapshot are not discarded.
-                ClearCache();
-                Volatile.Write(ref _snapshot, CreateSnapshot(newMapping, fetched: true));
-                RecordReloadAttempt(unmappedField);
-            }
-
-            _logger.LogInformation("Got server mapping");
-
-            return MappingFetchResult.Updated;
-        }
-        finally
-        {
-            try
-            {
-                _fetchSemaphore.Release();
-            }
-            catch (ObjectDisposedException)
-            {
-                // the resolver was disposed while the fetch was in flight
-            }
-        }
     }
 
     public static ElasticMappingResolver Create<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, ElasticsearchClient client, ILogger? logger = null) where T : class
@@ -1015,65 +821,9 @@ public class ElasticMappingResolver : IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
-            return;
-
-        _disposed = true;
-        _fetchSemaphore.Dispose();
+        _cache.Dispose();
     }
 
-    /// <summary>
-    /// An immutable point-in-time view of the mapping. Published by reference swap so that readers never
-    /// need a lock and always observe a consistent mapping plus version pair.
-    /// </summary>
-    private sealed class MappingSnapshot
-    {
-        private readonly Lazy<Properties?> _properties;
-
-        public MappingSnapshot(long version, bool hasServerMapping, bool fetched, Func<Properties?> propertiesFactory, DateTime createdUtc)
-        {
-            Version = version;
-            HasServerMapping = hasServerMapping;
-            Fetched = fetched;
-            CreatedUtc = createdUtc;
-            _properties = new Lazy<Properties?>(propertiesFactory, LazyThreadSafetyMode.ExecutionAndPublication);
-        }
-
-        /// <summary>Monotonically increasing version used to detect field cache entries from older mappings.</summary>
-        public long Version { get; }
-
-        /// <summary>Whether the server returned a mapping (as opposed to no mapping being available).</summary>
-        public bool HasServerMapping { get; }
-
-        /// <summary>Whether a server mapping fetch has been attempted for this snapshot.</summary>
-        public bool Fetched { get; }
-
-        public DateTime CreatedUtc { get; }
-
-        /// <summary>Code and server properties merged once, on first use.</summary>
-        public Properties? Properties => _properties.Value;
-    }
-
-    private enum MappingFetchResult
-    {
-        /// <summary>No fetch was attempted (no fetch function, disposed, or already reloaded).</summary>
-        Skipped,
-
-        /// <summary>A fetch was warranted but suppressed by a refresh throttle.</summary>
-        Throttled,
-
-        /// <summary>
-        /// A fetch was already in flight but did not complete within <see cref="FetchJoinTimeout"/>, so the
-        /// loaded mapping is known to be stale.
-        /// </summary>
-        JoinTimedOut,
-
-        /// <summary>The server mapping was reloaded and a new snapshot published.</summary>
-        Updated,
-
-        /// <summary>The fetch was attempted but did not produce a usable mapping.</summary>
-        Failed
-    }
 }
 
 public class FieldMapping

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -295,21 +295,18 @@ public class ElasticMappingResolver : IDisposable
                 return resolvedMapping;
             }
 
-            if (fieldMapping is ObjectProperty objectProperty)
+            // Object and nested properties hold sub-objects in Properties; every other property type can
+            // only hold multi-fields. GetFields() covers all property types, so a multi-field on a keyword,
+            // date or numeric property resolves the same way one on a text property does.
+            currentProperties = fieldMapping switch
             {
-                currentProperties = objectProperty.Properties;
-            }
-            else if (fieldMapping is NestedProperty nestedProperty)
-            {
-                currentProperties = nestedProperty.Properties;
-            }
-            else
-            {
-                if (fieldMapping is TextProperty textProperty)
-                    currentProperties = textProperty.Fields;
-                else
-                    break;
-            }
+                ObjectProperty objectProperty => objectProperty.Properties ?? objectProperty.Fields,
+                NestedProperty nestedProperty => nestedProperty.Properties ?? nestedProperty.Fields,
+                _ => fieldMapping.GetFields()
+            };
+
+            if (currentProperties is null)
+                break;
         }
 
         // A freshly reloaded mapping that still does not contain the field means the field probably does not

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -16,8 +16,6 @@ namespace Foundatio.Parsers.ElasticQueries;
 
 public class ElasticMappingResolver : IDisposable
 {
-    private static readonly TimeSpan _fetchJoinTimeout = TimeSpan.FromSeconds(5);
-
     private readonly TypeMapping? _codeMapping;
     private readonly Lazy<Properties?> _inferredCodeProperties;
     private readonly Inferrer? _inferrer;
@@ -71,7 +69,18 @@ public class ElasticMappingResolver : IDisposable
     /// Reloads that do not resolve the field back off exponentially up to <see cref="MappingRefreshInterval"/>.
     /// Set to <see cref="TimeSpan.Zero"/> to always reload on an unresolved field.
     /// </summary>
-    public TimeSpan UnmappedFieldRefreshInterval { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan UnmappedFieldRefreshInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Maximum time a resolution will wait to join a server mapping fetch that is already in flight. Only one
+    /// fetch runs at a time, so concurrent lookups of a field that is missing from the loaded mapping wait for
+    /// that fetch instead of issuing their own. Waiting is never more expensive than performing the fetch, so
+    /// this must comfortably exceed the latency of the configured mapping fetch; giving up early would resolve
+    /// the field as unmapped even though a fetch that could have resolved it was already running. It is bounded
+    /// rather than infinite so that an unresponsive cluster cannot pin request threads indefinitely.
+    /// Set to a negative value to wait indefinitely.
+    /// </summary>
+    public TimeSpan FetchJoinTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Approximate upper bound on the number of resolved field mappings held in memory. Field names come
@@ -308,6 +317,9 @@ public class ElasticMappingResolver : IDisposable
         // bogus field names cannot turn every query into a mapping fetch.
         if (reloadedForMiss)
             IncreaseUnmappedRefreshBackoff(snapshot.Version);
+        else if (lastFetchResult == MappingFetchResult.JoinTimedOut && ShouldLogSuppressedReload())
+            _logger.LogWarning("Unable to resolve mapping for field {Field}. A server mapping reload was already in flight but did not complete within {JoinTimeout}, so this field is being treated as unmapped. Increase {Property} if the mapping fetch is expected to take longer than this", field,
+                FetchJoinTimeout, nameof(FetchJoinTimeout));
         else if (lastFetchResult == MappingFetchResult.Throttled && snapshot.HasServerMapping && ShouldLogSuppressedReload())
             _logger.LogWarning("Unable to resolve mapping for field {Field}. The loaded server mapping is {MappingAge} old and a reload was suppressed by the {RefreshInterval} unmapped field refresh throttle, so this field is being treated as unmapped", field,
                 _timeProvider.GetUtcNow().UtcDateTime - snapshot.CreatedUtc, new TimeSpan(GetUnmappedRefreshIntervalTicks()));
@@ -315,6 +327,8 @@ public class ElasticMappingResolver : IDisposable
         if (_logger.IsEnabled(LogLevel.Trace))
             _logger.LogTrace("Mapping not found: {Field}", field);
 
+        // A cached miss is always revalidated against an in-flight or throttled reload before it is trusted
+        // (see GetMapping), so caching this result cannot pin a stale answer.
         var notFoundMapping = new FieldMapping(resolvedFieldName.ToString(), null, snapshot.CreatedUtc, snapshot.Version);
         CacheFieldMapping(field, notFoundMapping, snapshot.Version);
 
@@ -779,12 +793,20 @@ public class ElasticMappingResolver : IDisposable
 
         long versionBeforeWait = Snapshot.Version;
 
+        var joinTimeout = FetchJoinTimeout;
+        if (joinTimeout < TimeSpan.Zero)
+            joinTimeout = Timeout.InfiniteTimeSpan;
+        else if (joinTimeout.TotalMilliseconds > Int32.MaxValue)
+            joinTimeout = TimeSpan.FromMilliseconds(Int32.MaxValue);
+
         bool acquired;
         try
         {
-            // Join an in-flight fetch instead of silently continuing with a stale mapping. The wait is
-            // bounded because the fetch callback is user supplied and does blocking network I/O.
-            acquired = _fetchSemaphore.Wait(_fetchJoinTimeout);
+            // Join an in-flight fetch instead of silently continuing with a stale mapping. That fetch is
+            // exactly the work this resolution needs, so waiting for it is never more expensive than doing
+            // it ourselves. The wait is bounded because the fetch callback is user supplied and does
+            // blocking network I/O, and an unresponsive cluster must not pin request threads forever.
+            acquired = _fetchSemaphore.Wait(joinTimeout);
         }
         catch (ObjectDisposedException)
         {
@@ -793,8 +815,12 @@ public class ElasticMappingResolver : IDisposable
 
         if (!acquired)
         {
-            _logger.LogWarning("Timed out after {Timeout} joining an in-flight server mapping fetch, continuing with the loaded mapping", _fetchJoinTimeout);
-            return MappingFetchResult.Throttled;
+            // The in-flight fetch may have published while we were giving up.
+            var snapshotAfterTimeout = Snapshot;
+            if (snapshotAfterTimeout.Version != versionBeforeWait && snapshotAfterTimeout.Fetched)
+                return MappingFetchResult.Updated;
+
+            return MappingFetchResult.JoinTimedOut;
         }
 
         try
@@ -1038,6 +1064,12 @@ public class ElasticMappingResolver : IDisposable
 
         /// <summary>A fetch was warranted but suppressed by a refresh throttle.</summary>
         Throttled,
+
+        /// <summary>
+        /// A fetch was already in flight but did not complete within <see cref="FetchJoinTimeout"/>, so the
+        /// loaded mapping is known to be stale.
+        /// </summary>
+        JoinTimedOut,
 
         /// <summary>The server mapping was reloaded and a new snapshot published.</summary>
         Updated,

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.IndexManagement;
 using Elastic.Clients.Elasticsearch.Mapping;
-using Exceptionless.DateTimeExtensions;
 using Foundatio.Parsers.ElasticQueries.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -17,16 +16,28 @@ namespace Foundatio.Parsers.ElasticQueries;
 
 public class ElasticMappingResolver : IDisposable
 {
-    private TypeMapping? _serverMapping;
+    private static readonly TimeSpan _fetchJoinTimeout = TimeSpan.FromSeconds(5);
+
     private readonly TypeMapping? _codeMapping;
+    private readonly Lazy<Properties?> _inferredCodeProperties;
     private readonly Inferrer? _inferrer;
-    private readonly ConcurrentDictionary<string, FieldMapping> _mappingCache = new();
-    private readonly object _mappingLock = new();
+    private readonly ConcurrentDictionary<string, FieldMapping> _mappingCache = new(StringComparer.Ordinal);
     private readonly SemaphoreSlim _fetchSemaphore = new(1, 1);
-    private long _refreshEpoch;
+    private readonly object _publishLock = new();
     private readonly TimeProvider _timeProvider;
     private readonly ConditionalWeakTable<IProperty, ConcurrentDictionary<string, object>> _propertyMetadata = new();
     private readonly ILogger _logger;
+
+    private MappingSnapshot _snapshot;
+    private long _snapshotVersion;
+    private long _refreshVersion;
+    private long _cachedFieldCount;
+    private long _lastFetchTimestamp;
+    private long _lastUnmappedFetchTimestamp;
+    private long _unmappedRefreshBackoffTicks;
+    private long _backoffAppliedForVersion;
+    private long _lastSuppressedReloadWarningTimestamp;
+    private volatile bool _disposed;
 
     public static readonly ElasticMappingResolver NullInstance = new(() => null);
 
@@ -36,6 +47,8 @@ public class ElasticMappingResolver : IDisposable
         _inferrer = inferrer;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _logger = logger ?? NullLogger.Instance;
+        _inferredCodeProperties = new Lazy<Properties?>(() => InferCodeProperties(_codeMapping?.Properties), LazyThreadSafetyMode.ExecutionAndPublication);
+        _snapshot = CreateSnapshot(null, fetched: false);
     }
 
     public ElasticMappingResolver(TypeMapping codeMapping, Inferrer inferrer, Func<TypeMapping?> getMapping, TimeProvider? timeProvider = null, ILogger? logger = null)
@@ -45,24 +58,78 @@ public class ElasticMappingResolver : IDisposable
     }
 
     /// <summary>
+    /// Maximum age of the loaded server mapping before an ordinary resolution will reload it. This also
+    /// acts as the ceiling when backing off repeated reloads triggered by fields that cannot be resolved.
+    /// </summary>
+    public TimeSpan MappingRefreshInterval { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Minimum interval between server mapping reloads that are triggered by a field which could not be
+    /// resolved from the loaded mapping. A resolution failure is the strongest available signal that the
+    /// index mapping changed (fields created by dynamic templates only exist after the first document
+    /// that uses them is indexed), so this is intentionally much shorter than <see cref="MappingRefreshInterval"/>.
+    /// Reloads that do not resolve the field back off exponentially up to <see cref="MappingRefreshInterval"/>.
+    /// Set to <see cref="TimeSpan.Zero"/> to always reload on an unresolved field.
+    /// </summary>
+    public TimeSpan UnmappedFieldRefreshInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Approximate upper bound on the number of resolved field mappings held in memory. Field names come
+    /// from user supplied queries, so this bounds memory usage when queries reference many distinct
+    /// (often non-existent) fields. The cache is cleared once the bound is exceeded. Set to zero or less
+    /// to disable caching entirely.
+    /// </summary>
+    public int MaxCachedFields { get; set; } = 10000;
+
+    /// <summary>
+    /// Approximate number of field names currently held in the resolved mapping cache.
+    /// </summary>
+    public long CachedFieldCount => Interlocked.Read(ref _cachedFieldCount);
+
+    private MappingSnapshot Snapshot => Volatile.Read(ref _snapshot);
+
+    /// <summary>
     /// Clears the cached mapping, forcing a fresh fetch from the server on the next access.
     /// </summary>
     /// <remarks>
-    /// Mappings are automatically refreshed at most once per minute. This method bypasses that
-    /// throttle and is primarily useful in unit tests where index mappings change rapidly.
-    /// In production, the automatic refresh is typically sufficient.
+    /// Server mappings are reloaded automatically: at most once per <see cref="MappingRefreshInterval"/>
+    /// for ordinary resolutions and at most once per <see cref="UnmappedFieldRefreshInterval"/> when a
+    /// field cannot be resolved. This method bypasses both throttles and discards the entire field cache,
+    /// which is expensive on a large mapping. Prefer <see cref="InvalidateFieldMapping"/> when only a
+    /// specific field is known to have changed.
     /// </remarks>
     public void RefreshMapping()
     {
-        lock (_mappingLock)
+        lock (_publishLock)
         {
-            Interlocked.Increment(ref _refreshEpoch);
-            _serverMapping = null;
-            Interlocked.Exchange(ref _lastMappingUpdateTicks, 0);
-            _mappingCache.Clear();
+            Interlocked.Increment(ref _refreshVersion);
+            ClearCache();
+            Volatile.Write(ref _snapshot, CreateSnapshot(null, fetched: false));
+            Interlocked.Exchange(ref _lastFetchTimestamp, 0);
+            Interlocked.Exchange(ref _lastUnmappedFetchTimestamp, 0);
+            Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
         }
 
         _logger.LogInformation("Mapping refresh triggered");
+    }
+
+    /// <summary>
+    /// Drops the cached resolution for a single field and allows the next resolution of any unmapped field
+    /// to reload the server mapping. Use this when a specific field is known to have just been created,
+    /// instead of discarding the whole cache with <see cref="RefreshMapping"/>.
+    /// </summary>
+    public void InvalidateFieldMapping(string? field)
+    {
+        if (String.IsNullOrWhiteSpace(field))
+            return;
+
+        if (_mappingCache.TryRemove(field!, out _))
+            Interlocked.Decrement(ref _cachedFieldCount);
+
+        Interlocked.Exchange(ref _lastUnmappedFetchTimestamp, 0);
+        Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
+
+        _logger.LogTrace("Invalidated field mapping: {Field}", field);
     }
 
     public FieldMapping? GetMapping(string? field, bool followAlias = false)
@@ -73,99 +140,110 @@ public class ElasticMappingResolver : IDisposable
         if (GetServerMappingFunc is null && _codeMapping is null)
             throw new InvalidOperationException("No mappings are available.");
 
-        long currentEpoch = Interlocked.Read(ref _refreshEpoch);
+        var snapshot = Snapshot;
 
-        if (_mappingCache.TryGetValue(field, out var mapping) && mapping.Epoch >= currentEpoch)
+        if (_mappingCache.TryGetValue(field!, out var cached) && cached.Epoch == snapshot.Version)
         {
-            long lastUpdateTicks = Interlocked.Read(ref _lastMappingUpdateTicks);
-            bool mappingCurrent = lastUpdateTicks == 0
-                || (mapping.ServerMapTime.HasValue && mapping.ServerMapTime.Value.Ticks >= lastUpdateTicks);
-
-            if (mapping.Found && mappingCurrent)
+            if (cached.Found)
             {
-                if (followAlias && mapping.Property is FieldAliasProperty fieldAlias)
+                if (followAlias && cached.Property is FieldAliasProperty cachedAlias)
                 {
-                    _logger.LogTrace("Cached alias mapping: {Field}={FieldPath}:{FieldType}", field, mapping.FullPath, mapping.Property.Type);
-                    return GetMapping(fieldAlias.Path?.Name);
+                    if (_logger.IsEnabled(LogLevel.Trace))
+                        _logger.LogTrace("Cached alias mapping: {Field}={FieldPath}:{FieldType}", field, cached.FullPath, cached.Property.Type);
+
+                    return GetMapping(cachedAlias.Path?.Name);
                 }
 
-                _logger.LogTrace("Cached mapping: {Field}={FieldPath}:{FieldType}", field, mapping.FullPath, mapping.Property?.Type);
-                return mapping;
+                if (_logger.IsEnabled(LogLevel.Trace))
+                    _logger.LogTrace("Cached mapping: {Field}={FieldPath}:{FieldType}", field, cached.FullPath, cached.Property?.Type);
+
+                return cached;
             }
 
-            if (!mapping.Found && mappingCurrent && !GetServerMapping())
+            // A cached miss is the strongest available signal that the server mapping may have changed,
+            // so attempt a rate limited reload before trusting it.
+            if (ReloadServerMapping(unmappedField: true) != MappingFetchResult.Updated)
             {
-                _logger.LogTrace("Cached mapping (not found): {Field}=<null>", field);
-                return mapping;
+                if (_logger.IsEnabled(LogLevel.Trace))
+                    _logger.LogTrace("Cached mapping (not found): {Field}=<null>", field);
+
+                return cached;
+            }
+
+            return ResolveMapping(field!, followAlias, Snapshot, reloadedForUnmappedField: true);
+        }
+
+        return ResolveMapping(field!, followAlias, snapshot, reloadedForUnmappedField: false);
+    }
+
+    private FieldMapping ResolveMapping(string field, bool followAlias, MappingSnapshot snapshot, bool reloadedForUnmappedField)
+    {
+        var lastFetchResult = MappingFetchResult.Skipped;
+        bool reloaded = reloadedForUnmappedField;
+        bool reloadedForMiss = reloadedForUnmappedField;
+
+        // Load the server mapping the first time one is needed. This deliberately does not arm the
+        // unmapped field throttle: a cold start fetch must never suppress the first miss driven reload,
+        // otherwise fields created after startup resolve as unmapped until the throttle expires.
+        if (!snapshot.Fetched && !reloaded)
+        {
+            lastFetchResult = ReloadServerMapping(unmappedField: false);
+            if (lastFetchResult == MappingFetchResult.Updated)
+            {
+                snapshot = Snapshot;
+                reloaded = true;
             }
         }
 
         string[] fieldParts = field.Split('.');
         var resolvedFieldName = new StringBuilder();
-
-        // Snapshot server mapping under lock so readers see a consistent pair of
-        // _serverMapping + _lastMappingUpdateTicks (both are set together in GetServerMapping).
-        TypeMapping? serverMapping;
-        DateTime? mappingServerTime;
-        lock (_mappingLock)
-        {
-            serverMapping = _serverMapping;
-            long ticks = Interlocked.Read(ref _lastMappingUpdateTicks);
-            mappingServerTime = ticks > 0 ? new DateTime(ticks, DateTimeKind.Utc) : null;
-        }
-
-        if (serverMapping is null && GetServerMappingFunc is not null && GetServerMapping())
-        {
-            lock (_mappingLock)
-            {
-                serverMapping = _serverMapping;
-                long ticks = Interlocked.Read(ref _lastMappingUpdateTicks);
-                mappingServerTime = ticks > 0 ? new DateTime(ticks, DateTimeKind.Utc) : null;
-            }
-        }
-
-        var currentProperties = MergeProperties(_codeMapping?.Properties, serverMapping?.Properties);
+        var currentProperties = snapshot.Properties;
 
         for (int depth = 0; depth < fieldParts.Length; depth++)
         {
             string fieldPart = fieldParts[depth];
             IProperty? fieldMapping = null;
-            PropertyName? foundPropertyName = null;
-            if (currentProperties is null || !currentProperties.TryGetProperty(fieldPart, out fieldMapping))
+            string? resolvedName = null;
+
+            if (currentProperties is not null && currentProperties.TryGetProperty(fieldPart, out fieldMapping))
             {
+                // Properties is keyed by property name, so an exact hit means the key name is the field part.
+                resolvedName = fieldPart;
+            }
+            else
+            {
+                fieldMapping = null;
+
                 // check to see if there is a name match by iterating through the dictionary keys
                 if (currentProperties is not null)
                 {
                     foreach (var kvp in (IDictionary<PropertyName, IProperty>)currentProperties)
                     {
-                        string? propertyName = null;
-                        if (_inferrer is not null && kvp.Key?.Name is not null)
-                            propertyName = _inferrer.PropertyName(kvp.Key);
-                        else if (kvp.Key?.Name is not null)
-                            propertyName = kvp.Key.Name;
-
+                        string? propertyName = ResolvePropertyName(kvp.Key);
                         if (propertyName is not null && propertyName.Equals(fieldPart, StringComparison.OrdinalIgnoreCase))
                         {
                             fieldMapping = kvp.Value;
-                            foundPropertyName = kvp.Key;
+                            resolvedName = propertyName;
                             break;
                         }
                     }
                 }
 
-                // no mapping found, call GetServerMapping again in case it hasn't been called recently and there are possibly new mappings
-                if (fieldMapping is null && GetServerMapping())
+                // The field is unknown to the loaded mapping: reload once in case it was created after the
+                // mapping was loaded, then start over from the top against the new mapping.
+                if (fieldMapping is null && !reloaded)
                 {
-                    depth = -1;
-                    resolvedFieldName.Clear();
-                    lock (_mappingLock)
+                    lastFetchResult = ReloadServerMapping(unmappedField: true);
+                    if (lastFetchResult == MappingFetchResult.Updated)
                     {
-                        serverMapping = _serverMapping;
-                        long ticks = Interlocked.Read(ref _lastMappingUpdateTicks);
-                        mappingServerTime = ticks > 0 ? new DateTime(ticks, DateTimeKind.Utc) : null;
+                        reloaded = true;
+                        reloadedForMiss = true;
+                        depth = -1;
+                        resolvedFieldName.Clear();
+                        snapshot = Snapshot;
+                        currentProperties = snapshot.Properties;
+                        continue;
                     }
-                    currentProperties = MergeProperties(_codeMapping?.Properties, serverMapping?.Properties);
-                    continue;
                 }
 
                 if (fieldMapping is null)
@@ -184,36 +262,26 @@ public class ElasticMappingResolver : IDisposable
                     break;
                 }
             }
-            else
-            {
-                // TryGetProperty succeeded, find the PropertyName key for this mapping
-                foundPropertyName = ((IDictionary<PropertyName, IProperty>)currentProperties)
-                    .FirstOrDefault(kvp => kvp.Value == fieldMapping).Key;
-            }
-
-            // Determine the property name - use foundPropertyName if available, otherwise fall back to fieldPart
-            string resolvedName;
-            if (foundPropertyName is not null && _inferrer is not null && foundPropertyName.Name is not null)
-                resolvedName = _inferrer.PropertyName(foundPropertyName);
-            else if (foundPropertyName is not null && foundPropertyName.Name is not null)
-                resolvedName = foundPropertyName.Name;
-            else
-                resolvedName = fieldPart;
 
             if (depth > 0)
                 resolvedFieldName.Append('.');
-            resolvedFieldName.Append(resolvedName);
+            resolvedFieldName.Append(resolvedName ?? fieldPart);
 
             if (depth == fieldParts.Length - 1)
             {
-                var resolvedMapping = new FieldMapping(resolvedFieldName.ToString(), fieldMapping, mappingServerTime, currentEpoch);
-                if (IsSnapshotCurrent(currentEpoch, mappingServerTime))
-                    _mappingCache.AddOrUpdate(field, resolvedMapping, (_, existing) =>
-                        existing.Epoch > resolvedMapping.Epoch ? existing : resolvedMapping);
-                _logger.LogTrace("Resolved mapping: {Field}={FieldPath}:{FieldType}", field, resolvedMapping.FullPath, resolvedMapping.Property?.Type);
+                var resolvedMapping = new FieldMapping(resolvedFieldName.ToString(), fieldMapping, snapshot.CreatedUtc, snapshot.Version);
+                CacheFieldMapping(field, resolvedMapping, snapshot.Version);
+
+                // A miss driven reload that resolved the field is proof the mapping really had changed:
+                // return to the fast base interval so the next schema change is picked up quickly.
+                if (reloadedForMiss)
+                    Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
+
+                if (_logger.IsEnabled(LogLevel.Trace))
+                    _logger.LogTrace("Resolved mapping: {Field}={FieldPath}:{FieldType}", field, resolvedMapping.FullPath, resolvedMapping.Property?.Type);
 
                 if (followAlias && resolvedMapping.Property is FieldAliasProperty fieldAlias)
-                    return GetMapping(fieldAlias.Path?.Name);
+                    return GetMapping(fieldAlias.Path?.Name) ?? resolvedMapping;
 
                 return resolvedMapping;
             }
@@ -235,13 +303,77 @@ public class ElasticMappingResolver : IDisposable
             }
         }
 
-        _logger.LogTrace("Mapping not found: {field}", field);
-        var notFoundMapping = new FieldMapping(resolvedFieldName.ToString(), null, mappingServerTime, currentEpoch);
-        if (IsSnapshotCurrent(currentEpoch, mappingServerTime))
-            _mappingCache.AddOrUpdate(field, notFoundMapping, (_, existing) =>
-                existing.Epoch > notFoundMapping.Epoch ? existing : notFoundMapping);
+        // A freshly reloaded mapping that still does not contain the field means the field probably does not
+        // exist at all (a typo or a query against a field that was never indexed). Back off so a flood of
+        // bogus field names cannot turn every query into a mapping fetch.
+        if (reloadedForMiss)
+            IncreaseUnmappedRefreshBackoff(snapshot.Version);
+        else if (lastFetchResult == MappingFetchResult.Throttled && snapshot.HasServerMapping && ShouldLogSuppressedReload())
+            _logger.LogWarning("Unable to resolve mapping for field {Field}. The loaded server mapping is {MappingAge} old and a reload was suppressed by the {RefreshInterval} unmapped field refresh throttle, so this field is being treated as unmapped", field,
+                _timeProvider.GetUtcNow().UtcDateTime - snapshot.CreatedUtc, new TimeSpan(GetUnmappedRefreshIntervalTicks()));
+
+        if (_logger.IsEnabled(LogLevel.Trace))
+            _logger.LogTrace("Mapping not found: {Field}", field);
+
+        var notFoundMapping = new FieldMapping(resolvedFieldName.ToString(), null, snapshot.CreatedUtc, snapshot.Version);
+        CacheFieldMapping(field, notFoundMapping, snapshot.Version);
 
         return notFoundMapping;
+    }
+
+    /// <summary>
+    /// Rate limits the suppressed reload warning so a flood of queries against non-existent fields cannot
+    /// flood the log. At most one warning is emitted per <see cref="MappingRefreshInterval"/>.
+    /// </summary>
+    private bool ShouldLogSuppressedReload()
+    {
+        if (!_logger.IsEnabled(LogLevel.Warning))
+            return false;
+
+        long last = Interlocked.Read(ref _lastSuppressedReloadWarningTimestamp);
+        if (last != 0 && _timeProvider.GetElapsedTime(last) < MappingRefreshInterval)
+            return false;
+
+        return Interlocked.CompareExchange(ref _lastSuppressedReloadWarningTimestamp, _timeProvider.GetTimestamp(), last) == last;
+    }
+
+    private string? ResolvePropertyName(PropertyName? key)
+    {
+        if (key?.Name is null)
+            return null;
+
+        return _inferrer is not null ? _inferrer.PropertyName(key) : key.Name;
+    }
+
+    private void CacheFieldMapping(string field, FieldMapping mapping, long snapshotVersion)
+    {
+        int maxCachedFields = MaxCachedFields;
+        if (maxCachedFields <= 0)
+            return;
+
+        // Do not publish a resolution that was made against a mapping which has already been replaced.
+        if (Snapshot.Version != snapshotVersion)
+            return;
+
+        if (Interlocked.Read(ref _cachedFieldCount) >= maxCachedFields && !_mappingCache.ContainsKey(field))
+        {
+            _logger.LogWarning("Field mapping cache exceeded {MaxCachedFields} entries and was cleared", maxCachedFields);
+            ClearCache();
+        }
+
+        if (_mappingCache.TryAdd(field, mapping))
+        {
+            Interlocked.Increment(ref _cachedFieldCount);
+            return;
+        }
+
+        _mappingCache.AddOrUpdate(field, mapping, (_, existing) => existing.Epoch > mapping.Epoch ? existing : mapping);
+    }
+
+    private void ClearCache()
+    {
+        _mappingCache.Clear();
+        Interlocked.Exchange(ref _cachedFieldCount, 0);
     }
 
     public FieldMapping? GetMapping(Field field, bool followAlias = false)
@@ -468,54 +600,66 @@ public class ElasticMappingResolver : IDisposable
         };
     }
 
-    private Properties? MergeProperties(Properties? codeProperties, Properties? serverProperties)
+    private Properties? InferCodeProperties(Properties? codeProperties)
     {
-        if (codeProperties is null && serverProperties is null)
+        if (codeProperties is null)
             return null;
 
-        Properties? mergedCodeProperties = null;
         // resolve code mapping property expressions using inferrer
-        if (codeProperties is not null)
+        var inferredProperties = new Properties();
+
+        foreach (var kvp in codeProperties)
         {
-            mergedCodeProperties = new Properties();
+            var propertyName = kvp.Key;
+            if (_inferrer is not null && (String.IsNullOrEmpty(kvp.Key.Name) || kvp.Value is FieldAliasProperty))
+                propertyName = _inferrer.PropertyName(kvp.Key) ?? kvp.Key;
 
-            foreach (var kvp in codeProperties)
-            {
-                var propertyName = kvp.Key;
-                if (_inferrer is not null && (String.IsNullOrEmpty(kvp.Key.Name) || kvp.Value is FieldAliasProperty))
-                    propertyName = _inferrer.PropertyName(kvp.Key) ?? kvp.Key;
-
-                mergedCodeProperties[propertyName] = kvp.Value;
-            }
-
-            if (_inferrer is not null)
-            {
-                // resolve field alias
-                foreach (var kvp in codeProperties)
-                {
-                    if (kvp.Value is not FieldAliasProperty aliasProperty)
-                        continue;
-
-                    var newAliasProperty = new FieldAliasProperty
-                    {
-                        Path = _inferrer!.Field(aliasProperty.Path!) ?? aliasProperty.Path,
-                    };
-                    CopyPropertyMetadata(aliasProperty, newAliasProperty);
-                    mergedCodeProperties[kvp.Key] = newAliasProperty;
-                }
-            }
+            inferredProperties[propertyName] = kvp.Value;
         }
 
-        // no need to merge
-        if (mergedCodeProperties is null || serverProperties is null)
-            return mergedCodeProperties ?? serverProperties;
+        if (_inferrer is null)
+            return inferredProperties;
 
-        Properties properties = new Properties();
+        // resolve field alias
+        foreach (var kvp in codeProperties)
+        {
+            if (kvp.Value is not FieldAliasProperty aliasProperty)
+                continue;
+
+            var newAliasProperty = new FieldAliasProperty
+            {
+                Path = _inferrer.Field(aliasProperty.Path!) ?? aliasProperty.Path,
+            };
+            CopyPropertyMetadata(aliasProperty, newAliasProperty);
+            inferredProperties[_inferrer.PropertyName(kvp.Key) ?? kvp.Key] = newAliasProperty;
+        }
+
+        return inferredProperties;
+    }
+
+    private Properties? MergeCodeAndServerProperties(Properties? codeProperties, Properties? serverProperties)
+    {
+        return MergeProperties(InferCodeProperties(codeProperties), serverProperties);
+    }
+
+    /// <remarks>
+    /// Merging mutates the sub-property collections of the server property objects, so the
+    /// <c>getMapping</c> callback must return a mapping instance the resolver can take ownership of
+    /// (a freshly deserialized <c>GetMapping</c> response, not a cached shared instance). Merging is done
+    /// exactly once per snapshot, so a single mapping instance is never merged concurrently.
+    /// </remarks>
+    private Properties? MergeProperties(Properties? inferredCodeProperties, Properties? serverProperties)
+    {
+        // no need to merge
+        if (inferredCodeProperties is null || serverProperties is null)
+            return inferredCodeProperties ?? serverProperties;
+
+        var properties = new Properties();
         foreach (var serverProperty in serverProperties)
         {
             var merged = serverProperty.Value;
 
-            if (mergedCodeProperties.TryGetProperty(serverProperty.Key, out var codeProperty))
+            if (inferredCodeProperties.TryGetProperty(serverProperty.Key, out var codeProperty))
             {
                 // Copy local metadata from code property to merged property
                 CopyPropertyMetadata(codeProperty, merged);
@@ -523,13 +667,15 @@ public class ElasticMappingResolver : IDisposable
                 switch (merged)
                 {
                     case ObjectProperty objectProperty:
-                        var codeObjectProperty = codeProperty as ObjectProperty;
                         objectProperty.Properties =
-                            MergeProperties(codeObjectProperty?.Properties, objectProperty.Properties);
+                            MergeCodeAndServerProperties((codeProperty as ObjectProperty)?.Properties, objectProperty.Properties);
+                        break;
+                    case NestedProperty nestedProperty:
+                        nestedProperty.Properties =
+                            MergeCodeAndServerProperties((codeProperty as NestedProperty)?.Properties, nestedProperty.Properties);
                         break;
                     case TextProperty textProperty:
-                        var codeTextProperty = codeProperty as TextProperty;
-                        textProperty.Fields = MergeProperties(codeTextProperty?.Fields, textProperty.Fields);
+                        textProperty.Fields = MergeCodeAndServerProperties((codeProperty as TextProperty)?.Fields, textProperty.Fields);
                         break;
                 }
             }
@@ -537,7 +683,7 @@ public class ElasticMappingResolver : IDisposable
             properties.Add(serverProperty.Key, merged);
         }
 
-        foreach (var codeProperty in mergedCodeProperties)
+        foreach (var codeProperty in inferredCodeProperties)
         {
             if (properties.TryGetProperty(codeProperty.Key, out _))
                 continue;
@@ -549,74 +695,176 @@ public class ElasticMappingResolver : IDisposable
     }
 
     private Func<TypeMapping?>? GetServerMappingFunc { get; set; }
-    private long _lastMappingUpdateTicks;
 
-    private bool IsSnapshotCurrent(long snapshotEpoch, DateTime? snapshotServerTime)
+    private MappingSnapshot CreateSnapshot(TypeMapping? serverMapping, bool fetched)
     {
-        if (Interlocked.Read(ref _refreshEpoch) != snapshotEpoch)
-            return false;
+        long version = Interlocked.Increment(ref _snapshotVersion);
 
-        long currentTicks = Interlocked.Read(ref _lastMappingUpdateTicks);
-        if (currentTicks == 0)
-            return true;
-
-        return snapshotServerTime.HasValue && snapshotServerTime.Value.Ticks >= currentTicks;
+        // Properties are merged lazily and exactly once per snapshot: merging walks (and mutates) the
+        // whole property tree, which is far too expensive to repeat for every field resolution.
+        return new MappingSnapshot(version, serverMapping is not null, fetched,
+            () => MergeProperties(_inferredCodeProperties.Value, serverMapping?.Properties),
+            _timeProvider.GetUtcNow().UtcDateTime);
     }
 
-    /// <returns>true if a new mapping was fetched and applied; false if throttled or unavailable.</returns>
-    private bool GetServerMapping()
+    private long GetUnmappedRefreshIntervalTicks()
     {
-        if (GetServerMappingFunc is null)
-            return false;
+        long baseTicks = Math.Max(UnmappedFieldRefreshInterval.Ticks, 0);
+        long maxTicks = Math.Max(MappingRefreshInterval.Ticks, baseTicks);
+        long backoffTicks = Interlocked.Read(ref _unmappedRefreshBackoffTicks);
 
-        long epochBeforeFetch;
-        lock (_mappingLock)
+        return Math.Min(Math.Max(baseTicks, backoffTicks), maxTicks);
+    }
+
+    private void IncreaseUnmappedRefreshBackoff()
+    {
+        long baseTicks = Math.Max(UnmappedFieldRefreshInterval.Ticks, 0);
+        long maxTicks = Math.Max(MappingRefreshInterval.Ticks, baseTicks);
+        long current = Interlocked.Read(ref _unmappedRefreshBackoffTicks);
+        if (current >= maxTicks)
+            return;
+
+        long next = Math.Min(Math.Max(current, baseTicks) * 2, maxTicks);
+        Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, next);
+    }
+
+    /// <summary>
+    /// Backs off at most once per mapping reload. Many concurrent lookups adopt the result of a single
+    /// reload, and without this guard one reload would ratchet the interval all the way to the ceiling.
+    /// </summary>
+    private void IncreaseUnmappedRefreshBackoff(long snapshotVersion)
+    {
+        long applied = Interlocked.Read(ref _backoffAppliedForVersion);
+        if (applied == snapshotVersion || Interlocked.CompareExchange(ref _backoffAppliedForVersion, snapshotVersion, applied) != applied)
+            return;
+
+        IncreaseUnmappedRefreshBackoff();
+    }
+
+    private bool IsReloadAllowed(bool unmappedField)
+    {
+        if (unmappedField)
         {
-            long lastTicks = Interlocked.Read(ref _lastMappingUpdateTicks);
-            if (lastTicks > 0 && new DateTime(lastTicks, DateTimeKind.Utc) > _timeProvider.GetUtcNow().UtcDateTime.SubtractMinutes(1))
-                return false;
-            epochBeforeFetch = Interlocked.Read(ref _refreshEpoch);
+            long lastUnmappedFetch = Interlocked.Read(ref _lastUnmappedFetchTimestamp);
+            return lastUnmappedFetch == 0 || _timeProvider.GetElapsedTime(lastUnmappedFetch) >= new TimeSpan(GetUnmappedRefreshIntervalTicks());
         }
 
-        if (!_fetchSemaphore.Wait(0))
-            return false;
+        long lastFetch = Interlocked.Read(ref _lastFetchTimestamp);
+        return lastFetch == 0 || _timeProvider.GetElapsedTime(lastFetch) >= MappingRefreshInterval;
+    }
+
+    private void RecordReloadAttempt(bool unmappedField)
+    {
+        long timestamp = _timeProvider.GetTimestamp();
+        Interlocked.Exchange(ref _lastFetchTimestamp, timestamp);
+        if (unmappedField)
+            Interlocked.Exchange(ref _lastUnmappedFetchTimestamp, timestamp);
+    }
+
+    /// <summary>
+    /// Reloads the server mapping, publishing a new snapshot when it succeeds.
+    /// </summary>
+    /// <param name="unmappedField">
+    /// True when the reload was triggered by a field that could not be resolved. Miss driven reloads use
+    /// their own (much shorter, self backing off) throttle so that a cold start fetch cannot suppress them.
+    /// </param>
+    private MappingFetchResult ReloadServerMapping(bool unmappedField)
+    {
+        var getServerMapping = GetServerMappingFunc;
+        if (getServerMapping is null || _disposed)
+            return MappingFetchResult.Skipped;
+
+        if (!IsReloadAllowed(unmappedField))
+            return MappingFetchResult.Throttled;
+
+        long versionBeforeWait = Snapshot.Version;
+
+        bool acquired;
+        try
+        {
+            // Join an in-flight fetch instead of silently continuing with a stale mapping. The wait is
+            // bounded because the fetch callback is user supplied and does blocking network I/O.
+            acquired = _fetchSemaphore.Wait(_fetchJoinTimeout);
+        }
+        catch (ObjectDisposedException)
+        {
+            return MappingFetchResult.Skipped;
+        }
+
+        if (!acquired)
+        {
+            _logger.LogWarning("Timed out after {Timeout} joining an in-flight server mapping fetch, continuing with the loaded mapping", _fetchJoinTimeout);
+            return MappingFetchResult.Throttled;
+        }
 
         try
         {
-            lock (_mappingLock)
-            {
-                long lastTicks = Interlocked.Read(ref _lastMappingUpdateTicks);
-                if (lastTicks > 0 && new DateTime(lastTicks, DateTimeKind.Utc) > _timeProvider.GetUtcNow().UtcDateTime.SubtractMinutes(1))
-                    return false;
-            }
+            // Another caller finished a fetch while we waited, so adopt its result rather than refetching.
+            // A snapshot that has not been fetched means RefreshMapping() ran while we waited, in which case
+            // we still have to do the fetch ourselves.
+            var snapshotAfterWait = Snapshot;
+            if (snapshotAfterWait.Version != versionBeforeWait && snapshotAfterWait.Fetched)
+                return MappingFetchResult.Updated;
+
+            if (!IsReloadAllowed(unmappedField))
+                return MappingFetchResult.Throttled;
+
+            long refreshVersion = Interlocked.Read(ref _refreshVersion);
 
             TypeMapping? newMapping;
             try
             {
-                newMapping = GetServerMappingFunc();
+                newMapping = getServerMapping();
             }
             catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
             {
+                // Record the attempt so a failing cluster is not retried for every unresolved field.
+                RecordReloadAttempt(unmappedField);
+                if (unmappedField)
+                    IncreaseUnmappedRefreshBackoff();
+
                 _logger.LogError(ex, "Error getting server mapping: {Message}", ex.Message);
-                return false;
+                return MappingFetchResult.Failed;
             }
 
-            lock (_mappingLock)
+            var current = Snapshot;
+            if (newMapping is null && current.Fetched && !current.HasServerMapping)
             {
-                if (Interlocked.Read(ref _refreshEpoch) != epochBeforeFetch)
-                    return false;
+                // Nothing changed, so keep the current snapshot (and its resolved field cache) intact.
+                RecordReloadAttempt(unmappedField);
+                if (unmappedField)
+                    IncreaseUnmappedRefreshBackoff();
 
-                _serverMapping = newMapping;
-                Interlocked.Exchange(ref _lastMappingUpdateTicks, _timeProvider.GetUtcNow().UtcDateTime.Ticks);
-                _mappingCache.Clear();
+                return MappingFetchResult.Failed;
+            }
+
+            lock (_publishLock)
+            {
+                // A RefreshMapping() during the fetch means this result may predate the schema change the
+                // caller knows about, so discard it and let the next resolution fetch again.
+                if (Interlocked.Read(ref _refreshVersion) != refreshVersion)
+                    return MappingFetchResult.Failed;
+
+                // Clear before publishing so resolutions made against the new snapshot are not discarded.
+                ClearCache();
+                Volatile.Write(ref _snapshot, CreateSnapshot(newMapping, fetched: true));
+                RecordReloadAttempt(unmappedField);
             }
 
             _logger.LogInformation("Got server mapping");
-            return true;
+
+            return MappingFetchResult.Updated;
         }
         finally
         {
-            _fetchSemaphore.Release();
+            try
+            {
+                _fetchSemaphore.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // the resolver was disposed while the fetch was in flight
+            }
         }
     }
 
@@ -744,7 +992,58 @@ public class ElasticMappingResolver : IDisposable
 
     public void Dispose()
     {
+        if (_disposed)
+            return;
+
+        _disposed = true;
         _fetchSemaphore.Dispose();
+    }
+
+    /// <summary>
+    /// An immutable point-in-time view of the mapping. Published by reference swap so that readers never
+    /// need a lock and always observe a consistent mapping plus version pair.
+    /// </summary>
+    private sealed class MappingSnapshot
+    {
+        private readonly Lazy<Properties?> _properties;
+
+        public MappingSnapshot(long version, bool hasServerMapping, bool fetched, Func<Properties?> propertiesFactory, DateTime createdUtc)
+        {
+            Version = version;
+            HasServerMapping = hasServerMapping;
+            Fetched = fetched;
+            CreatedUtc = createdUtc;
+            _properties = new Lazy<Properties?>(propertiesFactory, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        /// <summary>Monotonically increasing version used to detect field cache entries from older mappings.</summary>
+        public long Version { get; }
+
+        /// <summary>Whether the server returned a mapping (as opposed to no mapping being available).</summary>
+        public bool HasServerMapping { get; }
+
+        /// <summary>Whether a server mapping fetch has been attempted for this snapshot.</summary>
+        public bool Fetched { get; }
+
+        public DateTime CreatedUtc { get; }
+
+        /// <summary>Code and server properties merged once, on first use.</summary>
+        public Properties? Properties => _properties.Value;
+    }
+
+    private enum MappingFetchResult
+    {
+        /// <summary>No fetch was attempted (no fetch function, disposed, or already reloaded).</summary>
+        Skipped,
+
+        /// <summary>A fetch was warranted but suppressed by a refresh throttle.</summary>
+        Throttled,
+
+        /// <summary>The server mapping was reloaded and a new snapshot published.</summary>
+        Updated,
+
+        /// <summary>The fetch was attempted but did not produce a usable mapping.</summary>
+        Failed
     }
 }
 
@@ -762,6 +1061,10 @@ public class FieldMapping
     public string FullPath { get; private set; }
     public IProperty? Property { get; private set; }
     public DateTime Date { get; private set; } = DateTime.UtcNow;
+
+    /// <summary>When the mapping this resolution was made against was loaded.</summary>
     internal DateTime? ServerMapTime { get; private set; }
+
+    /// <summary>Version of the mapping snapshot this resolution was made against.</summary>
     internal long Epoch { get; private set; }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -218,7 +218,7 @@ public class ElasticMappingResolver : IDisposable
 
         if (!hadFetchedSnapshot)
         {
-            loadResult = await _cache.LoadInitialAsync(snapshot, cancellationToken).ConfigureAwait(false);
+            loadResult = await _cache.LoadInitialAsync(snapshot, cancellationToken).AnyContext();
             snapshot = _cache.Current;
         }
 
@@ -226,7 +226,7 @@ public class ElasticMappingResolver : IDisposable
 
         if (!resolved.Found && hadFetchedSnapshot)
         {
-            loadResult = await _cache.ReloadForMissingFieldAsync(snapshot, cancellationToken).ConfigureAwait(false);
+            loadResult = await _cache.ReloadForMissingFieldAsync(snapshot, cancellationToken).AnyContext();
             if (loadResult == MappingRefreshResult.Updated)
             {
                 snapshot = _cache.Current;
@@ -241,7 +241,7 @@ public class ElasticMappingResolver : IDisposable
             if (_logger.IsEnabled(LogLevel.Trace))
                 _logger.LogTrace("Resolved mapping: {Field}={FieldPath}:{FieldType}", field, resolved.FullPath, resolved.Property?.Type);
 
-            return await FollowAliasAsync(resolved, followAlias, cancellationToken).ConfigureAwait(false);
+            return await FollowAliasAsync(resolved, followAlias, cancellationToken).AnyContext();
         }
 
         LogUnresolvedField(field, loadResult, snapshot);
@@ -369,12 +369,12 @@ public class ElasticMappingResolver : IDisposable
 
     public async ValueTask<IProperty?> GetMappingPropertyAsync(string? field, bool followAlias = false, CancellationToken cancellationToken = default)
     {
-        return (await GetMappingAsync(field, followAlias, cancellationToken).ConfigureAwait(false))?.Property;
+        return (await GetMappingAsync(field, followAlias, cancellationToken).AnyContext())?.Property;
     }
 
     public async ValueTask<IProperty?> GetMappingPropertyAsync(Field field, bool followAlias = false, CancellationToken cancellationToken = default)
     {
-        return (await GetMappingAsync(field, followAlias, cancellationToken).ConfigureAwait(false))?.Property;
+        return (await GetMappingAsync(field, followAlias, cancellationToken).AnyContext())?.Property;
     }
 
     public string? GetResolvedField(string? field)
@@ -393,7 +393,7 @@ public class ElasticMappingResolver : IDisposable
 
     public async ValueTask<string?> GetResolvedFieldAsync(string? field, CancellationToken cancellationToken = default)
     {
-        var result = await GetMappingAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false);
+        var result = await GetMappingAsync(field, followAlias: true, cancellationToken).AnyContext();
         return result?.FullPath ?? field;
     }
 
@@ -402,7 +402,7 @@ public class ElasticMappingResolver : IDisposable
         if (_inferrer is null)
             throw new InvalidOperationException("Unable to resolve Field without inferrer");
 
-        return (await GetResolvedFieldAsync(_inferrer.Field(field), cancellationToken).ConfigureAwait(false))!;
+        return (await GetResolvedFieldAsync(_inferrer.Field(field), cancellationToken).AnyContext())!;
     }
 
     public string? GetSortFieldName(string? field)
@@ -422,8 +422,8 @@ public class ElasticMappingResolver : IDisposable
 
     public async ValueTask<string> GetSortFieldNameAsync(Field field, CancellationToken cancellationToken = default)
     {
-        string resolved = await GetResolvedFieldAsync(field, cancellationToken).ConfigureAwait(false);
-        return (await GetNonAnalyzedFieldNameAsync(resolved, ElasticMapping.SortFieldName, cancellationToken).ConfigureAwait(false))!;
+        string resolved = await GetResolvedFieldAsync(field, cancellationToken).AnyContext();
+        return (await GetNonAnalyzedFieldNameAsync(resolved, ElasticMapping.SortFieldName, cancellationToken).AnyContext())!;
     }
 
     public string? GetAggregationsFieldName(string? field)
@@ -443,7 +443,7 @@ public class ElasticMappingResolver : IDisposable
 
     public async ValueTask<string> GetAggregationsFieldNameAsync(Field field, CancellationToken cancellationToken = default)
     {
-        return (await GetNonAnalyzedFieldNameAsync(field, ElasticMapping.KeywordFieldName, cancellationToken).ConfigureAwait(false))!;
+        return (await GetNonAnalyzedFieldNameAsync(field, ElasticMapping.KeywordFieldName, cancellationToken).AnyContext())!;
     }
 
     public string GetNonAnalyzedFieldName(Field field, string? preferredSubField = null)
@@ -454,8 +454,8 @@ public class ElasticMappingResolver : IDisposable
     public async ValueTask<string> GetNonAnalyzedFieldNameAsync(Field field, string? preferredSubField = null,
         CancellationToken cancellationToken = default)
     {
-        string resolved = await GetResolvedFieldAsync(field, cancellationToken).ConfigureAwait(false);
-        return (await GetNonAnalyzedFieldNameAsync(resolved, preferredSubField, cancellationToken).ConfigureAwait(false))!;
+        string resolved = await GetResolvedFieldAsync(field, cancellationToken).AnyContext();
+        return (await GetNonAnalyzedFieldNameAsync(resolved, preferredSubField, cancellationToken).AnyContext())!;
     }
 
     public string? GetNonAnalyzedFieldName(string? field, string? preferredSubField = null)
@@ -473,7 +473,7 @@ public class ElasticMappingResolver : IDisposable
         if (String.IsNullOrEmpty(field))
             return field;
 
-        var mapping = await GetMappingAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false);
+        var mapping = await GetMappingAsync(field, followAlias: true, cancellationToken).AnyContext();
         return GetNonAnalyzedFieldName(field, mapping, preferredSubField);
     }
 
@@ -512,7 +512,7 @@ public class ElasticMappingResolver : IDisposable
         if (String.IsNullOrEmpty(field))
             return true;
 
-        var property = await GetMappingAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false);
+        var property = await GetMappingAsync(field, followAlias: true, cancellationToken).AnyContext();
         return property is not null && property.Found && IsPropertyAnalyzed(property.Property!);
     }
 
@@ -535,7 +535,7 @@ public class ElasticMappingResolver : IDisposable
     public async ValueTask<bool> IsNestedPropertyTypeAsync(string? field, CancellationToken cancellationToken = default)
     {
         return !String.IsNullOrEmpty(field)
-            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false) is NestedProperty;
+            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).AnyContext() is NestedProperty;
     }
 
     public bool IsGeoPropertyType(string? field)
@@ -549,7 +549,7 @@ public class ElasticMappingResolver : IDisposable
     public async ValueTask<bool> IsGeoPropertyTypeAsync(string? field, CancellationToken cancellationToken = default)
     {
         return !String.IsNullOrEmpty(field)
-            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false) is GeoPointProperty;
+            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).AnyContext() is GeoPointProperty;
     }
 
     public bool IsNumericPropertyType(string? field)
@@ -565,7 +565,7 @@ public class ElasticMappingResolver : IDisposable
         if (String.IsNullOrEmpty(field))
             return false;
 
-        var property = await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false);
+        var property = await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).AnyContext();
         return IsNumericProperty(property);
     }
 
@@ -593,7 +593,7 @@ public class ElasticMappingResolver : IDisposable
     public async ValueTask<bool> IsBooleanPropertyTypeAsync(string? field, CancellationToken cancellationToken = default)
     {
         return !String.IsNullOrEmpty(field)
-            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false) is BooleanProperty;
+            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).AnyContext() is BooleanProperty;
     }
 
     public bool IsDatePropertyType(string? field)
@@ -607,7 +607,7 @@ public class ElasticMappingResolver : IDisposable
     public async ValueTask<bool> IsDatePropertyTypeAsync(string? field, CancellationToken cancellationToken = default)
     {
         return !String.IsNullOrEmpty(field)
-            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false) is DateProperty or DateNanosProperty;
+            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).AnyContext() is DateProperty or DateNanosProperty;
     }
 
     public FieldType GetFieldType(string? field)
@@ -623,7 +623,7 @@ public class ElasticMappingResolver : IDisposable
         if (String.IsNullOrWhiteSpace(field))
             return FieldType.None;
 
-        var property = await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false);
+        var property = await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).AnyContext();
         return GetFieldType(property);
     }
 
@@ -888,7 +888,7 @@ public class ElasticMappingResolver : IDisposable
     private static async Task<TypeMapping?> GetServerMappingAsync(ElasticsearchClient client, GetMappingRequest request, ILogger logger,
         CancellationToken cancellationToken)
     {
-        var response = await client.Indices.GetMappingAsync(request, cancellationToken).ConfigureAwait(false);
+        var response = await client.Indices.GetMappingAsync(request, cancellationToken).AnyContext();
         logger.LogTrace("GetMapping: {Request}", response.GetRequest(false, true));
         return response.Mappings.Values.FirstOrDefault()?.Mappings;
     }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -700,6 +700,11 @@ public class ElasticMappingResolver : IDisposable
 
     public void Dispose()
     {
+        // The shared null instance is process wide; disposing it must not silently disable mapping loads
+        // for every other consumer.
+        if (ReferenceEquals(this, NullInstance))
+            return;
+
         _cache.Dispose();
     }
 

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -119,7 +119,8 @@ public class ElasticMappingResolver : IDisposable
     /// <remarks>
     /// Unresolved fields automatically reload the server mapping at most once per
     /// <see cref="UnmappedFieldRefreshInterval"/>. This method bypasses that throttle and discards the
-    /// current mapping snapshot so the next resolution fetches it again.
+    /// current mapping snapshot so the next resolution fetches it again. An in-flight load is superseded;
+    /// its result cannot be published, and its physical callback may briefly overlap the replacement fetch.
     /// </remarks>
     public void RefreshMapping()
     {
@@ -274,6 +275,7 @@ public class ElasticMappingResolver : IDisposable
         var properties = snapshot.Properties;
         int start = 0;
         StringBuilder? resolvedName = null;
+        List<string>? nestedPathChain = null;
         MergedNode? node = null;
 
         while (true)
@@ -288,7 +290,7 @@ public class ElasticMappingResolver : IDisposable
                 if (resolvedName is null)
                     return new FieldMapping(remainder, null);
 
-                return new FieldMapping(resolvedName.Append('.').Append(remainder).ToString(), null);
+                return new FieldMapping(resolvedName.Append('.').Append(remainder).ToString(), null, null, nestedPathChain);
             }
 
             node = matched;
@@ -298,8 +300,14 @@ public class ElasticMappingResolver : IDisposable
             else
                 resolvedName.Append('.').Append(matched.Name);
 
+            if (matched.Property is NestedProperty)
+            {
+                nestedPathChain ??= [];
+                nestedPathChain.Add(resolvedName.ToString());
+            }
+
             if (separator < 0)
-                return new FieldMapping(resolvedName.ToString(), node.Property, node.Children);
+                return new FieldMapping(resolvedName.ToString(), node.Property, node.Children, nestedPathChain);
 
             properties = matched.Children;
             start = separator + 1;
@@ -477,7 +485,7 @@ public class ElasticMappingResolver : IDisposable
         return GetNonAnalyzedFieldName(field, mapping, preferredSubField);
     }
 
-    private string? GetNonAnalyzedFieldName(string? field, FieldMapping? mapping, string? preferredSubField)
+    internal string? GetNonAnalyzedFieldName(string? field, FieldMapping? mapping, string? preferredSubField)
     {
         if (mapping?.Property is null || !IsPropertyAnalyzed(mapping.Property))
             return field;
@@ -627,7 +635,7 @@ public class ElasticMappingResolver : IDisposable
         return GetFieldType(property);
     }
 
-    private static FieldType GetFieldType(IProperty? property)
+    internal static FieldType GetFieldType(IProperty? property)
     {
         if (property?.Type is null)
             return FieldType.None;

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -120,6 +120,22 @@ public class ElasticMappingResolver : IDisposable
     }
 
     /// <summary>
+    /// Optionally identifies a server mapping revision so automatic reloads of the same revision can reuse
+    /// the merged mapping and resolved fields. Null or empty revisions disable reuse for that load.
+    /// </summary>
+    /// <remarks>
+    /// Configure before sharing the resolver. The revision must identify the complete mapping, including
+    /// dynamically added fields and the concrete index identity. A schema deployment version alone is not
+    /// sufficient. The callback must be cheap, must not mutate the mapping, and must not call this resolver.
+    /// Explicit <see cref="RefreshMapping"/> always discards the cached mapping regardless of its revision.
+    /// </remarks>
+    public Func<TypeMapping, string?>? ServerMappingRevisionResolver
+    {
+        get => _cache.ServerMappingRevisionResolver;
+        set => _cache.ServerMappingRevisionResolver = value;
+    }
+
+    /// <summary>
     /// Clears the cached mapping, forcing a fresh fetch from the server on the next access.
     /// </summary>
     /// <remarks>

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -16,14 +16,15 @@ namespace Foundatio.Parsers.ElasticQueries;
 
 public class ElasticMappingResolver : IDisposable
 {
+    private static readonly TimeSpan _suppressedRefreshWarningInterval = TimeSpan.FromMinutes(1);
+
     private readonly TypeMapping? _codeMapping;
-    private readonly Lazy<Properties?> _inferredCodeProperties;
     private readonly Inferrer? _inferrer;
     private readonly MappingCache _cache;
     private readonly ConditionalWeakTable<IProperty, ConcurrentDictionary<string, object>> _propertyMetadata = new();
-    private readonly ConditionalWeakTable<IProperty, Properties> _mergedChildProperties = new();
     private readonly TimeProvider _timeProvider;
     private readonly ILogger _logger;
+    private long _lastSuppressedRefreshWarningTimestamp;
 
     public static readonly ElasticMappingResolver NullInstance = new(() => null);
 
@@ -32,8 +33,7 @@ public class ElasticMappingResolver : IDisposable
         _inferrer = inferrer;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _logger = logger ?? NullLogger.Instance;
-        _inferredCodeProperties = new Lazy<Properties?>(() => InferCodeProperties(_codeMapping?.Properties), LazyThreadSafetyMode.ExecutionAndPublication);
-        _cache = new MappingCache(getMapping, serverMapping => MergeProperties(_inferredCodeProperties.Value, serverMapping?.Properties), _timeProvider, _logger);
+        _cache = new MappingCache(getMapping, BuildMergedProperties, _timeProvider, _logger);
     }
 
     public ElasticMappingResolver(TypeMapping codeMapping, Inferrer inferrer, Func<TypeMapping?> getMapping, TimeProvider? timeProvider = null, ILogger? logger = null)
@@ -43,39 +43,22 @@ public class ElasticMappingResolver : IDisposable
     }
 
     /// <summary>
-    /// Maximum age of the loaded server mapping before an ordinary resolution will reload it. This also acts
-    /// as the ceiling when backing off repeated reloads triggered by fields that cannot be resolved.
-    /// </summary>
-    /// <exception cref="ArgumentOutOfRangeException">The value is negative.</exception>
-    public TimeSpan MappingRefreshInterval
-    {
-        get => _cache.RefreshInterval;
-        set
-        {
-            ArgumentOutOfRangeException.ThrowIfLessThan(value, TimeSpan.Zero);
-            _cache.RefreshInterval = value;
-        }
-    }
-
-    /// <summary>
     /// Minimum interval between server mapping reloads that are triggered by a field which could not be
     /// resolved from the loaded mapping. A resolution failure is the strongest available signal that the
     /// index mapping changed (fields created by dynamic templates only exist after the first document that
-    /// uses them is indexed), so this is intentionally much shorter than <see cref="MappingRefreshInterval"/>.
-    /// Reloads that do not resolve the field back off exponentially up to <see cref="MappingRefreshInterval"/>.
+    /// uses them is indexed).
     /// </summary>
     /// <remarks>
     /// A reload walks and merges the whole property tree, which on a large mapping costs several milliseconds
     /// and allocates megabytes, so this trades staleness against that cost rather than against network time.
-    /// Set to <see cref="TimeSpan.Zero"/> to always reload on an unresolved field.
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">The value is negative.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The value is negative or zero.</exception>
     public TimeSpan UnmappedFieldRefreshInterval
     {
         get => _cache.UnmappedFieldRefreshInterval;
         set
         {
-            ArgumentOutOfRangeException.ThrowIfLessThan(value, TimeSpan.Zero);
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, TimeSpan.Zero);
             _cache.UnmappedFieldRefreshInterval = value;
         }
     }
@@ -86,78 +69,35 @@ public class ElasticMappingResolver : IDisposable
     /// for that reload instead of issuing their own.
     /// </summary>
     /// <remarks>
-    /// Waiting is never more expensive than performing the reload, so this must comfortably exceed the
-    /// latency of the configured mapping fetch; giving up early resolves the field as unmapped even though a
-    /// reload that could have resolved it was already running. It is bounded rather than infinite so an
-    /// unresponsive cluster cannot pin request threads. Use <see cref="Timeout.InfiniteTimeSpan"/> to wait
-    /// indefinitely, which is safe when the fetch callback has its own timeout (the Elasticsearch client
-    /// applies one by default).
+    /// This must comfortably exceed the latency of the configured mapping fetch; giving up early resolves
+    /// the field as unmapped even though a reload that could have resolved it was already running. It is
+    /// bounded so an unresponsive cluster cannot pin request threads indefinitely. The mapping callback must
+    /// enforce a shorter timeout and must not call back into this resolver.
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// The value is negative or zero and is not <see cref="Timeout.InfiniteTimeSpan"/>.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">The value is negative or zero, or exceeds the maximum wait a semaphore accepts.</exception>
     public TimeSpan MappingRefreshWaitTimeout
     {
         get => _cache.RefreshWaitTimeout;
         set
         {
-            if (value != Timeout.InfiniteTimeSpan)
-                ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, TimeSpan.Zero);
-
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, TimeSpan.Zero);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, TimeSpan.FromMilliseconds(Int32.MaxValue));
             _cache.RefreshWaitTimeout = value;
         }
     }
 
     /// <summary>
-    /// Approximate upper bound on the number of resolved field mappings held in memory. Field names come from
-    /// user supplied queries, so this bounds memory usage when queries reference many distinct (often
-    /// non-existent) fields.
-    /// </summary>
-    /// <remarks>
-    /// When the bound is reached, cached misses are evicted first so that an abusive caller sending many
-    /// unknown field names cannot displace the resolutions real queries depend on. Set to zero or less to
-    /// disable caching entirely.
-    /// </remarks>
-    public int MaxCachedFields
-    {
-        get => _cache.MaxCachedFields;
-        set => _cache.MaxCachedFields = value;
-    }
-
-    /// <summary>
-    /// Approximate number of field names currently held in the resolved mapping cache.
-    /// </summary>
-    public long CachedFieldCount => _cache.CachedFieldCount;
-
-
-    /// <summary>
     /// Clears the cached mapping, forcing a fresh fetch from the server on the next access.
     /// </summary>
     /// <remarks>
-    /// Server mappings are reloaded automatically: at most once per <see cref="MappingRefreshInterval"/>
-    /// for ordinary resolutions and at most once per <see cref="UnmappedFieldRefreshInterval"/> when a
-    /// field cannot be resolved. This method bypasses both throttles and discards the entire field cache,
-    /// which is expensive on a large mapping. Prefer <see cref="InvalidateFieldMapping"/> when only a
-    /// specific field is known to have changed.
+    /// Unresolved fields automatically reload the server mapping at most once per
+    /// <see cref="UnmappedFieldRefreshInterval"/>. This method bypasses that throttle and discards the
+    /// current mapping snapshot so the next resolution fetches it again.
     /// </remarks>
     public void RefreshMapping()
     {
         _cache.Reset();
         _logger.LogInformation("Mapping refresh triggered");
-    }
-
-    /// <summary>
-    /// Drops the cached resolution for a single field and allows the next resolution of any unmapped field
-    /// to reload the server mapping. Use this when a specific field is known to have just been created,
-    /// instead of discarding the whole cache with <see cref="RefreshMapping"/>.
-    /// </summary>
-    public void InvalidateFieldMapping(string? field)
-    {
-        if (String.IsNullOrWhiteSpace(field))
-            return;
-
-        _cache.InvalidateField(field!);
-        _logger.LogTrace("Invalidated field mapping: {Field}", field);
     }
 
     public FieldMapping? GetMapping(string? field, bool followAlias = false)
@@ -170,185 +110,138 @@ public class ElasticMappingResolver : IDisposable
 
         var snapshot = _cache.Current;
 
-        if (_cache.TryGetField(field!, snapshot, out var cached))
+        if (snapshot.TryGetField(field!, out var cached))
         {
-            if (cached.Found)
-            {
-                if (followAlias && cached.Property is FieldAliasProperty cachedAlias)
-                {
-                    if (_logger.IsEnabled(LogLevel.Trace))
-                        _logger.LogTrace("Cached alias mapping: {Field}={FieldPath}:{FieldType}", field, cached.FullPath, cached.Property.Type);
+            if (_logger.IsEnabled(LogLevel.Trace))
+                _logger.LogTrace("Cached mapping: {Field}={FieldPath}:{FieldType}", field, cached.FullPath, cached.Property?.Type);
 
-                    return GetMapping(cachedAlias.Path?.Name);
-                }
-
-                if (_logger.IsEnabled(LogLevel.Trace))
-                    _logger.LogTrace("Cached mapping: {Field}={FieldPath}:{FieldType}", field, cached.FullPath, cached.Property?.Type);
-
-                return cached;
-            }
-
-            // A cached miss is the strongest available signal that the server mapping may have changed,
-            // so attempt a rate limited reload before trusting it.
-            if (_cache.Refresh(triggeredByUnmappedField: true) != MappingRefreshResult.Updated)
-            {
-                if (_logger.IsEnabled(LogLevel.Trace))
-                    _logger.LogTrace("Cached mapping (not found): {Field}=<null>", field);
-
-                return cached;
-            }
-
-            return ResolveMapping(field!, followAlias, _cache.Current, reloadedForUnmappedField: true);
+            return FollowAlias(cached, followAlias);
         }
 
-        return ResolveMapping(field!, followAlias, snapshot, reloadedForUnmappedField: false);
+        return ResolveMapping(field!, followAlias, snapshot);
     }
 
-    private FieldMapping ResolveMapping(string field, bool followAlias, MappingSnapshot snapshot, bool reloadedForUnmappedField)
+    private FieldMapping? ResolveMapping(string field, bool followAlias, MappingSnapshot snapshot)
     {
-        var lastRefreshResult = MappingRefreshResult.Skipped;
-        bool reloaded = reloadedForUnmappedField;
-        bool reloadedForMiss = reloadedForUnmappedField;
+        var loadResult = MappingRefreshResult.Unavailable;
 
-        // Load the server mapping the first time one is needed. This deliberately does not arm the
-        // unmapped field throttle: a cold start fetch must never suppress the first miss driven reload,
-        // otherwise fields created after startup resolve as unmapped until the throttle expires.
-        if (!snapshot.Fetched && !reloaded)
+        if (!snapshot.Fetched)
         {
-            lastRefreshResult = _cache.Refresh(triggeredByUnmappedField: false);
-            if (lastRefreshResult == MappingRefreshResult.Updated)
+            loadResult = _cache.LoadInitial(snapshot);
+            snapshot = _cache.Current;
+        }
+
+        var resolved = Resolve(field, snapshot);
+
+        // The field is unknown to the loaded mapping, which is the strongest available signal that the mapping
+        // changed, so reload once and resolve again against the new one.
+        if (!resolved.Found)
+        {
+            loadResult = _cache.ReloadForMissingField(snapshot);
+            if (loadResult == MappingRefreshResult.Updated)
             {
                 snapshot = _cache.Current;
-                reloaded = true;
+                resolved = Resolve(field, snapshot);
             }
         }
 
-        string[] fieldParts = field.Split('.');
-        var resolvedFieldName = new StringBuilder();
-        var currentProperties = snapshot.Properties;
+        snapshot.CacheField(resolved);
 
-        for (int depth = 0; depth < fieldParts.Length; depth++)
+        if (resolved.Found)
         {
-            string fieldPart = fieldParts[depth];
-            IProperty? fieldMapping = null;
-            string? resolvedName = null;
+            if (_logger.IsEnabled(LogLevel.Trace))
+                _logger.LogTrace("Resolved mapping: {Field}={FieldPath}:{FieldType}", field, resolved.FullPath, resolved.Property?.Type);
 
-            if (currentProperties is not null && currentProperties.TryGetProperty(fieldPart, out fieldMapping))
-            {
-                // Properties is keyed by property name, so an exact hit means the key name is the field part.
-                resolvedName = fieldPart;
-            }
-            else
-            {
-                fieldMapping = null;
-
-                // check to see if there is a name match by iterating through the dictionary keys
-                if (currentProperties is not null)
-                {
-                    foreach (var kvp in (IDictionary<PropertyName, IProperty>)currentProperties)
-                    {
-                        string? propertyName = ResolvePropertyName(kvp.Key);
-                        if (propertyName is not null && propertyName.Equals(fieldPart, StringComparison.OrdinalIgnoreCase))
-                        {
-                            fieldMapping = kvp.Value;
-                            resolvedName = propertyName;
-                            break;
-                        }
-                    }
-                }
-
-                // The field is unknown to the loaded mapping: reload once in case it was created after the
-                // mapping was loaded, then start over from the top against the new mapping.
-                if (fieldMapping is null && !reloaded)
-                {
-                    lastRefreshResult = _cache.Refresh(triggeredByUnmappedField: true);
-                    if (lastRefreshResult == MappingRefreshResult.Updated)
-                    {
-                        reloaded = true;
-                        reloadedForMiss = true;
-                        depth = -1;
-                        resolvedFieldName.Clear();
-                        snapshot = _cache.Current;
-                        currentProperties = snapshot.Properties;
-                        continue;
-                    }
-                }
-
-                if (fieldMapping is null)
-                {
-                    if (depth > 0)
-                        resolvedFieldName.Append('.');
-                    resolvedFieldName.Append(fieldPart);
-
-                    // mapping is not fully resolved, append the rest of the parts unmodified and break
-                    for (int i = depth + 1; i < fieldParts.Length; i++)
-                    {
-                        resolvedFieldName.Append('.');
-                        resolvedFieldName.Append(fieldParts[i]);
-                    }
-
-                    break;
-                }
-            }
-
-            if (depth > 0)
-                resolvedFieldName.Append('.');
-            resolvedFieldName.Append(resolvedName ?? fieldPart);
-
-            if (depth == fieldParts.Length - 1)
-            {
-                var resolvedMapping = new FieldMapping(resolvedFieldName.ToString(), fieldMapping, snapshot.CreatedUtc, snapshot.Version);
-                _cache.CacheField(field, resolvedMapping, snapshot.Version);
-
-                // A miss driven reload that resolved the field is proof the mapping really had changed:
-                // return to the fast base interval so the next schema change is picked up quickly.
-                if (reloadedForMiss)
-                    _cache.ResetUnmappedRefreshBackoff();
-
-                if (_logger.IsEnabled(LogLevel.Trace))
-                    _logger.LogTrace("Resolved mapping: {Field}={FieldPath}:{FieldType}", field, resolvedMapping.FullPath, resolvedMapping.Property?.Type);
-
-                if (followAlias && resolvedMapping.Property is FieldAliasProperty fieldAlias)
-                    return GetMapping(fieldAlias.Path?.Name) ?? resolvedMapping;
-
-                return resolvedMapping;
-            }
-
-            currentProperties = GetChildProperties(fieldMapping);
-
-            if (currentProperties is null)
-                break;
+            return FollowAlias(resolved, followAlias);
         }
 
-        // A freshly reloaded mapping that still does not contain the field means the field probably does not
-        // exist at all (a typo or a query against a field that was never indexed). Back off so a flood of
-        // bogus field names cannot turn every query into a mapping fetch.
-        if (reloadedForMiss)
-            _cache.RecordUnresolvedAfterRefresh(snapshot.Version);
-        else if (lastRefreshResult == MappingRefreshResult.WaitTimedOut && _cache.ShouldLogSuppressedRefresh())
-            _logger.LogWarning("Unable to resolve mapping for field {Field}. A server mapping reload was already in flight but did not complete within {WaitTimeout}, so this field is being treated as unmapped. Increase {Property} if the mapping fetch is expected to take longer than this", field,
-                MappingRefreshWaitTimeout, nameof(MappingRefreshWaitTimeout));
-        else if (lastRefreshResult == MappingRefreshResult.Throttled && snapshot.HasServerMapping && _cache.ShouldLogSuppressedRefresh())
-            _logger.LogWarning("Unable to resolve mapping for field {Field}. The loaded server mapping is {MappingAge} old and a reload was suppressed by the {RefreshInterval} unmapped field refresh throttle, so this field is being treated as unmapped", field,
-                _timeProvider.GetUtcNow().UtcDateTime - snapshot.CreatedUtc, _cache.CurrentUnmappedRefreshInterval);
-
-        if (_logger.IsEnabled(LogLevel.Trace))
-            _logger.LogTrace("Mapping not found: {Field}", field);
-
-        // A cached miss is always revalidated against an in-flight or throttled reload before it is trusted
-        // (see GetMapping), so caching this result cannot pin a stale answer.
-        var notFoundMapping = new FieldMapping(resolvedFieldName.ToString(), null, snapshot.CreatedUtc, snapshot.Version);
-        _cache.CacheField(field, notFoundMapping, snapshot.Version);
-
-        return notFoundMapping;
+        LogUnresolvedField(field, loadResult, snapshot);
+        return resolved;
     }
 
-    private string? ResolvePropertyName(PropertyName? key)
+    private FieldMapping? FollowAlias(FieldMapping mapping, bool followAlias)
     {
-        if (key?.Name is null)
-            return null;
+        if (!followAlias || mapping.Property is not FieldAliasProperty alias)
+            return mapping;
 
-        return _inferrer is not null ? _inferrer.PropertyName(key) : key.Name;
+        return GetMapping(alias.Path?.Name);
+    }
+
+    /// <summary>
+    /// Walks a dotted field name through the merged property tree, resolving each part to its canonical
+    /// mapping name. Parts past the deepest resolvable one are appended unchanged so callers still get a
+    /// usable field path for an unmapped field.
+    /// </summary>
+    private static FieldMapping Resolve(string field, MappingSnapshot snapshot)
+    {
+        var properties = snapshot.Properties;
+        int start = 0;
+        StringBuilder? resolvedName = null;
+        MergedNode? node = null;
+
+        while (true)
+        {
+            int separator = field.IndexOf('.', start);
+            string part = separator < 0 ? field[start..] : field[start..separator];
+
+            if (properties is null || !properties.TryGetNode(part, out var matched))
+            {
+                // Unresolvable from here down: keep what was resolved and append the remainder verbatim.
+                string remainder = field[start..];
+                if (resolvedName is null)
+                    return new FieldMapping(remainder, null);
+
+                return new FieldMapping(resolvedName.Append('.').Append(remainder).ToString(), null);
+            }
+
+            node = matched;
+
+            if (resolvedName is null)
+                resolvedName = new StringBuilder(matched.Name);
+            else
+                resolvedName.Append('.').Append(matched.Name);
+
+            if (separator < 0)
+                return new FieldMapping(resolvedName.ToString(), node.Property, node.Children);
+
+            properties = matched.Children;
+            start = separator + 1;
+        }
+    }
+
+    private void LogUnresolvedField(string field, MappingRefreshResult loadResult, MappingSnapshot snapshot)
+    {
+        if (loadResult == MappingRefreshResult.WaitTimedOut && ShouldLogSuppressedRefresh())
+        {
+            _logger.LogWarning("Unable to resolve mapping for field {Field}. A server mapping reload was already in flight but did not complete within {WaitTimeout}, so this field is being treated as unmapped. Increase {Property} if the mapping fetch is expected to take longer than this",
+                field, MappingRefreshWaitTimeout, nameof(MappingRefreshWaitTimeout));
+        }
+        else if (loadResult == MappingRefreshResult.Throttled && snapshot.HasServerMapping && ShouldLogSuppressedRefresh())
+        {
+            _logger.LogWarning("Unable to resolve mapping for field {Field}. The loaded server mapping is {MappingAge} old and a reload was suppressed by the {RefreshInterval} unmapped field refresh throttle, so this field is being treated as unmapped",
+                field, _timeProvider.GetUtcNow().UtcDateTime - snapshot.CreatedUtc, UnmappedFieldRefreshInterval);
+        }
+        else if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace("Mapping not found: {Field}", field);
+        }
+    }
+
+    /// <summary>
+    /// Rate limits warnings about suppressed reloads so a flood of queries against non-existent fields cannot
+    /// flood the log.
+    /// </summary>
+    private bool ShouldLogSuppressedRefresh()
+    {
+        if (!_logger.IsEnabled(LogLevel.Warning))
+            return false;
+
+        long last = Interlocked.Read(ref _lastSuppressedRefreshWarningTimestamp);
+        if (last != 0 && _timeProvider.GetElapsedTime(last) < _suppressedRefreshWarningInterval)
+            return false;
+
+        long timestamp = _timeProvider.GetTimestamp();
+        return Interlocked.CompareExchange(ref _lastSuppressedRefreshWarningTimestamp, timestamp == 0 ? 1 : timestamp, last) == last;
     }
 
     public FieldMapping? GetMapping(Field field, bool followAlias = false)
@@ -418,27 +311,17 @@ public class ElasticMappingResolver : IDisposable
         if (mapping?.Property is null || !IsPropertyAnalyzed(mapping.Property))
             return field;
 
-        var multiFieldProperty = mapping.Property;
-        var fields = GetChildProperties(multiFieldProperty);
-        if (fields is null || (IDictionary<PropertyName, IProperty>)fields is not { Count: > 0 })
+        var children = mapping.Children;
+        if (children is null || children.Count == 0)
             return mapping.FullPath;
 
-        var nonAnalyzedProperty = fields.OrderByDescending(kvp => kvp.Key.Name == preferredSubField).FirstOrDefault(kvp =>
-        {
-            if (kvp.Value is KeywordProperty)
-                return true;
+        var preferred = children.Nodes.FirstOrDefault(n => n.Name == preferredSubField && IsNonAnalyzed(n.Property));
+        var nonAnalyzed = preferred ?? children.Nodes.FirstOrDefault(n => IsNonAnalyzed(n.Property));
 
-            if (!IsPropertyAnalyzed(kvp.Value))
-                return true;
-
-            return false;
-        });
-
-        if (nonAnalyzedProperty.Value is not null)
-            return mapping.FullPath + "." + nonAnalyzedProperty.Key.Name;
-
-        return mapping.FullPath;
+        return nonAnalyzed is not null ? mapping.FullPath + "." + nonAnalyzed.Name : mapping.FullPath;
     }
+
+    private bool IsNonAnalyzed(IProperty property) => property is KeywordProperty || !IsPropertyAnalyzed(property);
 
     public bool IsPropertyAnalyzed(string? field)
     {
@@ -575,126 +458,121 @@ public class ElasticMappingResolver : IDisposable
         };
     }
 
-    private Properties? InferCodeProperties(Properties? codeProperties)
+    /// <summary>
+    /// Builds the merged view of the code and server mappings as a name-keyed tree, ready for resolution.
+    /// </summary>
+    /// <remarks>
+    /// Pure with respect to both mappings: nothing is written back into the mapping the <c>getMapping</c>
+    /// callback returned, so that instance stays safe to cache and share. Keying children by name rather than
+    /// by <see cref="IProperty"/> instance is what makes merging work for every property type instead of only
+    /// the few that expose settable sub-property collections, and is also why reusing one property instance
+    /// across several fields cannot leak one field's sub-fields into another's.
+    /// </remarks>
+    private MergedProperties? BuildMergedProperties(TypeMapping? serverMapping)
     {
-        if (codeProperties is null)
+        return Merge(_codeMapping?.Properties, serverMapping?.Properties);
+    }
+
+    private MergedProperties? Merge(Properties? codeProperties, Properties? serverProperties)
+    {
+        if (codeProperties is null && serverProperties is null)
             return null;
 
-        // resolve code mapping property expressions using inferrer
-        var inferredProperties = new Properties();
+        var nodes = new List<MergedNode>();
+        var codeByName = IndexCodeProperties(codeProperties);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var kvp in codeProperties)
+        if (serverProperties is not null)
         {
-            var propertyName = kvp.Key;
-            if (_inferrer is not null && (String.IsNullOrEmpty(kvp.Key.Name) || kvp.Value is FieldAliasProperty))
-                propertyName = _inferrer.PropertyName(kvp.Key) ?? kvp.Key;
+            foreach (var kvp in serverProperties)
+            {
+                string? name = ResolvePropertyName(kvp.Key);
+                if (name is null || !seen.Add(name))
+                    continue;
 
-            inferredProperties[propertyName] = kvp.Value;
+                // The server mapping is authoritative, so a code property only contributes children when both
+                // sides agree on whether the field is a container.
+                codeByName.TryGetValue(name, out var codeProperty);
+                var codeChildren = codeProperty is not null && IsContainer(codeProperty) == IsContainer(kvp.Value)
+                    ? GetChildProperties(codeProperty)
+                    : null;
+
+                if (codeProperty is not null)
+                    CopyPropertyMetadata(codeProperty, kvp.Value);
+
+                nodes.Add(new MergedNode(name, kvp.Value, Merge(codeChildren, GetChildProperties(kvp.Value))));
+            }
         }
 
-        if (_inferrer is null)
-            return inferredProperties;
-
-        // resolve field alias
-        foreach (var kvp in codeProperties)
+        foreach (var (name, property) in codeByName)
         {
-            if (kvp.Value is not FieldAliasProperty aliasProperty)
+            if (!seen.Add(name))
                 continue;
 
-            var newAliasProperty = new FieldAliasProperty
-            {
-                Path = _inferrer.Field(aliasProperty.Path!) ?? aliasProperty.Path,
-            };
-            CopyPropertyMetadata(aliasProperty, newAliasProperty);
-            inferredProperties[_inferrer.PropertyName(kvp.Key) ?? kvp.Key] = newAliasProperty;
+            nodes.Add(new MergedNode(name, property, Merge(GetChildProperties(property), null)));
         }
 
-        return inferredProperties;
+        return nodes.Count > 0 ? new MergedProperties(nodes) : null;
     }
 
-    private Properties? MergeCodeAndServerProperties(Properties? codeProperties, Properties? serverProperties)
+    /// <summary>
+    /// Resolves code mapping property names and alias paths through the inferrer, so a mapping declared with
+    /// property expressions is keyed by the same names the server reports.
+    /// </summary>
+    private Dictionary<string, IProperty> IndexCodeProperties(Properties? codeProperties)
     {
-        return MergeProperties(InferCodeProperties(codeProperties), serverProperties);
+        var indexed = new Dictionary<string, IProperty>(StringComparer.Ordinal);
+        if (codeProperties is null)
+            return indexed;
+
+        foreach (var kvp in codeProperties)
+        {
+            string? name = ResolvePropertyName(kvp.Key);
+            if (name is null)
+                continue;
+
+            var property = kvp.Value;
+            if (_inferrer is not null && property is FieldAliasProperty alias)
+            {
+                var resolvedAlias = new FieldAliasProperty { Path = _inferrer.Field(alias.Path!) ?? alias.Path };
+                CopyPropertyMetadata(alias, resolvedAlias);
+                property = resolvedAlias;
+            }
+
+            indexed[name] = property;
+        }
+
+        return indexed;
     }
+
+    private string? ResolvePropertyName(PropertyName? key)
+    {
+        if (key is null)
+            return null;
+
+        // A property expression has no literal name until the inferrer resolves it.
+        if (_inferrer is not null)
+            return _inferrer.PropertyName(key);
+
+        return key.Name;
+    }
+
+    private static bool IsContainer(IProperty property) => property is ObjectProperty or NestedProperty;
 
     /// <summary>
     /// Returns the child properties a field name can descend into. Object and nested properties hold
     /// sub-objects in <c>Properties</c>; every other property type can only hold multi-fields. Using one
-    /// accessor for every property type keeps resolution and merging symmetric, so a multi-field on a
-    /// keyword, date or numeric property behaves exactly like one on a text property.
+    /// accessor for every property type is what makes a multi-field on a keyword, date or numeric property
+    /// behave exactly like one on a text property.
     /// </summary>
-    private static Properties? GetOwnChildProperties(IProperty property)
+    private static Properties? GetChildProperties(IProperty property)
     {
         return property switch
         {
-            ObjectProperty objectProperty => objectProperty.Properties ?? objectProperty.Fields,
-            NestedProperty nestedProperty => nestedProperty.Properties ?? nestedProperty.Fields,
+            ObjectProperty objectProperty => objectProperty.Properties,
+            NestedProperty nestedProperty => nestedProperty.Properties,
             _ => property.GetFields()
         };
-    }
-
-    /// <summary>
-    /// Returns the child properties of a property, preferring the merged view recorded while combining the
-    /// code mapping with the server mapping.
-    /// </summary>
-    private Properties? GetChildProperties(IProperty property)
-    {
-        // Merged children only exist when a code mapping was supplied, so resolvers backed purely by the
-        // server mapping never pay for the lookup.
-        if (_codeMapping is not null && _mergedChildProperties.TryGetValue(property, out var mergedChildren))
-            return mergedChildren;
-
-        return GetOwnChildProperties(property);
-    }
-
-    /// <summary>
-    /// Combines the properties declared in code with the properties reported by the server, preferring the
-    /// server definition and layering code-only properties on top.
-    /// </summary>
-    /// <remarks>
-    /// Merging never mutates the server mapping. Where a property is declared in both mappings its combined
-    /// children are recorded in a side table keyed by the server property instance, which keeps the mapping
-    /// returned by the <c>getMapping</c> callback safe to share and makes merging work identically for every
-    /// property type rather than only the handful that expose settable sub-property collections.
-    /// </remarks>
-    private Properties? MergeProperties(Properties? inferredCodeProperties, Properties? serverProperties)
-    {
-        // no need to merge
-        if (inferredCodeProperties is null || serverProperties is null)
-            return inferredCodeProperties ?? serverProperties;
-
-        var properties = new Properties();
-        foreach (var serverProperty in serverProperties)
-        {
-            var merged = serverProperty.Value;
-
-            if (inferredCodeProperties.TryGetProperty(serverProperty.Key, out var codeProperty))
-            {
-                // Copy local metadata from code property to merged property
-                CopyPropertyMetadata(codeProperty, merged);
-
-                var codeChildren = GetOwnChildProperties(codeProperty);
-                if (codeChildren is not null)
-                {
-                    var serverChildren = GetOwnChildProperties(merged);
-                    var mergedChildren = MergeCodeAndServerProperties(codeChildren, serverChildren);
-                    if (mergedChildren is not null && !ReferenceEquals(mergedChildren, serverChildren))
-                        _mergedChildProperties.AddOrUpdate(merged, mergedChildren);
-                }
-            }
-
-            properties.Add(serverProperty.Key, merged);
-        }
-
-        foreach (var codeProperty in inferredCodeProperties)
-        {
-            if (properties.TryGetProperty(codeProperty.Key, out _))
-                continue;
-
-            properties.Add(codeProperty.Key, codeProperty.Value);
-        }
-
-        return properties;
     }
 
     public static ElasticMappingResolver Create<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, ElasticsearchClient client, ILogger? logger = null) where T : class
@@ -828,12 +706,16 @@ public class ElasticMappingResolver : IDisposable
 
 public class FieldMapping
 {
-    public FieldMapping(string path, IProperty? property, DateTime? serverMapTime, long epoch = 0)
+    public FieldMapping(string path, IProperty? property)
+        : this(path, property, null)
+    {
+    }
+
+    internal FieldMapping(string path, IProperty? property, MergedProperties? children)
     {
         FullPath = path;
         Property = property;
-        ServerMapTime = serverMapTime;
-        Epoch = epoch;
+        Children = children;
     }
 
     public bool Found => Property is not null;
@@ -841,9 +723,56 @@ public class FieldMapping
     public IProperty? Property { get; private set; }
     public DateTime Date { get; private set; } = DateTime.UtcNow;
 
-    /// <summary>When the mapping this resolution was made against was loaded.</summary>
-    internal DateTime? ServerMapTime { get; private set; }
+    /// <summary>
+    /// Merged sub-objects and multi-fields of this field, captured during resolution so sub-field lookups do
+    /// not have to walk the mapping again.
+    /// </summary>
+    internal MergedProperties? Children { get; }
+}
 
-    /// <summary>Version of the mapping snapshot this resolution was made against.</summary>
-    internal long Epoch { get; private set; }
+/// <summary>A name-indexed merged view of the code and server properties at one mapping level.</summary>
+internal sealed class MergedProperties
+{
+    private readonly IReadOnlyList<MergedNode> _nodes;
+    private readonly Dictionary<string, MergedNode> _byExactName;
+    private readonly Dictionary<string, MergedNode> _byIgnoreCaseName;
+
+    public MergedProperties(IReadOnlyList<MergedNode> nodes)
+    {
+        _nodes = nodes;
+        _byExactName = new Dictionary<string, MergedNode>(nodes.Count, StringComparer.Ordinal);
+        _byIgnoreCaseName = new Dictionary<string, MergedNode>(nodes.Count, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var node in nodes)
+        {
+            _byExactName[node.Name] = node;
+            _byIgnoreCaseName.TryAdd(node.Name, node);
+        }
+    }
+
+    public int Count => _nodes.Count;
+
+    public IReadOnlyList<MergedNode> Nodes => _nodes;
+
+    public bool TryGetNode(string name, out MergedNode node)
+    {
+        return _byExactName.TryGetValue(name, out node!) || _byIgnoreCaseName.TryGetValue(name, out node!);
+    }
+}
+
+/// <summary>A canonical property and the merged children reachable through its field name.</summary>
+internal sealed class MergedNode
+{
+    public MergedNode(string name, IProperty property, MergedProperties? children)
+    {
+        Name = name;
+        Property = property;
+        Children = children;
+    }
+
+    public string Name { get; }
+
+    public IProperty Property { get; }
+
+    public MergedProperties? Children { get; }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -124,8 +124,9 @@ public class ElasticMappingResolver : IDisposable
     private FieldMapping? ResolveMapping(string field, bool followAlias, MappingSnapshot snapshot)
     {
         var loadResult = MappingRefreshResult.Unavailable;
+        bool hadFetchedSnapshot = snapshot.Fetched;
 
-        if (!snapshot.Fetched)
+        if (!hadFetchedSnapshot)
         {
             loadResult = _cache.LoadInitial(snapshot);
             snapshot = _cache.Current;
@@ -134,8 +135,10 @@ public class ElasticMappingResolver : IDisposable
         var resolved = Resolve(field, snapshot);
 
         // The field is unknown to the loaded mapping, which is the strongest available signal that the mapping
-        // changed, so reload once and resolve again against the new one.
-        if (!resolved.Found)
+        // changed, so reload once and resolve again against the new one. Do not reload immediately after this
+        // resolution already loaded or joined the initial mapping; that would repeat the same work and can
+        // consume the join timeout twice.
+        if (!resolved.Found && hadFetchedSnapshot)
         {
             loadResult = _cache.ReloadForMissingField(snapshot);
             if (loadResult == MappingRefreshResult.Updated)
@@ -706,8 +709,13 @@ public class ElasticMappingResolver : IDisposable
 
 public class FieldMapping
 {
-    public FieldMapping(string path, IProperty? property)
-        : this(path, property, null)
+    public FieldMapping(string path, IProperty? property, DateTime? serverMapTime, long epoch = 0)
+        : this(path, property, (MergedProperties?)null)
+    {
+    }
+
+    internal FieldMapping(string path, IProperty? property)
+        : this(path, property, (MergedProperties?)null)
     {
     }
 

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -37,7 +37,7 @@ public class ElasticMappingResolver : IDisposable
         _cache = new MappingCache(getMapping, BuildMergedProperties, _timeProvider, _logger);
     }
 
-    public ElasticMappingResolver(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null,
+    private ElasticMappingResolver(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null,
         TimeProvider? timeProvider = null, ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(getMappingAsync);
@@ -62,7 +62,7 @@ public class ElasticMappingResolver : IDisposable
         _codeMapping = codeMapping;
     }
 
-    public ElasticMappingResolver(TypeMapping codeMapping, Inferrer inferrer, Func<CancellationToken, Task<TypeMapping?>> getMappingAsync,
+    private ElasticMappingResolver(TypeMapping codeMapping, Inferrer inferrer, Func<CancellationToken, Task<TypeMapping?>> getMappingAsync,
         TimeProvider? timeProvider = null, ILogger? logger = null)
         : this(getMappingAsync, inferrer, timeProvider, logger)
     {
@@ -832,12 +832,12 @@ public class ElasticMappingResolver : IDisposable
         return new ElasticMappingResolver(descriptor, inferrer, getMapping, logger: logger);
     }
 
-    public static ElasticMappingResolver Create<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, Inferrer inferrer,
-        Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, ILogger? logger = null) where T : class
+    public static ElasticMappingResolver CreateWithAsyncLoader<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, Inferrer inferrer,
+        Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, TimeProvider? timeProvider = null, ILogger? logger = null) where T : class
     {
         var descriptor = new TypeMappingDescriptor<T>();
         mappingBuilder(descriptor);
-        return new ElasticMappingResolver(descriptor, inferrer, getMappingAsync, logger: logger);
+        return new ElasticMappingResolver(descriptor, inferrer, getMappingAsync, timeProvider, logger);
     }
 
     public static ElasticMappingResolver Create<T>(ElasticsearchClient client, ILogger? logger = null)
@@ -865,10 +865,10 @@ public class ElasticMappingResolver : IDisposable
         return new ElasticMappingResolver(getMapping, inferrer, logger: logger);
     }
 
-    public static ElasticMappingResolver Create(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null,
-        ILogger? logger = null)
+    public static ElasticMappingResolver CreateWithAsyncLoader(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null,
+        TimeProvider? timeProvider = null, ILogger? logger = null)
     {
-        return new ElasticMappingResolver(getMappingAsync, inferrer, logger: logger);
+        return new ElasticMappingResolver(getMappingAsync, inferrer, timeProvider, logger);
     }
 
     private ElasticMappingResolver(TypeMapping codeMapping, Inferrer inferrer, Func<TypeMapping?> getMapping,
@@ -953,82 +953,4 @@ public class ElasticMappingResolver : IDisposable
         _cache.Dispose();
     }
 
-}
-
-public class FieldMapping
-{
-    public FieldMapping(string path, IProperty? property, DateTime? serverMapTime, long epoch = 0)
-        : this(path, property, (MergedProperties?)null)
-    {
-    }
-
-    internal FieldMapping(string path, IProperty? property)
-        : this(path, property, (MergedProperties?)null)
-    {
-    }
-
-    internal FieldMapping(string path, IProperty? property, MergedProperties? children)
-    {
-        FullPath = path;
-        Property = property;
-        Children = children;
-    }
-
-    public bool Found => Property is not null;
-    public string FullPath { get; private set; }
-    public IProperty? Property { get; private set; }
-    public DateTime Date { get; private set; } = DateTime.UtcNow;
-
-    /// <summary>
-    /// Merged sub-objects and multi-fields of this field, captured during resolution so sub-field lookups do
-    /// not have to walk the mapping again.
-    /// </summary>
-    internal MergedProperties? Children { get; }
-}
-
-/// <summary>A name-indexed merged view of the code and server properties at one mapping level.</summary>
-internal sealed class MergedProperties
-{
-    private readonly IReadOnlyList<MergedNode> _nodes;
-    private readonly Dictionary<string, MergedNode> _byExactName;
-    private readonly Dictionary<string, MergedNode> _byIgnoreCaseName;
-
-    public MergedProperties(IReadOnlyList<MergedNode> nodes)
-    {
-        _nodes = nodes;
-        _byExactName = new Dictionary<string, MergedNode>(nodes.Count, StringComparer.Ordinal);
-        _byIgnoreCaseName = new Dictionary<string, MergedNode>(nodes.Count, StringComparer.OrdinalIgnoreCase);
-
-        foreach (var node in nodes)
-        {
-            _byExactName[node.Name] = node;
-            _byIgnoreCaseName.TryAdd(node.Name, node);
-        }
-    }
-
-    public int Count => _nodes.Count;
-
-    public IReadOnlyList<MergedNode> Nodes => _nodes;
-
-    public bool TryGetNode(string name, out MergedNode node)
-    {
-        return _byExactName.TryGetValue(name, out node!) || _byIgnoreCaseName.TryGetValue(name, out node!);
-    }
-}
-
-/// <summary>A canonical property and the merged children reachable through its field name.</summary>
-internal sealed class MergedNode
-{
-    public MergedNode(string name, IProperty property, MergedProperties? children)
-    {
-        Name = name;
-        Property = property;
-        Children = children;
-    }
-
-    public string Name { get; }
-
-    public IProperty Property { get; }
-
-    public MergedProperties? Children { get; }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -748,13 +748,16 @@ public class ElasticMappingResolver : IDisposable
                 // sides describe the same field type.
                 codeByName.TryGetValue(name, out var codeProperty);
                 var codeChildren = codeProperty is not null && codeProperty.GetType() == kvp.Value.GetType()
-                    ? GetChildProperties(codeProperty)
+                    ? MappingProperty.GetChildren(codeProperty)
                     : null;
 
+                var children = Merge(codeChildren, MappingProperty.GetChildren(kvp.Value));
+                var property = MappingProperty.WithChildren(kvp.Value, children);
+                CopyPropertyMetadata(kvp.Value, property);
                 if (codeProperty is not null)
-                    CopyPropertyMetadata(codeProperty, kvp.Value);
+                    CopyPropertyMetadata(codeProperty, property);
 
-                nodes.Add(new MergedNode(name, kvp.Value, Merge(codeChildren, GetChildProperties(kvp.Value))));
+                nodes.Add(new MergedNode(name, property, children));
             }
         }
 
@@ -763,7 +766,10 @@ public class ElasticMappingResolver : IDisposable
             if (!seen.Add(name))
                 continue;
 
-            nodes.Add(new MergedNode(name, property, Merge(GetChildProperties(property), null)));
+            var children = Merge(MappingProperty.GetChildren(property), null);
+            var mergedProperty = MappingProperty.WithChildren(property, children);
+            CopyPropertyMetadata(property, mergedProperty);
+            nodes.Add(new MergedNode(name, mergedProperty, children));
         }
 
         return nodes.Count > 0 ? new MergedProperties(nodes) : null;
@@ -809,22 +815,6 @@ public class ElasticMappingResolver : IDisposable
             return _inferrer.PropertyName(key);
 
         return key.Name;
-    }
-
-    /// <summary>
-    /// Returns the child properties a field name can descend into. Object and nested properties hold
-    /// sub-objects in <c>Properties</c>; every other property type can only hold multi-fields. Using one
-    /// accessor for every property type is what makes a multi-field on a keyword, date or numeric property
-    /// behave exactly like one on a text property.
-    /// </summary>
-    private static Properties? GetChildProperties(IProperty property)
-    {
-        return property switch
-        {
-            ObjectProperty objectProperty => objectProperty.Properties,
-            NestedProperty nestedProperty => nestedProperty.Properties,
-            _ => property.GetFields()
-        };
     }
 
     public static ElasticMappingResolver Create<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, ElasticsearchClient client, ILogger? logger = null) where T : class

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.IndexManagement;
 using Elastic.Clients.Elasticsearch.Mapping;
@@ -36,8 +37,34 @@ public class ElasticMappingResolver : IDisposable
         _cache = new MappingCache(getMapping, BuildMergedProperties, _timeProvider, _logger);
     }
 
+    public ElasticMappingResolver(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null,
+        TimeProvider? timeProvider = null, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(getMappingAsync);
+        _inferrer = inferrer;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _logger = logger ?? NullLogger.Instance;
+        _cache = new MappingCache(getMappingAsync, BuildMergedProperties, _timeProvider, _logger);
+    }
+
+    private ElasticMappingResolver(Func<TypeMapping?> getMapping, Func<CancellationToken, Task<TypeMapping?>> getMappingAsync,
+        Inferrer? inferrer, ILogger? logger)
+    {
+        _inferrer = inferrer;
+        _timeProvider = TimeProvider.System;
+        _logger = logger ?? NullLogger.Instance;
+        _cache = new MappingCache(getMapping, getMappingAsync, BuildMergedProperties, _timeProvider, _logger);
+    }
+
     public ElasticMappingResolver(TypeMapping codeMapping, Inferrer inferrer, Func<TypeMapping?> getMapping, TimeProvider? timeProvider = null, ILogger? logger = null)
         : this(getMapping, inferrer, timeProvider, logger)
+    {
+        _codeMapping = codeMapping;
+    }
+
+    public ElasticMappingResolver(TypeMapping codeMapping, Inferrer inferrer, Func<CancellationToken, Task<TypeMapping?>> getMappingAsync,
+        TimeProvider? timeProvider = null, ILogger? logger = null)
+        : this(getMappingAsync, inferrer, timeProvider, logger)
     {
         _codeMapping = codeMapping;
     }
@@ -74,7 +101,7 @@ public class ElasticMappingResolver : IDisposable
     /// bounded so an unresponsive cluster cannot pin request threads indefinitely. The mapping callback must
     /// enforce a shorter timeout and must not call back into this resolver.
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">The value is negative or zero, or exceeds the maximum wait a semaphore accepts.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The value is negative or zero, or exceeds the supported maximum wait.</exception>
     public TimeSpan MappingRefreshWaitTimeout
     {
         get => _cache.RefreshWaitTimeout;
@@ -121,6 +148,27 @@ public class ElasticMappingResolver : IDisposable
         return ResolveMapping(field!, followAlias, snapshot);
     }
 
+    public ValueTask<FieldMapping?> GetMappingAsync(string? field, bool followAlias = false, CancellationToken cancellationToken = default)
+    {
+        if (String.IsNullOrWhiteSpace(field))
+            return ValueTask.FromResult<FieldMapping?>(null);
+
+        if (!_cache.HasServerMappingFunc && _codeMapping is null)
+            throw new InvalidOperationException("No mappings are available.");
+
+        var snapshot = _cache.Current;
+
+        if (snapshot.TryGetField(field!, out var cached))
+        {
+            if (_logger.IsEnabled(LogLevel.Trace))
+                _logger.LogTrace("Cached mapping: {Field}={FieldPath}:{FieldType}", field, cached.FullPath, cached.Property?.Type);
+
+            return FollowAliasAsync(cached, followAlias, cancellationToken);
+        }
+
+        return ResolveMappingAsync(field!, followAlias, snapshot, cancellationToken);
+    }
+
     private FieldMapping? ResolveMapping(string field, bool followAlias, MappingSnapshot snapshot)
     {
         var loadResult = MappingRefreshResult.Unavailable;
@@ -162,12 +210,58 @@ public class ElasticMappingResolver : IDisposable
         return resolved;
     }
 
+    private async ValueTask<FieldMapping?> ResolveMappingAsync(string field, bool followAlias, MappingSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        var loadResult = MappingRefreshResult.Unavailable;
+        bool hadFetchedSnapshot = snapshot.Fetched;
+
+        if (!hadFetchedSnapshot)
+        {
+            loadResult = await _cache.LoadInitialAsync(snapshot, cancellationToken).ConfigureAwait(false);
+            snapshot = _cache.Current;
+        }
+
+        var resolved = Resolve(field, snapshot);
+
+        if (!resolved.Found && hadFetchedSnapshot)
+        {
+            loadResult = await _cache.ReloadForMissingFieldAsync(snapshot, cancellationToken).ConfigureAwait(false);
+            if (loadResult == MappingRefreshResult.Updated)
+            {
+                snapshot = _cache.Current;
+                resolved = Resolve(field, snapshot);
+            }
+        }
+
+        snapshot.CacheField(resolved);
+
+        if (resolved.Found)
+        {
+            if (_logger.IsEnabled(LogLevel.Trace))
+                _logger.LogTrace("Resolved mapping: {Field}={FieldPath}:{FieldType}", field, resolved.FullPath, resolved.Property?.Type);
+
+            return await FollowAliasAsync(resolved, followAlias, cancellationToken).ConfigureAwait(false);
+        }
+
+        LogUnresolvedField(field, loadResult, snapshot);
+        return resolved;
+    }
+
     private FieldMapping? FollowAlias(FieldMapping mapping, bool followAlias)
     {
         if (!followAlias || mapping.Property is not FieldAliasProperty alias)
             return mapping;
 
         return GetMapping(alias.Path?.Name);
+    }
+
+    private ValueTask<FieldMapping?> FollowAliasAsync(FieldMapping mapping, bool followAlias, CancellationToken cancellationToken)
+    {
+        if (!followAlias || mapping.Property is not FieldAliasProperty alias)
+            return ValueTask.FromResult<FieldMapping?>(mapping);
+
+        return GetMappingAsync(alias.Path?.Name, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -255,6 +349,14 @@ public class ElasticMappingResolver : IDisposable
         return GetMapping(_inferrer.Field(field), followAlias);
     }
 
+    public ValueTask<FieldMapping?> GetMappingAsync(Field field, bool followAlias = false, CancellationToken cancellationToken = default)
+    {
+        if (_inferrer is null)
+            throw new InvalidOperationException("Unable to resolve Field without inferrer");
+
+        return GetMappingAsync(_inferrer.Field(field), followAlias, cancellationToken);
+    }
+
     public IProperty? GetMappingProperty(string? field, bool followAlias = false)
     {
         return GetMapping(field, followAlias)?.Property;
@@ -263,6 +365,16 @@ public class ElasticMappingResolver : IDisposable
     public IProperty? GetMappingProperty(Field field, bool followAlias = false)
     {
         return GetMapping(field, followAlias)?.Property;
+    }
+
+    public async ValueTask<IProperty?> GetMappingPropertyAsync(string? field, bool followAlias = false, CancellationToken cancellationToken = default)
+    {
+        return (await GetMappingAsync(field, followAlias, cancellationToken).ConfigureAwait(false))?.Property;
+    }
+
+    public async ValueTask<IProperty?> GetMappingPropertyAsync(Field field, bool followAlias = false, CancellationToken cancellationToken = default)
+    {
+        return (await GetMappingAsync(field, followAlias, cancellationToken).ConfigureAwait(false))?.Property;
     }
 
     public string? GetResolvedField(string? field)
@@ -279,6 +391,20 @@ public class ElasticMappingResolver : IDisposable
         return GetResolvedField(_inferrer.Field(field))!;
     }
 
+    public async ValueTask<string?> GetResolvedFieldAsync(string? field, CancellationToken cancellationToken = default)
+    {
+        var result = await GetMappingAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false);
+        return result?.FullPath ?? field;
+    }
+
+    public async ValueTask<string> GetResolvedFieldAsync(Field field, CancellationToken cancellationToken = default)
+    {
+        if (_inferrer is null)
+            throw new InvalidOperationException("Unable to resolve Field without inferrer");
+
+        return (await GetResolvedFieldAsync(_inferrer.Field(field), cancellationToken).ConfigureAwait(false))!;
+    }
+
     public string? GetSortFieldName(string? field)
     {
         return GetNonAnalyzedFieldName(field, ElasticMapping.SortFieldName);
@@ -287,6 +413,17 @@ public class ElasticMappingResolver : IDisposable
     public string GetSortFieldName(Field field)
     {
         return GetNonAnalyzedFieldName(GetResolvedField(field), ElasticMapping.SortFieldName)!;
+    }
+
+    public ValueTask<string?> GetSortFieldNameAsync(string? field, CancellationToken cancellationToken = default)
+    {
+        return GetNonAnalyzedFieldNameAsync(field, ElasticMapping.SortFieldName, cancellationToken);
+    }
+
+    public async ValueTask<string> GetSortFieldNameAsync(Field field, CancellationToken cancellationToken = default)
+    {
+        string resolved = await GetResolvedFieldAsync(field, cancellationToken).ConfigureAwait(false);
+        return (await GetNonAnalyzedFieldNameAsync(resolved, ElasticMapping.SortFieldName, cancellationToken).ConfigureAwait(false))!;
     }
 
     public string? GetAggregationsFieldName(string? field)
@@ -299,9 +436,26 @@ public class ElasticMappingResolver : IDisposable
         return GetNonAnalyzedFieldName(field, ElasticMapping.KeywordFieldName)!;
     }
 
+    public ValueTask<string?> GetAggregationsFieldNameAsync(string? field, CancellationToken cancellationToken = default)
+    {
+        return GetNonAnalyzedFieldNameAsync(field, ElasticMapping.KeywordFieldName, cancellationToken);
+    }
+
+    public async ValueTask<string> GetAggregationsFieldNameAsync(Field field, CancellationToken cancellationToken = default)
+    {
+        return (await GetNonAnalyzedFieldNameAsync(field, ElasticMapping.KeywordFieldName, cancellationToken).ConfigureAwait(false))!;
+    }
+
     public string GetNonAnalyzedFieldName(Field field, string? preferredSubField = null)
     {
         return GetNonAnalyzedFieldName(GetResolvedField(field), preferredSubField)!;
+    }
+
+    public async ValueTask<string> GetNonAnalyzedFieldNameAsync(Field field, string? preferredSubField = null,
+        CancellationToken cancellationToken = default)
+    {
+        string resolved = await GetResolvedFieldAsync(field, cancellationToken).ConfigureAwait(false);
+        return (await GetNonAnalyzedFieldNameAsync(resolved, preferredSubField, cancellationToken).ConfigureAwait(false))!;
     }
 
     public string? GetNonAnalyzedFieldName(string? field, string? preferredSubField = null)
@@ -310,7 +464,21 @@ public class ElasticMappingResolver : IDisposable
             return field;
 
         var mapping = GetMapping(field, true);
+        return GetNonAnalyzedFieldName(field, mapping, preferredSubField);
+    }
 
+    public async ValueTask<string?> GetNonAnalyzedFieldNameAsync(string? field, string? preferredSubField = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (String.IsNullOrEmpty(field))
+            return field;
+
+        var mapping = await GetMappingAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false);
+        return GetNonAnalyzedFieldName(field, mapping, preferredSubField);
+    }
+
+    private string? GetNonAnalyzedFieldName(string? field, FieldMapping? mapping, string? preferredSubField)
+    {
         if (mapping?.Property is null || !IsPropertyAnalyzed(mapping.Property))
             return field;
 
@@ -339,6 +507,15 @@ public class ElasticMappingResolver : IDisposable
         return IsPropertyAnalyzed(property.Property!);
     }
 
+    public async ValueTask<bool> IsPropertyAnalyzedAsync(string? field, CancellationToken cancellationToken = default)
+    {
+        if (String.IsNullOrEmpty(field))
+            return true;
+
+        var property = await GetMappingAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false);
+        return property is not null && property.Found && IsPropertyAnalyzed(property.Property!);
+    }
+
     public bool IsPropertyAnalyzed(IProperty property)
     {
         if (property is TextProperty textProperty)
@@ -355,6 +532,12 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is NestedProperty;
     }
 
+    public async ValueTask<bool> IsNestedPropertyTypeAsync(string? field, CancellationToken cancellationToken = default)
+    {
+        return !String.IsNullOrEmpty(field)
+            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false) is NestedProperty;
+    }
+
     public bool IsGeoPropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
@@ -363,12 +546,31 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is GeoPointProperty;
     }
 
+    public async ValueTask<bool> IsGeoPropertyTypeAsync(string? field, CancellationToken cancellationToken = default)
+    {
+        return !String.IsNullOrEmpty(field)
+            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false) is GeoPointProperty;
+    }
+
     public bool IsNumericPropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
             return false;
 
-        var property = GetMappingProperty(field, true);
+        return IsNumericProperty(GetMappingProperty(field, true));
+    }
+
+    public async ValueTask<bool> IsNumericPropertyTypeAsync(string? field, CancellationToken cancellationToken = default)
+    {
+        if (String.IsNullOrEmpty(field))
+            return false;
+
+        var property = await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false);
+        return IsNumericProperty(property);
+    }
+
+    private static bool IsNumericProperty(IProperty? property)
+    {
         return property is ByteNumberProperty
             or DoubleNumberProperty
             or FloatNumberProperty
@@ -388,6 +590,12 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is BooleanProperty;
     }
 
+    public async ValueTask<bool> IsBooleanPropertyTypeAsync(string? field, CancellationToken cancellationToken = default)
+    {
+        return !String.IsNullOrEmpty(field)
+            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false) is BooleanProperty;
+    }
+
     public bool IsDatePropertyType(string? field)
     {
         if (String.IsNullOrEmpty(field))
@@ -396,13 +604,31 @@ public class ElasticMappingResolver : IDisposable
         return GetMappingProperty(field, true) is DateProperty or DateNanosProperty;
     }
 
+    public async ValueTask<bool> IsDatePropertyTypeAsync(string? field, CancellationToken cancellationToken = default)
+    {
+        return !String.IsNullOrEmpty(field)
+            && await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false) is DateProperty or DateNanosProperty;
+    }
+
     public FieldType GetFieldType(string? field)
     {
         if (String.IsNullOrWhiteSpace(field))
             return FieldType.None;
 
-        var property = GetMappingProperty(field, true);
+        return GetFieldType(GetMappingProperty(field, true));
+    }
 
+    public async ValueTask<FieldType> GetFieldTypeAsync(string? field, CancellationToken cancellationToken = default)
+    {
+        if (String.IsNullOrWhiteSpace(field))
+            return FieldType.None;
+
+        var property = await GetMappingPropertyAsync(field, followAlias: true, cancellationToken).ConfigureAwait(false);
+        return GetFieldType(property);
+    }
+
+    private static FieldType GetFieldType(IProperty? property)
+    {
         if (property?.Type is null)
             return FieldType.None;
 
@@ -579,31 +805,24 @@ public class ElasticMappingResolver : IDisposable
     public static ElasticMappingResolver Create<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, ElasticsearchClient client, ILogger? logger = null) where T : class
     {
         logger ??= NullLogger.Instance;
-
-        return Create(mappingBuilder, client.Infer, () =>
-        {
-            var response = client.Indices.GetMapping(new GetMappingRequest(Indices.Index<T>()));
-            logger.LogTrace("GetMapping: {Request}", response.GetRequest(false, true));
-
-            // use first returned mapping because index could have been an index alias
-            var mapping = response.Mappings.Values.FirstOrDefault()?.Mappings;
-            return mapping;
-        }, logger);
+        var descriptor = new TypeMappingDescriptor<T>();
+        mappingBuilder(descriptor);
+        return new ElasticMappingResolver(descriptor, client.Infer,
+            () => GetServerMapping(client, new GetMappingRequest(Indices.Index<T>()), logger),
+            cancellationToken => GetServerMappingAsync(client, new GetMappingRequest(Indices.Index<T>()), logger, cancellationToken),
+            logger);
     }
 
     public static ElasticMappingResolver Create<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, ElasticsearchClient client, string index, ILogger? logger = null) where T : class
     {
         logger ??= NullLogger.Instance;
 
-        return Create(mappingBuilder, client.Infer, () =>
-        {
-            var response = client.Indices.GetMapping(new GetMappingRequest(index));
-            logger.LogTrace("GetMapping: {Request}", response.GetRequest(false, true));
-
-            // use first returned mapping because index could have been an index alias
-            var mapping = response.Mappings.Values.FirstOrDefault()?.Mappings;
-            return mapping;
-        }, logger);
+        var descriptor = new TypeMappingDescriptor<T>();
+        mappingBuilder(descriptor);
+        return new ElasticMappingResolver(descriptor, client.Infer,
+            () => GetServerMapping(client, new GetMappingRequest(index), logger),
+            cancellationToken => GetServerMappingAsync(client, new GetMappingRequest(index), logger, cancellationToken),
+            logger);
     }
 
     public static ElasticMappingResolver Create<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, Inferrer inferrer, Func<TypeMapping?> getMapping, ILogger? logger = null) where T : class
@@ -613,39 +832,65 @@ public class ElasticMappingResolver : IDisposable
         return new ElasticMappingResolver(descriptor, inferrer, getMapping, logger: logger);
     }
 
+    public static ElasticMappingResolver Create<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, Inferrer inferrer,
+        Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, ILogger? logger = null) where T : class
+    {
+        var descriptor = new TypeMappingDescriptor<T>();
+        mappingBuilder(descriptor);
+        return new ElasticMappingResolver(descriptor, inferrer, getMappingAsync, logger: logger);
+    }
+
     public static ElasticMappingResolver Create<T>(ElasticsearchClient client, ILogger? logger = null)
     {
         logger ??= NullLogger.Instance;
 
-        return Create(() =>
-        {
-            var response = client.Indices.GetMapping(new GetMappingRequest(Indices.Index<T>()));
-            logger.LogTrace("GetMapping: {Request}", response.GetRequest(false, true));
-
-            // use first returned mapping because index could have been an index alias
-            var mapping = response.Mappings.Values.FirstOrDefault()?.Mappings;
-            return mapping;
-        }, client.Infer, logger);
+        return new ElasticMappingResolver(
+            () => GetServerMapping(client, new GetMappingRequest(Indices.Index<T>()), logger),
+            cancellationToken => GetServerMappingAsync(client, new GetMappingRequest(Indices.Index<T>()), logger, cancellationToken),
+            client.Infer, logger);
     }
 
     public static ElasticMappingResolver Create(ElasticsearchClient client, string index, ILogger? logger = null)
     {
         logger ??= NullLogger.Instance;
 
-        return Create(() =>
-        {
-            var response = client.Indices.GetMapping(new GetMappingRequest(index));
-            logger.LogTrace("GetMapping: {Request}", response.GetRequest(false, true));
-
-            // use first returned mapping because index could have been an index alias
-            var mapping = response.Mappings.Values.FirstOrDefault()?.Mappings;
-            return mapping;
-        }, client.Infer, logger);
+        return new ElasticMappingResolver(
+            () => GetServerMapping(client, new GetMappingRequest(index), logger),
+            cancellationToken => GetServerMappingAsync(client, new GetMappingRequest(index), logger, cancellationToken),
+            client.Infer, logger);
     }
 
     public static ElasticMappingResolver Create(Func<TypeMapping?> getMapping, Inferrer? inferrer, ILogger? logger = null)
     {
         return new ElasticMappingResolver(getMapping, inferrer, logger: logger);
+    }
+
+    public static ElasticMappingResolver Create(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null,
+        ILogger? logger = null)
+    {
+        return new ElasticMappingResolver(getMappingAsync, inferrer, logger: logger);
+    }
+
+    private ElasticMappingResolver(TypeMapping codeMapping, Inferrer inferrer, Func<TypeMapping?> getMapping,
+        Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, ILogger? logger)
+        : this(getMapping, getMappingAsync, inferrer, logger)
+    {
+        _codeMapping = codeMapping;
+    }
+
+    private static TypeMapping? GetServerMapping(ElasticsearchClient client, GetMappingRequest request, ILogger logger)
+    {
+        var response = client.Indices.GetMapping(request);
+        logger.LogTrace("GetMapping: {Request}", response.GetRequest(false, true));
+        return response.Mappings.Values.FirstOrDefault()?.Mappings;
+    }
+
+    private static async Task<TypeMapping?> GetServerMappingAsync(ElasticsearchClient client, GetMappingRequest request, ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var response = await client.Indices.GetMappingAsync(request, cancellationToken).ConfigureAwait(false);
+        logger.LogTrace("GetMapping: {Request}", response.GetRequest(false, true));
+        return response.Mappings.Values.FirstOrDefault()?.Mappings;
     }
 
 

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -15,6 +15,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Foundatio.Parsers.ElasticQueries;
 
+/// <summary>Resolves fields using cached code and server mappings.</summary>
+/// <remarks>
+/// Async lookups cancel only the caller's wait, not a shared load. Dispose the resolver to cancel its loader
+/// lifetime. Loaders must enforce their own finite timeout. Synchronous APIs block when using an async loader;
+/// async APIs also block if the configured loader is synchronous. Configure the resolver before sharing it.
+/// </remarks>
 public class ElasticMappingResolver : IDisposable
 {
     private static readonly TimeSpan _suppressedRefreshWarningInterval = TimeSpan.FromMinutes(1);
@@ -149,6 +155,8 @@ public class ElasticMappingResolver : IDisposable
         return ResolveMapping(field!, followAlias, snapshot);
     }
 
+    /// <summary>Resolves a field, optionally following its alias, using the shared mapping loader when needed.</summary>
+    /// <remarks>Cancellation stops this caller's wait. A shared load continues for other callers. Cache hits may complete synchronously.</remarks>
     public ValueTask<FieldMapping?> GetMappingAsync(string? field, bool followAlias = false, CancellationToken cancellationToken = default)
     {
         if (String.IsNullOrWhiteSpace(field))
@@ -357,6 +365,7 @@ public class ElasticMappingResolver : IDisposable
         return GetMapping(_inferrer.Field(field), followAlias);
     }
 
+    /// <inheritdoc cref="GetMappingAsync(string, bool, CancellationToken)" />
     public ValueTask<FieldMapping?> GetMappingAsync(Field field, bool followAlias = false, CancellationToken cancellationToken = default)
     {
         if (_inferrer is null)
@@ -420,7 +429,7 @@ public class ElasticMappingResolver : IDisposable
 
     public string GetSortFieldName(Field field)
     {
-        return GetNonAnalyzedFieldName(GetResolvedField(field), ElasticMapping.SortFieldName)!;
+        return GetNonAnalyzedFieldName(field, ElasticMapping.SortFieldName);
     }
 
     public ValueTask<string?> GetSortFieldNameAsync(string? field, CancellationToken cancellationToken = default)
@@ -428,10 +437,9 @@ public class ElasticMappingResolver : IDisposable
         return GetNonAnalyzedFieldNameAsync(field, ElasticMapping.SortFieldName, cancellationToken);
     }
 
-    public async ValueTask<string> GetSortFieldNameAsync(Field field, CancellationToken cancellationToken = default)
+    public ValueTask<string> GetSortFieldNameAsync(Field field, CancellationToken cancellationToken = default)
     {
-        string resolved = await GetResolvedFieldAsync(field, cancellationToken).AnyContext();
-        return (await GetNonAnalyzedFieldNameAsync(resolved, ElasticMapping.SortFieldName, cancellationToken).AnyContext())!;
+        return GetNonAnalyzedFieldNameAsync(field, ElasticMapping.SortFieldName, cancellationToken);
     }
 
     public string? GetAggregationsFieldName(string? field)
@@ -449,21 +457,30 @@ public class ElasticMappingResolver : IDisposable
         return GetNonAnalyzedFieldNameAsync(field, ElasticMapping.KeywordFieldName, cancellationToken);
     }
 
-    public async ValueTask<string> GetAggregationsFieldNameAsync(Field field, CancellationToken cancellationToken = default)
+    public ValueTask<string> GetAggregationsFieldNameAsync(Field field, CancellationToken cancellationToken = default)
     {
-        return (await GetNonAnalyzedFieldNameAsync(field, ElasticMapping.KeywordFieldName, cancellationToken).AnyContext())!;
+        return GetNonAnalyzedFieldNameAsync(field, ElasticMapping.KeywordFieldName, cancellationToken);
     }
 
     public string GetNonAnalyzedFieldName(Field field, string? preferredSubField = null)
     {
-        return GetNonAnalyzedFieldName(GetResolvedField(field), preferredSubField)!;
+        if (_inferrer is null)
+            throw new InvalidOperationException("Unable to resolve Field without inferrer");
+
+        string name = _inferrer.Field(field)!;
+        var mapping = GetMapping(name, followAlias: true);
+        return GetNonAnalyzedFieldName(mapping?.FullPath ?? name, mapping, preferredSubField)!;
     }
 
     public async ValueTask<string> GetNonAnalyzedFieldNameAsync(Field field, string? preferredSubField = null,
         CancellationToken cancellationToken = default)
     {
-        string resolved = await GetResolvedFieldAsync(field, cancellationToken).AnyContext();
-        return (await GetNonAnalyzedFieldNameAsync(resolved, preferredSubField, cancellationToken).AnyContext())!;
+        if (_inferrer is null)
+            throw new InvalidOperationException("Unable to resolve Field without inferrer");
+
+        string name = _inferrer.Field(field)!;
+        var mapping = await GetMappingAsync(name, followAlias: true, cancellationToken).AnyContext();
+        return GetNonAnalyzedFieldName(mapping?.FullPath ?? name, mapping, preferredSubField)!;
     }
 
     public string? GetNonAnalyzedFieldName(string? field, string? preferredSubField = null)
@@ -840,6 +857,8 @@ public class ElasticMappingResolver : IDisposable
         return new ElasticMappingResolver(descriptor, inferrer, getMapping, logger: logger);
     }
 
+    /// <summary>Creates a resolver that combines code mappings with an asynchronous server mapping loader.</summary>
+    /// <remarks>The loader receives the resolver lifetime token, not an individual lookup token, and must enforce its own timeout.</remarks>
     public static ElasticMappingResolver CreateWithAsyncLoader<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, Inferrer inferrer,
         Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, TimeProvider? timeProvider = null, ILogger? logger = null) where T : class
     {
@@ -873,6 +892,8 @@ public class ElasticMappingResolver : IDisposable
         return new ElasticMappingResolver(getMapping, inferrer, logger: logger);
     }
 
+    /// <summary>Creates a resolver backed by an asynchronous server mapping loader.</summary>
+    /// <remarks>The caller owns this resolver. Dispose it to cancel the loader lifetime; cancelling a lookup does not cancel shared work.</remarks>
     public static ElasticMappingResolver CreateWithAsyncLoader(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null,
         TimeProvider? timeProvider = null, ILogger? logger = null)
     {

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticMappingResolver.cs
@@ -494,9 +494,9 @@ public class ElasticMappingResolver : IDisposable
                     continue;
 
                 // The server mapping is authoritative, so a code property only contributes children when both
-                // sides agree on whether the field is a container.
+                // sides describe the same field type.
                 codeByName.TryGetValue(name, out var codeProperty);
-                var codeChildren = codeProperty is not null && IsContainer(codeProperty) == IsContainer(kvp.Value)
+                var codeChildren = codeProperty is not null && codeProperty.GetType() == kvp.Value.GetType()
                     ? GetChildProperties(codeProperty)
                     : null;
 
@@ -559,8 +559,6 @@ public class ElasticMappingResolver : IDisposable
 
         return key.Name;
     }
-
-    private static bool IsContainer(IProperty property) => property is ObjectProperty or NestedProperty;
 
     /// <summary>
     /// Returns the child properties a field name can descend into. Object and nested properties hold

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -40,7 +40,7 @@ public class ElasticQueryParser : LuceneQueryParser
         query ??= String.Empty;
         context ??= new ElasticQueryVisitorContext();
 
-        context.ResetMappingResults();
+        using var mappingScope = context.BeginMappingScope();
         SetupQueryVisitorContextDefaults(context);
         try
         {
@@ -290,6 +290,7 @@ public class ElasticQueryParser : LuceneQueryParser
     {
         sort ??= String.Empty;
         context ??= new ElasticQueryVisitorContext();
+        using var mappingScope = context.BeginMappingScope();
         context.QueryType = QueryTypes.Sort;
 
         var result = await ParseAsync(sort, context).AnyContext();

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -176,7 +176,7 @@ public class ElasticQueryParser : LuceneQueryParser
         // try to use the runtime field resolver to dynamically discover a new runtime field and, if so, add it to the list of runtime fields
         if (elasticContext.EnableRuntimeFieldResolver is not false && elasticContext.RuntimeFieldResolver is not null)
         {
-            var newRuntimeField = await elasticContext.RuntimeFieldResolver(field).AnyContext();
+            var newRuntimeField = await context.GetRuntimeFieldAsync(field, elasticContext.RuntimeFieldResolver).AnyContext();
             if (newRuntimeField is not null)
             {
                 elasticContext.RuntimeFields?.Add(newRuntimeField);

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -89,6 +89,7 @@ public class ElasticQueryParser : LuceneQueryParser
 
         context.SetFieldResolver(async (field, context) =>
         {
+            var validationResult = context?.GetValidationResult();
             string? resolvedField = null;
             if (context?.Data.TryGetValue("@OriginalContextResolver", out object? data) is true && data is QueryFieldResolver resolver)
             {
@@ -107,6 +108,17 @@ public class ElasticQueryParser : LuceneQueryParser
             string? mappingResolvedField = await MappingFieldResolver(resolvedField ?? field, context).AnyContext();
             if (mappingResolvedField is not null)
                 resolvedField = mappingResolvedField;
+            // Validation also resolves configured restricted fields, so only record fields from the query itself.
+            else if (resolvedField is not null
+                && Configuration.MappingResolver is not null
+                && context?.GetValidationOptions().AllowUnresolvedFields is false
+                && validationResult is not null
+                && (validationResult.ReferencedFields.Count == 0
+                    || validationResult.ReferencedFields.Contains(field)))
+            {
+                if (context.QueryType is not QueryTypes.Aggregation || !field.StartsWith("@"))
+                    validationResult.UnresolvedFields.Add(field);
+            }
 
             return resolvedField;
         });

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Mapping;
 using Elastic.Clients.Elasticsearch.QueryDsl;
 using Foundatio.Parsers.ElasticQueries.Extensions;
 using Foundatio.Parsers.ElasticQueries.Visitors;
@@ -39,6 +40,7 @@ public class ElasticQueryParser : LuceneQueryParser
         query ??= String.Empty;
         context ??= new ElasticQueryVisitorContext();
 
+        context.ResetMappingResults();
         SetupQueryVisitorContextDefaults(context);
         try
         {
@@ -152,13 +154,27 @@ public class ElasticQueryParser : LuceneQueryParser
 
         // try to find Elasticsearch mapping
         // TODO: Need to test how runtime mappings defined on the server are handled
-        // TODO: Mark fields resolved so that we don't try to do lookups multiple times
 
         if (elasticContext.MappingResolver is not null)
         {
-            var resolvedField = await elasticContext.MappingResolver.GetMappingAsync(field).AnyContext();
-            if (resolvedField?.Found is true)
-                return resolvedField.FullPath;
+            string mappingField = field.Unescape() ?? field;
+            if (context.TryGetMappingResult(mappingField, out var cachedMapping))
+            {
+                if (cachedMapping?.Found is true && context.TryGetResolvedMappingField(mappingField, out string? cachedField))
+                    return cachedField;
+            }
+            else
+            {
+                var resolvedField = await elasticContext.MappingResolver.GetMappingAsync(mappingField).AnyContext();
+                var effectiveMapping = resolvedField;
+                if (resolvedField?.Property is FieldAliasProperty)
+                    effectiveMapping = await elasticContext.MappingResolver.GetMappingAsync(mappingField, followAlias: true).AnyContext();
+
+                context.SetMappingResult(mappingField, effectiveMapping, resolvedField?.FullPath);
+                context.SetMappingResult(field, effectiveMapping, resolvedField?.FullPath);
+                if (resolvedField?.Found is true)
+                    return resolvedField.FullPath;
+            }
         }
 
         // try to resolve from the list of runtime fields that are defined for this query

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -156,7 +156,7 @@ public class ElasticQueryParser : LuceneQueryParser
 
         if (elasticContext.MappingResolver is not null)
         {
-            var resolvedField = elasticContext.MappingResolver.GetMapping(field);
+            var resolvedField = await elasticContext.MappingResolver.GetMappingAsync(field).ConfigureAwait(false);
             if (resolvedField?.Found is true)
                 return resolvedField.FullPath;
         }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -91,7 +91,6 @@ public class ElasticQueryParser : LuceneQueryParser
 
         context.SetFieldResolver(async (field, context) =>
         {
-            var validationResult = context?.GetValidationResult();
             string? resolvedField = null;
             if (context?.Data.TryGetValue("@OriginalContextResolver", out object? data) is true && data is QueryFieldResolver resolver)
             {
@@ -107,20 +106,9 @@ public class ElasticQueryParser : LuceneQueryParser
                     resolvedField = configResolvedField;
             }
 
-            string? mappingResolvedField = await MappingFieldResolver(resolvedField ?? field, context).AnyContext();
+            string? mappingResolvedField = await ResolveMappingFieldAsync(resolvedField ?? field, context).AnyContext();
             if (mappingResolvedField is not null)
                 resolvedField = mappingResolvedField;
-            // Validation also resolves configured restricted fields, so only record fields from the query itself.
-            else if (resolvedField is not null
-                && Configuration.MappingResolver is not null
-                && context?.GetValidationOptions().AllowUnresolvedFields is false
-                && validationResult is not null
-                && (validationResult.ReferencedFields.Count == 0
-                    || validationResult.ReferencedFields.Contains(field)))
-            {
-                if (context.QueryType is not QueryTypes.Aggregation || !field.StartsWith("@"))
-                    validationResult.UnresolvedFields.Add(field);
-            }
 
             return resolvedField;
         });
@@ -144,7 +132,7 @@ public class ElasticQueryParser : LuceneQueryParser
         }
     }
 
-    private async Task<string?> MappingFieldResolver(string? field, IQueryVisitorContext? context)
+    internal static async Task<string?> ResolveMappingFieldAsync(string? field, IQueryVisitorContext? context)
     {
         if (field is null)
             return null;

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParser.cs
@@ -156,7 +156,7 @@ public class ElasticQueryParser : LuceneQueryParser
 
         if (elasticContext.MappingResolver is not null)
         {
-            var resolvedField = await elasticContext.MappingResolver.GetMappingAsync(field).ConfigureAwait(false);
+            var resolvedField = await elasticContext.MappingResolver.GetMappingAsync(field).AnyContext();
             if (resolvedField?.Found is true)
                 return resolvedField.FullPath;
         }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -78,6 +78,8 @@ public class ElasticQueryParserConfiguration
     {
         FieldResolver = resolver;
         ReplaceVisitor<FieldResolverQueryVisitor>(new FieldResolverQueryVisitor(resolver), priority);
+        // Equal priorities preserve insertion order, so mapping validation follows the replacement resolver.
+        ReplaceVisitor<MappingValidationVisitor>(new MappingValidationVisitor(), Math.Max(20, priority));
 
         return this;
     }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -42,6 +42,7 @@ public class ElasticQueryParserConfiguration
         AddAggregationVisitor(new AssignOperationTypeVisitor(), 0);
         AddAggregationVisitor(new CombineAggregationsVisitor(), 10000);
         AddVisitor(new FieldResolverQueryVisitor((field, context) => FieldResolver is not null ? FieldResolver(field, context) : Task.FromResult<string?>(null)), 10);
+        AddVisitor(new MappingValidationVisitor(), 20);
         AddVisitor(new ValidationVisitor(), 30);
     }
 
@@ -332,6 +333,8 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
+    /// <summary>Uses code mappings and an asynchronous server loader for field resolution.</summary>
+    /// <remarks>The application owns <see cref="MappingResolver"/> and should dispose it when no longer used. The loader must enforce a finite timeout.</remarks>
     public ElasticQueryParserConfiguration UseMappingsWithAsyncLoader<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, Inferrer inferrer,
         Func<CancellationToken, Task<TypeMapping?>> getMappingAsync) where T : class
     {
@@ -361,6 +364,8 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
+    /// <summary>Uses an asynchronous server loader for field resolution.</summary>
+    /// <remarks>The application owns <see cref="MappingResolver"/>. Its lifetime token cancels shared loads; an individual lookup's token cancels only that wait.</remarks>
     public ElasticQueryParserConfiguration UseMappingsWithAsyncLoader(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null)
     {
         MappingResolver = ElasticMappingResolver.CreateWithAsyncLoader(getMappingAsync, inferrer, logger: _logger);

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Mapping;
@@ -331,6 +332,14 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
+    public ElasticQueryParserConfiguration UseMappings<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, Inferrer inferrer,
+        Func<CancellationToken, Task<TypeMapping?>> getMappingAsync) where T : class
+    {
+        MappingResolver = ElasticMappingResolver.Create(mappingBuilder, inferrer, getMappingAsync, logger: _logger);
+
+        return this;
+    }
+
     public ElasticQueryParserConfiguration UseMappings<T>(ElasticsearchClient client)
     {
         MappingResolver = ElasticMappingResolver.Create<T>(client, logger: _logger);
@@ -348,6 +357,13 @@ public class ElasticQueryParserConfiguration
     public ElasticQueryParserConfiguration UseMappings(Func<TypeMapping?> getMapping, Inferrer? inferrer = null)
     {
         MappingResolver = ElasticMappingResolver.Create(getMapping, inferrer, logger: _logger);
+
+        return this;
+    }
+
+    public ElasticQueryParserConfiguration UseMappings(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null)
+    {
+        MappingResolver = ElasticMappingResolver.Create(getMappingAsync, inferrer, logger: _logger);
 
         return this;
     }

--- a/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/ElasticQueryParserConfiguration.cs
@@ -332,10 +332,10 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    public ElasticQueryParserConfiguration UseMappings<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, Inferrer inferrer,
+    public ElasticQueryParserConfiguration UseMappingsWithAsyncLoader<T>(Action<TypeMappingDescriptor<T>> mappingBuilder, Inferrer inferrer,
         Func<CancellationToken, Task<TypeMapping?>> getMappingAsync) where T : class
     {
-        MappingResolver = ElasticMappingResolver.Create(mappingBuilder, inferrer, getMappingAsync, logger: _logger);
+        MappingResolver = ElasticMappingResolver.CreateWithAsyncLoader(mappingBuilder, inferrer, getMappingAsync, logger: _logger);
 
         return this;
     }
@@ -361,9 +361,9 @@ public class ElasticQueryParserConfiguration
         return this;
     }
 
-    public ElasticQueryParserConfiguration UseMappings(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null)
+    public ElasticQueryParserConfiguration UseMappingsWithAsyncLoader(Func<CancellationToken, Task<TypeMapping?>> getMappingAsync, Inferrer? inferrer = null)
     {
-        MappingResolver = ElasticMappingResolver.Create(getMappingAsync, inferrer, logger: _logger);
+        MappingResolver = ElasticMappingResolver.CreateWithAsyncLoader(getMappingAsync, inferrer, logger: _logger);
 
         return this;
     }

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -56,11 +56,13 @@ public static class DefaultAggregationNodeExtensions
         if (!node.HasParens || String.IsNullOrEmpty(node.Field) || node.Left is not null)
             return null;
 
-        string? field = elasticContext.MappingResolver.GetAggregationsFieldName(node.UnescapedField);
+        var mapping = await context.GetMappingResultAsync(node.UnescapedField).AnyContext();
+        string? field = elasticContext.MappingResolver.GetNonAnalyzedFieldName(
+            node.UnescapedField, mapping, ElasticMapping.KeywordFieldName);
         if (field is null)
             return null;
 
-        var property = elasticContext.MappingResolver.GetMappingProperty(field, true);
+        var property = (await context.GetMappingResultAsync(field).AnyContext())?.Property;
         string? originalField = node.GetOriginalField().Unescape();
 
         switch (node.GetOperationType())
@@ -123,11 +125,13 @@ public static class DefaultAggregationNodeExtensions
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        string? aggField = elasticContext.MappingResolver.GetAggregationsFieldName(node.UnescapedField);
+        var mapping = await context.GetMappingResultAsync(node.UnescapedField).AnyContext();
+        string? aggField = elasticContext.MappingResolver.GetNonAnalyzedFieldName(
+            node.UnescapedField, mapping, ElasticMapping.KeywordFieldName);
         if (aggField is null)
             return null;
 
-        var property = elasticContext.MappingResolver.GetMappingProperty(node.UnescapedField, true);
+        var property = mapping?.Property;
         string? timezone = !String.IsNullOrWhiteSpace(node.UnescapedBoost) ? node.UnescapedBoost : node.GetTimeZone(await elasticContext.GetTimeZoneAsync().AnyContext());
         string? originalField = node.GetOriginalField().Unescape();
 

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultAggregationNodeExtensions.cs
@@ -56,6 +56,7 @@ public static class DefaultAggregationNodeExtensions
         if (!node.HasParens || String.IsNullOrEmpty(node.Field) || node.Left is not null)
             return null;
 
+        using var mappingScope = context.BeginMappingScope();
         var mapping = await context.GetMappingResultAsync(node.UnescapedField).AnyContext();
         string? field = elasticContext.MappingResolver.GetNonAnalyzedFieldName(
             node.UnescapedField, mapping, ElasticMapping.KeywordFieldName);

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -38,18 +38,21 @@ public static class DefaultQueryNodeExtensions
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
+        using var mappingScope = context.BeginMappingScope();
         string? field = node.UnescapedField;
         string[]? defaultFields = node.GetDefaultFields(elasticContext.DefaultFields);
 
-        if (String.IsNullOrEmpty(field) && defaultFields is not null)
+        if (!String.IsNullOrEmpty(field))
+        {
+            await context.GetMappingResultAsync(field).AnyContext();
+            return GetSingleFieldQuery(node, field, elasticContext);
+        }
+
+        if (defaultFields is not null)
         {
             foreach (string defaultField in defaultFields)
                 await context.GetMappingResultAsync(defaultField).AnyContext();
         }
-
-        // If a specific field is set, use single-field query
-        if (!String.IsNullOrEmpty(field))
-            return GetSingleFieldQuery(node, field, elasticContext);
 
         // If only one default field, use single-field query (wrapped in nested if applicable)
         if (defaultFields is { Length: 1 })

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Mapping;
@@ -18,7 +19,7 @@ public static class DefaultQueryNodeExtensions
     public static async Task<Query?> GetDefaultQueryAsync(this IQueryNode node, IQueryVisitorContext context)
     {
         if (node is TermNode termNode)
-            return await termNode.GetDefaultQueryAsync(context).ConfigureAwait(false);
+            return await termNode.GetDefaultQueryAsync(context).AnyContext();
 
         if (node is TermRangeNode termRangeNode)
             return await termRangeNode.GetDefaultQueryAsync(context).AnyContext();
@@ -43,7 +44,7 @@ public static class DefaultQueryNodeExtensions
         if (String.IsNullOrEmpty(field) && defaultFields is not null)
         {
             foreach (string defaultField in defaultFields)
-                await elasticContext.MappingResolver.GetMappingAsync(defaultField).ConfigureAwait(false);
+                await elasticContext.MappingResolver.GetMappingAsync(defaultField).AnyContext();
         }
 
         // If a specific field is set, use single-field query
@@ -64,7 +65,7 @@ public static class DefaultQueryNodeExtensions
                 var filterResolver = GetNestedFilterResolver(elasticContext);
                 if (filterResolver is not null)
                 {
-                    var filter = await filterResolver(nestedPath, defaultFields[0], defaultFields[0], context).ConfigureAwait(false);
+                    var filter = await filterResolver(nestedPath, defaultFields[0], defaultFields[0], context).AnyContext();
                     if (filter is not null)
                         innerQuery = new BoolQuery { Must = [innerQuery], Filter = [filter] };
                 }
@@ -87,7 +88,7 @@ public static class DefaultQueryNodeExtensions
             }
 
             // Otherwise, split into separate queries for each group
-            return await GetSplitNestedQueryAsync(node, fieldsByNestedPath, elasticContext).ConfigureAwait(false);
+            return await GetSplitNestedQueryAsync(node, fieldsByNestedPath, elasticContext).AnyContext();
         }
 
         // Fallback for no fields
@@ -100,7 +101,10 @@ public static class DefaultQueryNodeExtensions
     [Obsolete("Use GetDefaultQueryAsync to support async nested filter resolution.")]
     public static Query? GetDefaultQuery(this TermNode node, IQueryVisitorContext context)
     {
-        return GetDefaultQueryAsync(node, context).ConfigureAwait(false).GetAwaiter().GetResult();
+        if (SynchronizationContext.Current is not null || TaskScheduler.Current != TaskScheduler.Default)
+            return Task.Run(() => GetDefaultQueryAsync(node, context)).GetAwaiter().GetResult();
+
+        return GetDefaultQueryAsync(node, context).AnyContext().GetAwaiter().GetResult();
     }
 
     private static Query? GetSingleFieldQuery(TermNode node, string field, IElasticQueryVisitorContext context)
@@ -285,7 +289,7 @@ public static class DefaultQueryNodeExtensions
                             continue;
 
                         Query branch = q;
-                        var filter = await filterResolver(nestedPath, field, field, context).ConfigureAwait(false);
+                        var filter = await filterResolver(nestedPath, field, field, context).AnyContext();
                         if (filter is not null)
                             branch = new BoolQuery { Must = [branch], Filter = [filter] };
                         branches.Add(branch);

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -44,7 +44,7 @@ public static class DefaultQueryNodeExtensions
         if (String.IsNullOrEmpty(field) && defaultFields is not null)
         {
             foreach (string defaultField in defaultFields)
-                await elasticContext.MappingResolver.GetMappingAsync(defaultField).AnyContext();
+                await context.GetMappingResultAsync(defaultField).AnyContext();
         }
 
         // If a specific field is set, use single-field query
@@ -109,7 +109,7 @@ public static class DefaultQueryNodeExtensions
 
     private static Query? GetSingleFieldQuery(TermNode node, string field, IElasticQueryVisitorContext context)
     {
-        if (context.MappingResolver.IsPropertyAnalyzed(field))
+        if (IsPropertyAnalyzed(field, context))
         {
             if (node.UnescapedTerm is not { } term)
                 return null;
@@ -144,7 +144,7 @@ public static class DefaultQueryNodeExtensions
 
     private static FieldValue GetTypedFieldValue(string value, string field, IElasticQueryVisitorContext context)
     {
-        var fieldType = context.MappingResolver.GetFieldType(field);
+        var fieldType = ElasticMappingResolver.GetFieldType(context.GetMappingResult(field)?.Property);
 
         return fieldType switch
         {
@@ -177,7 +177,7 @@ public static class DefaultQueryNodeExtensions
 
         foreach (string field in fields)
         {
-            if (context.MappingResolver.IsPropertyAnalyzed(field))
+            if (IsPropertyAnalyzed(field, context))
                 analyzedFields.Add(field);
             else
                 nonAnalyzedFields.Add(field);
@@ -266,7 +266,13 @@ public static class DefaultQueryNodeExtensions
 
     private static string? GetNestedPath(string fullName, IElasticQueryVisitorContext context)
     {
-        return NestedPathResolver.GetDeepestNestedPath(fullName, context.MappingResolver);
+        return NestedPathResolver.GetDeepestNestedPath(fullName, context);
+    }
+
+    private static bool IsPropertyAnalyzed(string field, IElasticQueryVisitorContext context)
+    {
+        var mapping = context.GetMappingResult(field);
+        return mapping?.Found is true && context.MappingResolver.IsPropertyAnalyzed(mapping.Property!);
     }
 
     private static async Task<Query> GetSplitNestedQueryAsync(TermNode node, Dictionary<string, List<string>> fieldsByNestedPath, IElasticQueryVisitorContext context)
@@ -362,7 +368,8 @@ public static class DefaultQueryNodeExtensions
                 return null;
         }
 
-        if (elasticContext.MappingResolver.IsDatePropertyType(field))
+        var mapping = await context.GetMappingResultAsync(field).AnyContext();
+        if (mapping?.Property is DateProperty or DateNanosProperty)
         {
             var range = new DateRangeQuery(field) { TimeZone = node.Boost ?? node.GetTimeZone(await elasticContext.GetTimeZoneAsync().AnyContext()) };
             if (!String.IsNullOrWhiteSpace(node.UnescapedMin) && node.UnescapedMin != "*")

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultQueryNodeExtensions.cs
@@ -40,6 +40,12 @@ public static class DefaultQueryNodeExtensions
         string? field = node.UnescapedField;
         string[]? defaultFields = node.GetDefaultFields(elasticContext.DefaultFields);
 
+        if (String.IsNullOrEmpty(field) && defaultFields is not null)
+        {
+            foreach (string defaultField in defaultFields)
+                await elasticContext.MappingResolver.GetMappingAsync(defaultField).ConfigureAwait(false);
+        }
+
         // If a specific field is set, use single-field query
         if (!String.IsNullOrEmpty(field))
             return GetSingleFieldQuery(node, field, elasticContext);

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
@@ -19,17 +19,22 @@ public static class DefaultSortNodeExtensions
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
+        using var mappingScope = context.BeginMappingScope();
         var mapping = context.GetMappingResult(node.UnescapedField);
         return GetDefaultSort(node, context, elasticContext, mapping);
     }
 
-    internal static async Task<SortOptions> GetDefaultSortAsync(this TermNode node, IQueryVisitorContext context)
+    internal static async ValueTask PrepareSortMappingAsync(this TermNode node, IQueryVisitorContext context)
     {
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
         var mapping = await context.GetMappingResultAsync(node.UnescapedField).AnyContext();
-        return GetDefaultSort(node, context, elasticContext, mapping);
+        string? field = elasticContext.MappingResolver.GetNonAnalyzedFieldName(
+            node.UnescapedField, mapping, ElasticMapping.SortFieldName);
+        await context.GetMappingResultAsync(field).AnyContext();
+        if (node.GetNestedPath() is { } nestedPath)
+            await context.GetMappingResultAsync(nestedPath).AnyContext();
     }
 
     private static SortOptions GetDefaultSort(TermNode node, IQueryVisitorContext visitorContext,

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/DefaultSortNodeExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Mapping;
 using Elastic.Clients.Elasticsearch.QueryDsl;
@@ -18,8 +19,25 @@ public static class DefaultSortNodeExtensions
         if (context is not IElasticQueryVisitorContext elasticContext)
             throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
 
-        string? field = elasticContext.MappingResolver.GetSortFieldName(node.UnescapedField);
-        var fieldType = elasticContext.MappingResolver.GetFieldType(field);
+        var mapping = context.GetMappingResult(node.UnescapedField);
+        return GetDefaultSort(node, context, elasticContext, mapping);
+    }
+
+    internal static async Task<SortOptions> GetDefaultSortAsync(this TermNode node, IQueryVisitorContext context)
+    {
+        if (context is not IElasticQueryVisitorContext elasticContext)
+            throw new ArgumentException("Context must be of type IElasticQueryVisitorContext", nameof(context));
+
+        var mapping = await context.GetMappingResultAsync(node.UnescapedField).AnyContext();
+        return GetDefaultSort(node, context, elasticContext, mapping);
+    }
+
+    private static SortOptions GetDefaultSort(TermNode node, IQueryVisitorContext visitorContext,
+        IElasticQueryVisitorContext elasticContext, FieldMapping? mapping)
+    {
+        string? field = elasticContext.MappingResolver.GetNonAnalyzedFieldName(
+            node.UnescapedField, mapping, ElasticMapping.SortFieldName);
+        var fieldType = ElasticMappingResolver.GetFieldType(visitorContext.GetMappingResult(field)?.Property);
 
         if (fieldType == FieldType.GeoPoint && !String.IsNullOrEmpty(node.UnescapedTerm))
             return GetGeoDistanceSort(node, elasticContext, field!)!;
@@ -33,7 +51,7 @@ public static class DefaultSortNodeExtensions
         string? nestedPath = node.GetNestedPath();
         if (nestedPath is not null)
         {
-            fieldSort.Nested = BuildHierarchicalNestedSort(nestedPath, node.GetNestedFilter(), elasticContext);
+            fieldSort.Nested = BuildHierarchicalNestedSort(nestedPath, node.GetNestedFilter(), visitorContext);
         }
 
         return new SortOptions
@@ -78,9 +96,9 @@ public static class DefaultSortNodeExtensions
     }
 
     private static NestedSortValue BuildHierarchicalNestedSort(
-        string deepestPath, Query? filter, IElasticQueryVisitorContext context)
+        string deepestPath, Query? filter, IQueryVisitorContext context)
     {
-        var nestedPaths = NestedPathResolver.GetNestedPathChain(deepestPath, context.MappingResolver);
+        var nestedPaths = NestedPathResolver.GetNestedPathChain(deepestPath, context);
 
         if (nestedPaths.Count <= 1)
         {

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
@@ -104,8 +104,10 @@ public static class QueryVisitorContextExtensions
 
     private sealed class MappingResults
     {
+        private Dictionary<string, Task<ElasticRuntimeField?>>? _runtimeFields;
+
         public Dictionary<string, MappingResult> Fields { get; } = new(StringComparer.Ordinal);
-        public Dictionary<string, Task<ElasticRuntimeField?>> RuntimeFields { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, Task<ElasticRuntimeField?>> RuntimeFields => _runtimeFields ??= new(StringComparer.Ordinal);
     }
 
     private static MappingResults? GetMappingResults(IQueryVisitorContext context)

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
@@ -14,18 +14,21 @@ public static class QueryVisitorContextExtensions
 {
     private const string MappingResultsKey = "@MappingResults";
 
-    internal static void ResetMappingResults(this IQueryVisitorContext context)
+    internal static MappingResultScope BeginMappingScope(this IQueryVisitorContext context)
     {
-        context.Data[MappingResultsKey] = new Dictionary<string, MappingResult>(StringComparer.OrdinalIgnoreCase);
+        if (GetMappingResults(context) is not null)
+            return default;
+
+        context.Data[MappingResultsKey] = new Dictionary<string, MappingResult>(StringComparer.Ordinal);
+        return new MappingResultScope(context);
     }
 
     internal static void SetMappingResult(this IQueryVisitorContext context, string requestedField, FieldMapping? mapping,
         string? resolvedField = null)
     {
-        if (mapping is null)
+        if (mapping is null || GetMappingResults(context) is not { } mappings)
             return;
 
-        var mappings = GetMappingResults(context);
         mappings[requestedField] = new MappingResult(mapping, resolvedField ?? mapping.FullPath);
         mappings[mapping.FullPath] = new MappingResult(mapping, mapping.FullPath);
         if (!String.IsNullOrEmpty(resolvedField))
@@ -35,7 +38,8 @@ public static class QueryVisitorContextExtensions
     internal static bool TryGetMappingResult(this IQueryVisitorContext context, string? field, out FieldMapping? mapping)
     {
         mapping = null;
-        if (String.IsNullOrEmpty(field) || !GetMappingResults(context).TryGetValue(field, out var result))
+        if (String.IsNullOrEmpty(field) || GetMappingResults(context) is not { } mappings
+            || !mappings.TryGetValue(field, out var result))
             return false;
 
         mapping = result.Mapping;
@@ -44,7 +48,7 @@ public static class QueryVisitorContextExtensions
 
     internal static bool TryGetResolvedMappingField(this IQueryVisitorContext context, string field, out string? resolvedField)
     {
-        if (GetMappingResults(context).TryGetValue(field, out var result))
+        if (GetMappingResults(context) is { } mappings && mappings.TryGetValue(field, out var result))
         {
             resolvedField = result.ResolvedField;
             return true;
@@ -81,7 +85,7 @@ public static class QueryVisitorContextExtensions
         return mapping;
     }
 
-    private static Dictionary<string, MappingResult> GetMappingResults(IQueryVisitorContext context)
+    private static Dictionary<string, MappingResult>? GetMappingResults(IQueryVisitorContext context)
     {
         if (context.Data.TryGetValue(MappingResultsKey, out object? value)
             && value is Dictionary<string, MappingResult> mappings)
@@ -89,9 +93,13 @@ public static class QueryVisitorContextExtensions
             return mappings;
         }
 
-        mappings = new Dictionary<string, MappingResult>(StringComparer.OrdinalIgnoreCase);
-        context.Data[MappingResultsKey] = mappings;
-        return mappings;
+        return null;
+    }
+
+    // Nested calls share results; only the operation that created the cache removes it.
+    internal readonly struct MappingResultScope(IQueryVisitorContext? context) : IDisposable
+    {
+        public void Dispose() => context?.Data.Remove(MappingResultsKey);
     }
 
     private readonly record struct MappingResult(FieldMapping Mapping, string ResolvedField);

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
@@ -19,7 +19,7 @@ public static class QueryVisitorContextExtensions
         if (GetMappingResults(context) is not null)
             return default;
 
-        context.Data[MappingResultsKey] = new Dictionary<string, MappingResult>(StringComparer.Ordinal);
+        context.Data[MappingResultsKey] = new MappingResults();
         return new MappingResultScope(context);
     }
 
@@ -29,17 +29,17 @@ public static class QueryVisitorContextExtensions
         if (mapping is null || GetMappingResults(context) is not { } mappings)
             return;
 
-        mappings[requestedField] = new MappingResult(mapping, resolvedField ?? mapping.FullPath);
-        mappings[mapping.FullPath] = new MappingResult(mapping, mapping.FullPath);
+        mappings.Fields[requestedField] = new MappingResult(mapping, resolvedField ?? mapping.FullPath);
+        mappings.Fields[mapping.FullPath] = new MappingResult(mapping, mapping.FullPath);
         if (!String.IsNullOrEmpty(resolvedField))
-            mappings[resolvedField] = new MappingResult(mapping, resolvedField);
+            mappings.Fields[resolvedField] = new MappingResult(mapping, resolvedField);
     }
 
     internal static bool TryGetMappingResult(this IQueryVisitorContext context, string? field, out FieldMapping? mapping)
     {
         mapping = null;
         if (String.IsNullOrEmpty(field) || GetMappingResults(context) is not { } mappings
-            || !mappings.TryGetValue(field, out var result))
+            || !mappings.Fields.TryGetValue(field, out var result))
             return false;
 
         mapping = result.Mapping;
@@ -48,7 +48,7 @@ public static class QueryVisitorContextExtensions
 
     internal static bool TryGetResolvedMappingField(this IQueryVisitorContext context, string field, out string? resolvedField)
     {
-        if (GetMappingResults(context) is { } mappings && mappings.TryGetValue(field, out var result))
+        if (GetMappingResults(context) is { } mappings && mappings.Fields.TryGetValue(field, out var result))
         {
             resolvedField = result.ResolvedField;
             return true;
@@ -85,10 +85,33 @@ public static class QueryVisitorContextExtensions
         return mapping;
     }
 
-    private static Dictionary<string, MappingResult>? GetMappingResults(IQueryVisitorContext context)
+    internal static Task<ElasticRuntimeField?> GetRuntimeFieldAsync(this IQueryVisitorContext context, string field, RuntimeFieldResolver resolver)
+    {
+        var results = GetMappingResults(context);
+        if (results is null)
+            return ResolveAsync();
+
+        if (!results.RuntimeFields.TryGetValue(field, out var result))
+        {
+            result = ResolveAsync();
+            results.RuntimeFields[field] = result;
+        }
+
+        return result;
+
+        async Task<ElasticRuntimeField?> ResolveAsync() => await resolver(field).AnyContext();
+    }
+
+    private sealed class MappingResults
+    {
+        public Dictionary<string, MappingResult> Fields { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, Task<ElasticRuntimeField?>> RuntimeFields { get; } = new(StringComparer.Ordinal);
+    }
+
+    private static MappingResults? GetMappingResults(IQueryVisitorContext context)
     {
         if (context.Data.TryGetValue(MappingResultsKey, out object? value)
-            && value is Dictionary<string, MappingResult> mappings)
+            && value is MappingResults mappings)
         {
             return mappings;
         }

--- a/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Extensions/QueryVisitorContextExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch.QueryDsl;
 using Foundatio.Parsers.ElasticQueries.Visitors;
@@ -10,6 +12,90 @@ namespace Foundatio.Parsers.ElasticQueries.Extensions;
 
 public static class QueryVisitorContextExtensions
 {
+    private const string MappingResultsKey = "@MappingResults";
+
+    internal static void ResetMappingResults(this IQueryVisitorContext context)
+    {
+        context.Data[MappingResultsKey] = new Dictionary<string, MappingResult>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal static void SetMappingResult(this IQueryVisitorContext context, string requestedField, FieldMapping? mapping,
+        string? resolvedField = null)
+    {
+        if (mapping is null)
+            return;
+
+        var mappings = GetMappingResults(context);
+        mappings[requestedField] = new MappingResult(mapping, resolvedField ?? mapping.FullPath);
+        mappings[mapping.FullPath] = new MappingResult(mapping, mapping.FullPath);
+        if (!String.IsNullOrEmpty(resolvedField))
+            mappings[resolvedField] = new MappingResult(mapping, resolvedField);
+    }
+
+    internal static bool TryGetMappingResult(this IQueryVisitorContext context, string? field, out FieldMapping? mapping)
+    {
+        mapping = null;
+        if (String.IsNullOrEmpty(field) || !GetMappingResults(context).TryGetValue(field, out var result))
+            return false;
+
+        mapping = result.Mapping;
+        return true;
+    }
+
+    internal static bool TryGetResolvedMappingField(this IQueryVisitorContext context, string field, out string? resolvedField)
+    {
+        if (GetMappingResults(context).TryGetValue(field, out var result))
+        {
+            resolvedField = result.ResolvedField;
+            return true;
+        }
+
+        resolvedField = null;
+        return false;
+    }
+
+    internal static FieldMapping? GetMappingResult(this IQueryVisitorContext context, string? field)
+    {
+        if (String.IsNullOrEmpty(field))
+            return null;
+
+        if (context.TryGetMappingResult(field, out var mapping))
+            return mapping;
+
+        mapping = context.GetMappingResolver().GetMapping(field, followAlias: true);
+        context.SetMappingResult(field, mapping);
+        return mapping;
+    }
+
+    internal static async ValueTask<FieldMapping?> GetMappingResultAsync(this IQueryVisitorContext context, string? field,
+        CancellationToken cancellationToken = default)
+    {
+        if (String.IsNullOrEmpty(field))
+            return null;
+
+        if (context.TryGetMappingResult(field, out var mapping))
+            return mapping;
+
+        mapping = await context.GetMappingResolver().GetMappingAsync(field, followAlias: true, cancellationToken).AnyContext();
+        context.SetMappingResult(field, mapping);
+        return mapping;
+    }
+
+    private static Dictionary<string, MappingResult> GetMappingResults(IQueryVisitorContext context)
+    {
+        if (context.Data.TryGetValue(MappingResultsKey, out object? value)
+            && value is Dictionary<string, MappingResult> mappings)
+        {
+            return mappings;
+        }
+
+        mappings = new Dictionary<string, MappingResult>(StringComparer.OrdinalIgnoreCase);
+        context.Data[MappingResultsKey] = mappings;
+        return mappings;
+    }
+
+    private readonly record struct MappingResult(FieldMapping Mapping, string ResolvedField);
+
     public static bool? IsRuntimeFieldResolverEnabled<T>(this T context) where T : IQueryVisitorContext
     {
         if (context is not IElasticQueryVisitorContext elasticContext)

--- a/src/Foundatio.Parsers.ElasticQueries/FieldMapping.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/FieldMapping.cs
@@ -7,20 +7,26 @@ namespace Foundatio.Parsers.ElasticQueries;
 public class FieldMapping
 {
     public FieldMapping(string path, IProperty? property, DateTime? serverMapTime, long epoch = 0)
-        : this(path, property, (MergedProperties?)null)
+        : this(path, property, null, null)
     {
     }
 
     internal FieldMapping(string path, IProperty? property)
-        : this(path, property, (MergedProperties?)null)
+        : this(path, property, null, null)
     {
     }
 
     internal FieldMapping(string path, IProperty? property, MergedProperties? children)
+        : this(path, property, children, null)
+    {
+    }
+
+    internal FieldMapping(string path, IProperty? property, MergedProperties? children, IReadOnlyList<string>? nestedPathChain)
     {
         FullPath = path;
         Property = property;
         Children = children;
+        NestedPathChain = nestedPathChain ?? Array.Empty<string>();
     }
 
     public bool Found => Property is not null;
@@ -33,6 +39,10 @@ public class FieldMapping
     /// not have to walk the mapping again.
     /// </summary>
     internal MergedProperties? Children { get; }
+
+    /// <summary>Nested ancestors encountered while resolving <see cref="FullPath"/>, outermost first.</summary>
+    internal IReadOnlyList<string> NestedPathChain { get; }
+
 }
 
 /// <summary>A name-indexed merged view of the code and server properties at one mapping level.</summary>

--- a/src/Foundatio.Parsers.ElasticQueries/FieldMapping.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/FieldMapping.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using Elastic.Clients.Elasticsearch.Mapping;
+
+namespace Foundatio.Parsers.ElasticQueries;
+
+public class FieldMapping
+{
+    public FieldMapping(string path, IProperty? property, DateTime? serverMapTime, long epoch = 0)
+        : this(path, property, (MergedProperties?)null)
+    {
+    }
+
+    internal FieldMapping(string path, IProperty? property)
+        : this(path, property, (MergedProperties?)null)
+    {
+    }
+
+    internal FieldMapping(string path, IProperty? property, MergedProperties? children)
+    {
+        FullPath = path;
+        Property = property;
+        Children = children;
+    }
+
+    public bool Found => Property is not null;
+    public string FullPath { get; private set; }
+    public IProperty? Property { get; private set; }
+    public DateTime Date { get; private set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Merged sub-objects and multi-fields of this field, captured during resolution so sub-field lookups do
+    /// not have to walk the mapping again.
+    /// </summary>
+    internal MergedProperties? Children { get; }
+}
+
+/// <summary>A name-indexed merged view of the code and server properties at one mapping level.</summary>
+internal sealed class MergedProperties
+{
+    private readonly IReadOnlyList<MergedNode> _nodes;
+    private readonly Dictionary<string, MergedNode> _byExactName;
+    private readonly Dictionary<string, MergedNode> _byIgnoreCaseName;
+
+    public MergedProperties(IReadOnlyList<MergedNode> nodes)
+    {
+        _nodes = nodes;
+        _byExactName = new Dictionary<string, MergedNode>(nodes.Count, StringComparer.Ordinal);
+        _byIgnoreCaseName = new Dictionary<string, MergedNode>(nodes.Count, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var node in nodes)
+        {
+            _byExactName[node.Name] = node;
+            _byIgnoreCaseName.TryAdd(node.Name, node);
+        }
+    }
+
+    public int Count => _nodes.Count;
+
+    public IReadOnlyList<MergedNode> Nodes => _nodes;
+
+    public bool TryGetNode(string name, out MergedNode node)
+    {
+        return _byExactName.TryGetValue(name, out node!) || _byIgnoreCaseName.TryGetValue(name, out node!);
+    }
+}
+
+/// <summary>A canonical property and the merged children reachable through its field name.</summary>
+internal sealed class MergedNode
+{
+    public MergedNode(string name, IProperty property, MergedProperties? children)
+    {
+        Name = name;
+        Property = property;
+        Children = children;
+    }
+
+    public string Name { get; }
+
+    public IProperty Property { get; }
+
+    public MergedProperties? Children { get; }
+}

--- a/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Elastic.Clients.Elasticsearch.Mapping;
+using Microsoft.Extensions.Logging;
+
+namespace Foundatio.Parsers.ElasticQueries;
+
+/// <summary>
+/// Owns the loaded server mapping and everything derived from it: when to reload, how reloads are coalesced,
+/// and the per-field resolutions cached against each loaded mapping.
+/// </summary>
+/// <remarks>
+/// Split out of <see cref="ElasticMappingResolver"/> so that refresh policy can be reasoned about (and
+/// tested) independently of field name resolution. The resolver asks two questions — "what is the current
+/// mapping?" and "the field was not in it, is there a newer one?" — and this type answers both.
+/// </remarks>
+internal sealed class MappingCache : IDisposable
+{
+    private readonly Func<TypeMapping?>? _getServerMapping;
+    private readonly Func<TypeMapping?, Properties?> _mergeProperties;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger _logger;
+
+    private readonly ConcurrentDictionary<string, FieldMapping> _fields = new(StringComparer.Ordinal);
+    private readonly SemaphoreSlim _refreshSemaphore = new(1, 1);
+    private readonly object _publishLock = new();
+
+    private MappingSnapshot _snapshot;
+    private long _snapshotVersion;
+    private long _resetVersion;
+    private long _cachedFieldCount;
+    private long _lastRefreshTimestamp;
+    private long _lastUnmappedRefreshTimestamp;
+    private long _unmappedRefreshBackoffTicks;
+    private long _backoffAppliedForVersion;
+    private long _lastSuppressedRefreshWarningTimestamp;
+    private volatile bool _disposed;
+
+    public MappingCache(Func<TypeMapping?>? getServerMapping, Func<TypeMapping?, Properties?> mergeProperties, TimeProvider timeProvider, ILogger logger)
+    {
+        _getServerMapping = getServerMapping;
+        _mergeProperties = mergeProperties;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _snapshot = CreateSnapshot(null, fetched: false);
+    }
+
+    public TimeSpan RefreshInterval { get; set; } = TimeSpan.FromMinutes(1);
+
+    public TimeSpan UnmappedFieldRefreshInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    public TimeSpan RefreshWaitTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    public int MaxCachedFields { get; set; } = 10000;
+
+    public bool HasServerMappingFunc => _getServerMapping is not null;
+
+    public long CachedFieldCount => Interlocked.Read(ref _cachedFieldCount);
+
+    /// <summary>The currently published mapping. Never null; read without locking.</summary>
+    public MappingSnapshot Current => Volatile.Read(ref _snapshot);
+
+    /// <summary>
+    /// Discards the loaded mapping and every field resolved from it, and clears all refresh throttles so the
+    /// next resolution fetches immediately.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_publishLock)
+        {
+            Interlocked.Increment(ref _resetVersion);
+            ClearFields();
+            Volatile.Write(ref _snapshot, CreateSnapshot(null, fetched: false));
+            Interlocked.Exchange(ref _lastRefreshTimestamp, 0);
+            Interlocked.Exchange(ref _lastUnmappedRefreshTimestamp, 0);
+            Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
+        }
+    }
+
+    /// <summary>
+    /// Drops the cached resolution for a single field and clears the unmapped field throttle so the next
+    /// resolution of any unmapped field can refresh immediately.
+    /// </summary>
+    public void InvalidateField(string field)
+    {
+        if (_fields.TryRemove(field, out _))
+            Interlocked.Decrement(ref _cachedFieldCount);
+
+        Interlocked.Exchange(ref _lastUnmappedRefreshTimestamp, 0);
+        Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
+    }
+
+    public bool TryGetField(string field, MappingSnapshot snapshot, out FieldMapping mapping)
+    {
+        return _fields.TryGetValue(field, out mapping!) && mapping.Epoch == snapshot.Version;
+    }
+
+    /// <summary>
+    /// Caches a field resolution, dropping it if the mapping it was resolved against has since been replaced.
+    /// </summary>
+    public void CacheField(string field, FieldMapping mapping, long snapshotVersion)
+    {
+        int maxCachedFields = MaxCachedFields;
+        if (maxCachedFields <= 0)
+            return;
+
+        // Do not publish a resolution that was made against a mapping which has already been replaced.
+        if (Current.Version != snapshotVersion)
+            return;
+
+        if (Interlocked.Read(ref _cachedFieldCount) >= maxCachedFields && !_fields.ContainsKey(field) && !TryMakeRoom(maxCachedFields))
+            return;
+
+        if (_fields.TryAdd(field, mapping))
+        {
+            Interlocked.Increment(ref _cachedFieldCount);
+            return;
+        }
+
+        _fields.AddOrUpdate(field, mapping, (_, existing) => existing.Epoch > mapping.Epoch ? existing : mapping);
+    }
+
+    /// <summary>
+    /// Evicts cached misses to make room for a new entry. Field names come from user supplied queries, so
+    /// the unbounded growth vector is names that do not exist in the mapping; resolved fields are bounded by
+    /// the size of the mapping itself. Evicting misses first therefore sheds exactly the entries an abusive
+    /// caller can create without discarding the resolutions real queries depend on.
+    /// </summary>
+    /// <returns>True if there is now room for another entry.</returns>
+    private bool TryMakeRoom(int maxCachedFields)
+    {
+        int removed = 0;
+        foreach (var entry in _fields)
+        {
+            if (entry.Value.Found)
+                continue;
+
+            if (_fields.TryRemove(entry.Key, out _))
+            {
+                Interlocked.Decrement(ref _cachedFieldCount);
+                removed++;
+            }
+        }
+
+        if (removed > 0)
+        {
+            _logger.LogDebug("Evicted {RemovedCount} unresolved field names from the mapping cache after reaching {MaxCachedFields} entries", removed, maxCachedFields);
+            return true;
+        }
+
+        // Every entry is a resolved field, so the mapping genuinely has more fields than the cache allows.
+        // Stop adding rather than clearing: the entries already cached are the useful ones, and fields past
+        // the bound still resolve correctly, just without caching.
+        if (ShouldLogSuppressedRefresh())
+            _logger.LogWarning("Mapping cache is full at {MaxCachedFields} resolved fields, so further fields will be resolved without caching. Increase {Property} if the index mapping has more fields than this", maxCachedFields, nameof(MaxCachedFields));
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reloads the server mapping and publishes a new snapshot when it succeeds. Only one refresh runs at a
+    /// time; callers that arrive while one is in flight wait for it rather than issuing their own.
+    /// </summary>
+    /// <param name="triggeredByUnmappedField">
+    /// True when the refresh was triggered by a field that could not be resolved. Those refreshes use their
+    /// own much shorter, self backing off throttle so a cold start fetch cannot suppress them.
+    /// </param>
+    public MappingRefreshResult Refresh(bool triggeredByUnmappedField)
+    {
+        var getServerMapping = _getServerMapping;
+        if (getServerMapping is null || _disposed)
+            return MappingRefreshResult.Skipped;
+
+        if (!IsRefreshAllowed(triggeredByUnmappedField))
+            return MappingRefreshResult.Throttled;
+
+        long versionBeforeWait = Current.Version;
+
+        bool acquired;
+        try
+        {
+            // Wait for an in-flight refresh instead of silently continuing with a stale mapping. That refresh
+            // is exactly the work this resolution needs, so waiting for it is never more expensive than doing
+            // it here. The wait is bounded because the fetch callback is user supplied and does blocking
+            // network I/O, and an unresponsive cluster must not pin request threads forever.
+            acquired = _refreshSemaphore.Wait(GetRefreshWaitTimeout());
+        }
+        catch (ObjectDisposedException)
+        {
+            return MappingRefreshResult.Skipped;
+        }
+
+        if (!acquired)
+        {
+            // The in-flight refresh may have published while we were giving up.
+            var snapshotAfterTimeout = Current;
+            if (snapshotAfterTimeout.Version != versionBeforeWait && snapshotAfterTimeout.Fetched)
+                return MappingRefreshResult.Updated;
+
+            return MappingRefreshResult.WaitTimedOut;
+        }
+
+        try
+        {
+            // Another caller finished a refresh while we waited, so adopt its result rather than refetching.
+            // A snapshot that has not been fetched means Reset() ran while we waited, in which case we still
+            // have to do the fetch ourselves.
+            var snapshotAfterWait = Current;
+            if (snapshotAfterWait.Version != versionBeforeWait && snapshotAfterWait.Fetched)
+                return MappingRefreshResult.Updated;
+
+            if (!IsRefreshAllowed(triggeredByUnmappedField))
+                return MappingRefreshResult.Throttled;
+
+            long resetVersion = Interlocked.Read(ref _resetVersion);
+
+            TypeMapping? newMapping;
+            try
+            {
+                newMapping = getServerMapping();
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                // Record the attempt so a failing cluster is not retried for every unresolved field.
+                RecordRefreshAttempt(triggeredByUnmappedField);
+                if (triggeredByUnmappedField)
+                    IncreaseUnmappedRefreshBackoff();
+
+                _logger.LogError(ex, "Error getting server mapping: {Message}", ex.Message);
+                return MappingRefreshResult.Failed;
+            }
+
+            var current = Current;
+            if (newMapping is null && current.Fetched && !current.HasServerMapping)
+            {
+                // Nothing changed, so keep the current snapshot (and its resolved field cache) intact.
+                RecordRefreshAttempt(triggeredByUnmappedField);
+                if (triggeredByUnmappedField)
+                    IncreaseUnmappedRefreshBackoff();
+
+                return MappingRefreshResult.Failed;
+            }
+
+            lock (_publishLock)
+            {
+                // A Reset() during the fetch means this result may predate the schema change the caller knows
+                // about, so discard it and let the next resolution fetch again.
+                if (Interlocked.Read(ref _resetVersion) != resetVersion)
+                    return MappingRefreshResult.Failed;
+
+                // Clear before publishing so resolutions made against the new snapshot are not discarded.
+                ClearFields();
+                Volatile.Write(ref _snapshot, CreateSnapshot(newMapping, fetched: true));
+                RecordRefreshAttempt(triggeredByUnmappedField);
+            }
+
+            _logger.LogInformation("Got server mapping");
+
+            return MappingRefreshResult.Updated;
+        }
+        finally
+        {
+            try
+            {
+                _refreshSemaphore.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+                // the cache was disposed while the refresh was in flight
+            }
+        }
+    }
+
+    /// <summary>
+    /// Records that a field was still unresolvable after the mapping was refreshed, which means it probably
+    /// does not exist at all. Backs off at most once per refresh: many concurrent lookups adopt the result of
+    /// a single refresh, and without that guard one refresh would ratchet the interval to the ceiling.
+    /// </summary>
+    public void RecordUnresolvedAfterRefresh(long snapshotVersion)
+    {
+        long applied = Interlocked.Read(ref _backoffAppliedForVersion);
+        if (applied == snapshotVersion || Interlocked.CompareExchange(ref _backoffAppliedForVersion, snapshotVersion, applied) != applied)
+            return;
+
+        IncreaseUnmappedRefreshBackoff();
+    }
+
+    public void ResetUnmappedRefreshBackoff()
+    {
+        Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
+    }
+
+    /// <summary>The interval currently in force for unmapped field refreshes, including any backoff.</summary>
+    public TimeSpan CurrentUnmappedRefreshInterval => new(GetUnmappedRefreshIntervalTicks());
+
+    /// <summary>
+    /// Rate limits warnings about suppressed refreshes so a flood of queries against non-existent fields
+    /// cannot flood the log. At most one warning is emitted per <see cref="RefreshInterval"/>.
+    /// </summary>
+    public bool ShouldLogSuppressedRefresh()
+    {
+        if (!_logger.IsEnabled(LogLevel.Warning))
+            return false;
+
+        long last = Interlocked.Read(ref _lastSuppressedRefreshWarningTimestamp);
+        if (last != 0 && _timeProvider.GetElapsedTime(last) < RefreshInterval)
+            return false;
+
+        return Interlocked.CompareExchange(ref _lastSuppressedRefreshWarningTimestamp, _timeProvider.GetTimestamp(), last) == last;
+    }
+
+    private TimeSpan GetRefreshWaitTimeout()
+    {
+        var timeout = RefreshWaitTimeout;
+        if (timeout == Timeout.InfiniteTimeSpan)
+            return timeout;
+
+        // SemaphoreSlim rejects waits longer than Int32.MaxValue milliseconds.
+        return timeout.TotalMilliseconds > Int32.MaxValue ? TimeSpan.FromMilliseconds(Int32.MaxValue) : timeout;
+    }
+
+    private MappingSnapshot CreateSnapshot(TypeMapping? serverMapping, bool fetched)
+    {
+        long version = Interlocked.Increment(ref _snapshotVersion);
+
+        // Properties are merged lazily and exactly once per snapshot: merging walks (and mutates) the whole
+        // property tree, which is far too expensive to repeat for every field resolution.
+        return new MappingSnapshot(version, serverMapping is not null, fetched,
+            () => _mergeProperties(serverMapping), _timeProvider.GetUtcNow().UtcDateTime);
+    }
+
+    private long GetUnmappedRefreshIntervalTicks()
+    {
+        long baseTicks = Math.Max(UnmappedFieldRefreshInterval.Ticks, 0);
+        long maxTicks = Math.Max(RefreshInterval.Ticks, baseTicks);
+        long backoffTicks = Interlocked.Read(ref _unmappedRefreshBackoffTicks);
+
+        return Math.Min(Math.Max(baseTicks, backoffTicks), maxTicks);
+    }
+
+    private void IncreaseUnmappedRefreshBackoff()
+    {
+        long baseTicks = Math.Max(UnmappedFieldRefreshInterval.Ticks, 0);
+        long maxTicks = Math.Max(RefreshInterval.Ticks, baseTicks);
+        long current = Interlocked.Read(ref _unmappedRefreshBackoffTicks);
+        if (current >= maxTicks)
+            return;
+
+        long next = Math.Min(Math.Max(current, baseTicks) * 2, maxTicks);
+        Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, next);
+    }
+
+    private bool IsRefreshAllowed(bool triggeredByUnmappedField)
+    {
+        if (triggeredByUnmappedField)
+        {
+            long lastUnmappedRefresh = Interlocked.Read(ref _lastUnmappedRefreshTimestamp);
+            return lastUnmappedRefresh == 0 || _timeProvider.GetElapsedTime(lastUnmappedRefresh) >= CurrentUnmappedRefreshInterval;
+        }
+
+        long lastRefresh = Interlocked.Read(ref _lastRefreshTimestamp);
+        return lastRefresh == 0 || _timeProvider.GetElapsedTime(lastRefresh) >= RefreshInterval;
+    }
+
+    private void RecordRefreshAttempt(bool triggeredByUnmappedField)
+    {
+        long timestamp = _timeProvider.GetTimestamp();
+        Interlocked.Exchange(ref _lastRefreshTimestamp, timestamp);
+        if (triggeredByUnmappedField)
+            Interlocked.Exchange(ref _lastUnmappedRefreshTimestamp, timestamp);
+    }
+
+    private void ClearFields()
+    {
+        _fields.Clear();
+        Interlocked.Exchange(ref _cachedFieldCount, 0);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _refreshSemaphore.Dispose();
+    }
+}
+
+/// <summary>
+/// An immutable point-in-time view of the mapping. Published by reference swap so that readers never need a
+/// lock and always observe a consistent mapping plus version pair.
+/// </summary>
+internal sealed class MappingSnapshot
+{
+    private readonly Lazy<Properties?> _properties;
+
+    public MappingSnapshot(long version, bool hasServerMapping, bool fetched, Func<Properties?> propertiesFactory, DateTime createdUtc)
+    {
+        Version = version;
+        HasServerMapping = hasServerMapping;
+        Fetched = fetched;
+        CreatedUtc = createdUtc;
+        _properties = new Lazy<Properties?>(propertiesFactory, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <summary>Monotonically increasing version used to detect field cache entries from older mappings.</summary>
+    public long Version { get; }
+
+    /// <summary>Whether the server returned a mapping (as opposed to no mapping being available).</summary>
+    public bool HasServerMapping { get; }
+
+    /// <summary>Whether a server mapping fetch has been attempted for this snapshot.</summary>
+    public bool Fetched { get; }
+
+    public DateTime CreatedUtc { get; }
+
+    /// <summary>Code and server properties merged once, on first use.</summary>
+    public Properties? Properties => _properties.Value;
+}
+
+internal enum MappingRefreshResult
+{
+    /// <summary>No refresh was attempted (no fetch function, or the cache was disposed).</summary>
+    Skipped,
+
+    /// <summary>A refresh was warranted but suppressed by a throttle.</summary>
+    Throttled,
+
+    /// <summary>
+    /// A refresh was already in flight but did not complete within the wait timeout, so the loaded mapping is
+    /// known to be stale.
+    /// </summary>
+    WaitTimedOut,
+
+    /// <summary>The server mapping was reloaded and a new snapshot published.</summary>
+    Updated,
+
+    /// <summary>The refresh was attempted but did not produce a usable mapping.</summary>
+    Failed
+}

--- a/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
@@ -74,11 +74,16 @@ internal sealed class MappingCache : IDisposable
     /// </summary>
     public void Reset()
     {
+        MappingLoadOperation? supersededLoad;
         lock (_stateLock)
         {
+            supersededLoad = _inFlightLoad;
+            _inFlightLoad = null;
             ClearThrottle();
             Volatile.Write(ref _snapshot, CreateSnapshot(null, fetched: false));
         }
+
+        supersededLoad?.SetResult(MappingRefreshResult.Superseded);
     }
 
     /// <summary>Clears the load throttle so the next resolution that needs a mapping can load immediately.</summary>
@@ -146,6 +151,9 @@ internal sealed class MappingCache : IDisposable
 
     private ValueTask<MappingRefreshResult> LoadAsync(MappingSnapshot observedSnapshot, bool armThrottleOnSuccess, CancellationToken cancellationToken)
     {
+        if (cancellationToken.IsCancellationRequested)
+            return ValueTask.FromCanceled<MappingRefreshResult>(cancellationToken);
+
         if (!TryGetOrCreateLoad(observedSnapshot, armThrottleOnSuccess, preferAsync: true,
             out var operation, out bool isOwner, out var immediateResult))
             return ValueTask.FromResult(immediateResult);
@@ -238,7 +246,13 @@ internal sealed class MappingCache : IDisposable
     {
         if (operation.PreferAsync && _getServerMappingAsync is not null)
         {
-            _ = FetchAsync(operation);
+            // AnyContext protects continuations owned by this library, but an async loader can still capture the
+            // caller's context before it returns its Task. Isolate that boundary when a synchronous caller could
+            // otherwise block the only thread while joining this shared load.
+            if (SynchronizationContext.Current is not null || TaskScheduler.Current != TaskScheduler.Default)
+                _ = Task.Run(() => FetchAsync(operation));
+            else
+                _ = FetchAsync(operation);
             return;
         }
 
@@ -454,7 +468,7 @@ internal sealed class MappingSnapshot
     /// </summary>
     public void CacheField(FieldMapping mapping)
     {
-        if (mapping.Found)
+        if (Fetched && mapping.Found)
             _fields.TryAdd(mapping.FullPath, mapping);
     }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
@@ -7,374 +7,218 @@ using Microsoft.Extensions.Logging;
 namespace Foundatio.Parsers.ElasticQueries;
 
 /// <summary>
-/// Owns the loaded server mapping and everything derived from it: when to reload, how reloads are coalesced,
-/// and the per-field resolutions cached against each loaded mapping.
+/// Loads the server mapping and publishes it as an immutable <see cref="MappingSnapshot"/>. Owns only when to
+/// load and how concurrent loads are coalesced.
 /// </summary>
 /// <remarks>
-/// Split out of <see cref="ElasticMappingResolver"/> so that refresh policy can be reasoned about (and
-/// tested) independently of field name resolution. The resolver asks two questions — "what is the current
-/// mapping?" and "the field was not in it, is there a newer one?" — and this type answers both.
+/// Split out of <see cref="ElasticMappingResolver"/> so load policy can be reasoned about independently of
+/// field name resolution. This type never interprets the mapping; deriving the merged property tree is the
+/// resolver's job, supplied as a pure function and applied lazily by the snapshot.
 /// </remarks>
 internal sealed class MappingCache : IDisposable
 {
     private readonly Func<TypeMapping?>? _getServerMapping;
-    private readonly Func<TypeMapping?, Properties?> _mergeProperties;
+    private readonly Func<TypeMapping?, MergedProperties?> _merge;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger _logger;
-
-    private readonly ConcurrentDictionary<string, FieldMapping> _fields = new(StringComparer.Ordinal);
-    private readonly SemaphoreSlim _refreshSemaphore = new(1, 1);
+    private readonly SemaphoreSlim _loadSemaphore = new(1, 1);
     private readonly object _publishLock = new();
 
     private MappingSnapshot _snapshot;
     private long _snapshotVersion;
-    private long _resetVersion;
-    private long _cachedFieldCount;
-    private long _lastRefreshTimestamp;
-    private long _lastUnmappedRefreshTimestamp;
-    private long _unmappedRefreshBackoffTicks;
-    private long _backoffAppliedForVersion;
-    private long _lastSuppressedRefreshWarningTimestamp;
+    private long _lastLoadAttemptTimestamp;
+    private int _hasLoadAttempt;
     private volatile bool _disposed;
 
-    public MappingCache(Func<TypeMapping?>? getServerMapping, Func<TypeMapping?, Properties?> mergeProperties, TimeProvider timeProvider, ILogger logger)
+    public MappingCache(Func<TypeMapping?>? getServerMapping, Func<TypeMapping?, MergedProperties?> merge, TimeProvider timeProvider, ILogger logger)
     {
         _getServerMapping = getServerMapping;
-        _mergeProperties = mergeProperties;
+        _merge = merge;
         _timeProvider = timeProvider;
         _logger = logger;
         _snapshot = CreateSnapshot(null, fetched: false);
     }
 
-    public TimeSpan RefreshInterval { get; set; } = TimeSpan.FromMinutes(1);
-
     public TimeSpan UnmappedFieldRefreshInterval { get; set; } = TimeSpan.FromSeconds(5);
 
+    /// <summary>
+    /// How long a load waits to join one already in flight. Validated by the resolver to be positive and
+    /// within the range <see cref="SemaphoreSlim"/> accepts, so it is passed through unclamped.
+    /// </summary>
     public TimeSpan RefreshWaitTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
-    public int MaxCachedFields { get; set; } = 10000;
-
     public bool HasServerMappingFunc => _getServerMapping is not null;
-
-    public long CachedFieldCount => Interlocked.Read(ref _cachedFieldCount);
 
     /// <summary>The currently published mapping. Never null; read without locking.</summary>
     public MappingSnapshot Current => Volatile.Read(ref _snapshot);
 
     /// <summary>
-    /// Discards the loaded mapping and every field resolved from it, and clears all refresh throttles so the
-    /// next resolution fetches immediately.
+    /// Discards the loaded mapping, every field resolved from it, and the load throttle, so the next
+    /// resolution loads immediately.
     /// </summary>
     public void Reset()
     {
         lock (_publishLock)
         {
-            Interlocked.Increment(ref _resetVersion);
-            ClearFields();
             Volatile.Write(ref _snapshot, CreateSnapshot(null, fetched: false));
-            Interlocked.Exchange(ref _lastRefreshTimestamp, 0);
-            Interlocked.Exchange(ref _lastUnmappedRefreshTimestamp, 0);
-            Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
+            ClearThrottle();
         }
     }
 
-    /// <summary>
-    /// Drops the cached resolution for a single field and clears the unmapped field throttle so the next
-    /// resolution of any unmapped field can refresh immediately.
-    /// </summary>
-    public void InvalidateField(string field)
+    /// <summary>Clears the load throttle so the next resolution that needs a mapping can load immediately.</summary>
+    private void ClearThrottle()
     {
-        if (_fields.TryRemove(field, out _))
-            Interlocked.Decrement(ref _cachedFieldCount);
-
-        Interlocked.Exchange(ref _lastUnmappedRefreshTimestamp, 0);
-        Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
-    }
-
-    public bool TryGetField(string field, MappingSnapshot snapshot, out FieldMapping mapping)
-    {
-        return _fields.TryGetValue(field, out mapping!) && mapping.Epoch == snapshot.Version;
+        Interlocked.Exchange(ref _lastLoadAttemptTimestamp, 0);
+        Volatile.Write(ref _hasLoadAttempt, 0);
     }
 
     /// <summary>
-    /// Caches a field resolution, dropping it if the mapping it was resolved against has since been replaced.
+    /// Loads the mapping for the first time. A successful cold start never arms the unmapped field throttle:
+    /// loading an existing mapping must not suppress discovery of a field created immediately afterwards.
+    /// A failed one does, so an unreachable cluster is not retried on every lookup.
     /// </summary>
-    public void CacheField(string field, FieldMapping mapping, long snapshotVersion)
-    {
-        int maxCachedFields = MaxCachedFields;
-        if (maxCachedFields <= 0)
-            return;
-
-        // Do not publish a resolution that was made against a mapping which has already been replaced.
-        if (Current.Version != snapshotVersion)
-            return;
-
-        if (Interlocked.Read(ref _cachedFieldCount) >= maxCachedFields && !_fields.ContainsKey(field) && !TryMakeRoom(maxCachedFields))
-            return;
-
-        if (_fields.TryAdd(field, mapping))
-        {
-            Interlocked.Increment(ref _cachedFieldCount);
-            return;
-        }
-
-        _fields.AddOrUpdate(field, mapping, (_, existing) => existing.Epoch > mapping.Epoch ? existing : mapping);
-    }
+    public MappingRefreshResult LoadInitial(MappingSnapshot observedSnapshot) => Load(observedSnapshot, armThrottleOnSuccess: false);
 
     /// <summary>
-    /// Evicts cached misses to make room for a new entry. Field names come from user supplied queries, so
-    /// the unbounded growth vector is names that do not exist in the mapping; resolved fields are bounded by
-    /// the size of the mapping itself. Evicting misses first therefore sheds exactly the entries an abusive
-    /// caller can create without discarding the resolutions real queries depend on.
+    /// Reloads the mapping because a field could not be resolved from the loaded one. A resolution failure is
+    /// the strongest available signal that the mapping changed, but it is also caller-triggered, so it is rate
+    /// limited by <see cref="UnmappedFieldRefreshInterval"/>.
     /// </summary>
-    /// <returns>True if there is now room for another entry.</returns>
-    private bool TryMakeRoom(int maxCachedFields)
-    {
-        int removed = 0;
-        foreach (var entry in _fields)
-        {
-            if (entry.Value.Found)
-                continue;
+    public MappingRefreshResult ReloadForMissingField(MappingSnapshot observedSnapshot) => Load(observedSnapshot, armThrottleOnSuccess: true);
 
-            if (_fields.TryRemove(entry.Key, out _))
-            {
-                Interlocked.Decrement(ref _cachedFieldCount);
-                removed++;
-            }
-        }
-
-        if (removed > 0)
-        {
-            _logger.LogDebug("Evicted {RemovedCount} unresolved field names from the mapping cache after reaching {MaxCachedFields} entries", removed, maxCachedFields);
-            return true;
-        }
-
-        // Every entry is a resolved field, so the mapping genuinely has more fields than the cache allows.
-        // Stop adding rather than clearing: the entries already cached are the useful ones, and fields past
-        // the bound still resolve correctly, just without caching.
-        if (ShouldLogSuppressedRefresh())
-            _logger.LogWarning("Mapping cache is full at {MaxCachedFields} resolved fields, so further fields will be resolved without caching. Increase {Property} if the index mapping has more fields than this", maxCachedFields, nameof(MaxCachedFields));
-
-        return false;
-    }
-
-    /// <summary>
-    /// Reloads the server mapping and publishes a new snapshot when it succeeds. Only one refresh runs at a
-    /// time; callers that arrive while one is in flight wait for it rather than issuing their own.
-    /// </summary>
-    /// <param name="triggeredByUnmappedField">
-    /// True when the refresh was triggered by a field that could not be resolved. Those refreshes use their
-    /// own much shorter, self backing off throttle so a cold start fetch cannot suppress them.
-    /// </param>
-    public MappingRefreshResult Refresh(bool triggeredByUnmappedField)
+    private MappingRefreshResult Load(MappingSnapshot observedSnapshot, bool armThrottleOnSuccess)
     {
         var getServerMapping = _getServerMapping;
         if (getServerMapping is null || _disposed)
-            return MappingRefreshResult.Skipped;
+            return MappingRefreshResult.Unavailable;
 
-        if (!IsRefreshAllowed(triggeredByUnmappedField))
+        if (HasNewerMapping(observedSnapshot.Version))
+            return MappingRefreshResult.Updated;
+
+        if (!IsLoadAllowed())
             return MappingRefreshResult.Throttled;
-
-        long versionBeforeWait = Current.Version;
 
         bool acquired;
         try
         {
-            // Wait for an in-flight refresh instead of silently continuing with a stale mapping. That refresh
-            // is exactly the work this resolution needs, so waiting for it is never more expensive than doing
-            // it here. The wait is bounded because the fetch callback is user supplied and does blocking
+            // Wait for an in-flight load rather than continuing with a stale mapping or issuing a second
+            // fetch. That load is exactly the work this resolution needs, so waiting is never more expensive
+            // than doing it here. The wait is bounded because the callback is user supplied and does blocking
             // network I/O, and an unresponsive cluster must not pin request threads forever.
-            acquired = _refreshSemaphore.Wait(GetRefreshWaitTimeout());
+            acquired = _loadSemaphore.Wait(RefreshWaitTimeout);
         }
         catch (ObjectDisposedException)
         {
-            return MappingRefreshResult.Skipped;
+            return MappingRefreshResult.Unavailable;
         }
 
         if (!acquired)
         {
-            // The in-flight refresh may have published while we were giving up.
-            var snapshotAfterTimeout = Current;
-            if (snapshotAfterTimeout.Version != versionBeforeWait && snapshotAfterTimeout.Fetched)
-                return MappingRefreshResult.Updated;
-
-            return MappingRefreshResult.WaitTimedOut;
+            // The in-flight load may have published while we were giving up, in which case adopt it.
+            return HasNewerMapping(observedSnapshot.Version) ? MappingRefreshResult.Updated : MappingRefreshResult.WaitTimedOut;
         }
 
         try
         {
-            // Another caller finished a refresh while we waited, so adopt its result rather than refetching.
-            // A snapshot that has not been fetched means Reset() ran while we waited, in which case we still
-            // have to do the fetch ourselves.
-            var snapshotAfterWait = Current;
-            if (snapshotAfterWait.Version != versionBeforeWait && snapshotAfterWait.Fetched)
+            // Another caller published while we waited, so adopt its result rather than refetching. A snapshot
+            // that has not been fetched means Reset() ran while we waited, so we still have to load.
+            if (HasNewerMapping(observedSnapshot.Version))
                 return MappingRefreshResult.Updated;
 
-            if (!IsRefreshAllowed(triggeredByUnmappedField))
+            if (!IsLoadAllowed())
                 return MappingRefreshResult.Throttled;
 
-            long resetVersion = Interlocked.Read(ref _resetVersion);
-
-            TypeMapping? newMapping;
-            try
-            {
-                newMapping = getServerMapping();
-            }
-            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
-            {
-                // Record the attempt so a failing cluster is not retried for every unresolved field.
-                RecordRefreshAttempt(triggeredByUnmappedField);
-                if (triggeredByUnmappedField)
-                    IncreaseUnmappedRefreshBackoff();
-
-                _logger.LogError(ex, "Error getting server mapping: {Message}", ex.Message);
-                return MappingRefreshResult.Failed;
-            }
-
-            var current = Current;
-            if (newMapping is null && current.Fetched && !current.HasServerMapping)
-            {
-                // Nothing changed, so keep the current snapshot (and its resolved field cache) intact.
-                RecordRefreshAttempt(triggeredByUnmappedField);
-                if (triggeredByUnmappedField)
-                    IncreaseUnmappedRefreshBackoff();
-
-                return MappingRefreshResult.Failed;
-            }
-
-            lock (_publishLock)
-            {
-                // A Reset() during the fetch means this result may predate the schema change the caller knows
-                // about, so discard it and let the next resolution fetch again.
-                if (Interlocked.Read(ref _resetVersion) != resetVersion)
-                    return MappingRefreshResult.Failed;
-
-                // Clear before publishing so resolutions made against the new snapshot are not discarded.
-                ClearFields();
-                Volatile.Write(ref _snapshot, CreateSnapshot(newMapping, fetched: true));
-                RecordRefreshAttempt(triggeredByUnmappedField);
-            }
-
-            _logger.LogInformation("Got server mapping");
-
-            return MappingRefreshResult.Updated;
+            return Fetch(getServerMapping, armThrottleOnSuccess, Current.Version);
         }
         finally
         {
             try
             {
-                _refreshSemaphore.Release();
+                _loadSemaphore.Release();
             }
             catch (ObjectDisposedException)
             {
-                // the cache was disposed while the refresh was in flight
+                // the resolver was disposed while the user supplied callback was running
             }
         }
     }
 
+    private MappingRefreshResult Fetch(Func<TypeMapping?> getServerMapping, bool armThrottleOnSuccess, long expectedVersion)
+    {
+        TypeMapping? newMapping;
+        try
+        {
+            newMapping = getServerMapping();
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        {
+            // Record the attempt so a failing cluster is not retried for every unresolved field. The mapping
+            // is deliberately left unfetched so a failed cold start is retried once the interval elapses.
+            RecordAttemptUnlessSuperseded(expectedVersion);
+            _logger.LogError(ex, "Error getting server mapping: {Message}", ex.Message);
+            return MappingRefreshResult.Unavailable;
+        }
+
+        if (newMapping is null)
+        {
+            // Keep the last known good mapping and its resolved fields rather than regressing to no mapping.
+            RecordAttemptUnlessSuperseded(expectedVersion);
+            return MappingRefreshResult.Unavailable;
+        }
+
+        lock (_publishLock)
+        {
+            // A Reset() during the fetch means this result may predate the change the caller knows about, so
+            // discard it and let the next resolution load again.
+            if (Current.Version != expectedVersion)
+                return MappingRefreshResult.Unavailable;
+
+            Volatile.Write(ref _snapshot, CreateSnapshot(newMapping, fetched: true));
+            if (armThrottleOnSuccess)
+                RecordLoadAttempt();
+        }
+
+        _logger.LogInformation("Got server mapping");
+        return MappingRefreshResult.Updated;
+    }
+
+    private bool HasNewerMapping(long version)
+    {
+        var snapshot = Current;
+        return snapshot.Version != version && snapshot.Fetched;
+    }
+
+    private bool IsLoadAllowed()
+    {
+        // A separate flag rather than a timestamp sentinel: TimeProvider.GetTimestamp can legitimately return
+        // zero, and nudging the stored value off zero would shorten the very first interval.
+        return Volatile.Read(ref _hasLoadAttempt) == 0
+            || _timeProvider.GetElapsedTime(Interlocked.Read(ref _lastLoadAttemptTimestamp)) >= UnmappedFieldRefreshInterval;
+    }
+
     /// <summary>
-    /// Records that a field was still unresolvable after the mapping was refreshed, which means it probably
-    /// does not exist at all. Backs off at most once per refresh: many concurrent lookups adopt the result of
-    /// a single refresh, and without that guard one refresh would ratchet the interval to the ceiling.
+    /// Arms the throttle unless an explicit refresh landed during the fetch, in which case the caller asked
+    /// for a reload after this attempt started and must not be made to wait out an interval for it.
     /// </summary>
-    public void RecordUnresolvedAfterRefresh(long snapshotVersion)
+    private void RecordAttemptUnlessSuperseded(long expectedVersion)
     {
-        long applied = Interlocked.Read(ref _backoffAppliedForVersion);
-        if (applied == snapshotVersion || Interlocked.CompareExchange(ref _backoffAppliedForVersion, snapshotVersion, applied) != applied)
-            return;
-
-        IncreaseUnmappedRefreshBackoff();
+        lock (_publishLock)
+        {
+            if (Current.Version == expectedVersion)
+                RecordLoadAttempt();
+        }
     }
 
-    public void ResetUnmappedRefreshBackoff()
+    private void RecordLoadAttempt()
     {
-        Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, 0);
-    }
-
-    /// <summary>The interval currently in force for unmapped field refreshes, including any backoff.</summary>
-    public TimeSpan CurrentUnmappedRefreshInterval => new(GetUnmappedRefreshIntervalTicks());
-
-    /// <summary>
-    /// Rate limits warnings about suppressed refreshes so a flood of queries against non-existent fields
-    /// cannot flood the log. At most one warning is emitted per <see cref="RefreshInterval"/>.
-    /// </summary>
-    public bool ShouldLogSuppressedRefresh()
-    {
-        if (!_logger.IsEnabled(LogLevel.Warning))
-            return false;
-
-        long last = Interlocked.Read(ref _lastSuppressedRefreshWarningTimestamp);
-        if (last != 0 && _timeProvider.GetElapsedTime(last) < RefreshInterval)
-            return false;
-
-        return Interlocked.CompareExchange(ref _lastSuppressedRefreshWarningTimestamp, _timeProvider.GetTimestamp(), last) == last;
-    }
-
-    private TimeSpan GetRefreshWaitTimeout()
-    {
-        var timeout = RefreshWaitTimeout;
-        if (timeout == Timeout.InfiniteTimeSpan)
-            return timeout;
-
-        // SemaphoreSlim rejects waits longer than Int32.MaxValue milliseconds.
-        return timeout.TotalMilliseconds > Int32.MaxValue ? TimeSpan.FromMilliseconds(Int32.MaxValue) : timeout;
+        Interlocked.Exchange(ref _lastLoadAttemptTimestamp, _timeProvider.GetTimestamp());
+        Volatile.Write(ref _hasLoadAttempt, 1);
     }
 
     private MappingSnapshot CreateSnapshot(TypeMapping? serverMapping, bool fetched)
     {
         long version = Interlocked.Increment(ref _snapshotVersion);
-
-        // Properties are merged lazily and exactly once per snapshot: merging walks (and mutates) the whole
-        // property tree, which is far too expensive to repeat for every field resolution.
-        return new MappingSnapshot(version, serverMapping is not null, fetched,
-            () => _mergeProperties(serverMapping), _timeProvider.GetUtcNow().UtcDateTime);
-    }
-
-    private long GetUnmappedRefreshIntervalTicks()
-    {
-        long baseTicks = Math.Max(UnmappedFieldRefreshInterval.Ticks, 0);
-        long maxTicks = Math.Max(RefreshInterval.Ticks, baseTicks);
-        long backoffTicks = Interlocked.Read(ref _unmappedRefreshBackoffTicks);
-
-        return Math.Min(Math.Max(baseTicks, backoffTicks), maxTicks);
-    }
-
-    private void IncreaseUnmappedRefreshBackoff()
-    {
-        long baseTicks = Math.Max(UnmappedFieldRefreshInterval.Ticks, 0);
-        long maxTicks = Math.Max(RefreshInterval.Ticks, baseTicks);
-        long current = Interlocked.Read(ref _unmappedRefreshBackoffTicks);
-        if (current >= maxTicks)
-            return;
-
-        long next = Math.Min(Math.Max(current, baseTicks) * 2, maxTicks);
-        Interlocked.Exchange(ref _unmappedRefreshBackoffTicks, next);
-    }
-
-    private bool IsRefreshAllowed(bool triggeredByUnmappedField)
-    {
-        if (triggeredByUnmappedField)
-        {
-            long lastUnmappedRefresh = Interlocked.Read(ref _lastUnmappedRefreshTimestamp);
-            return lastUnmappedRefresh == 0 || _timeProvider.GetElapsedTime(lastUnmappedRefresh) >= CurrentUnmappedRefreshInterval;
-        }
-
-        long lastRefresh = Interlocked.Read(ref _lastRefreshTimestamp);
-        return lastRefresh == 0 || _timeProvider.GetElapsedTime(lastRefresh) >= RefreshInterval;
-    }
-
-    private void RecordRefreshAttempt(bool triggeredByUnmappedField)
-    {
-        long timestamp = _timeProvider.GetTimestamp();
-        Interlocked.Exchange(ref _lastRefreshTimestamp, timestamp);
-        if (triggeredByUnmappedField)
-            Interlocked.Exchange(ref _lastUnmappedRefreshTimestamp, timestamp);
-    }
-
-    private void ClearFields()
-    {
-        _fields.Clear();
-        Interlocked.Exchange(ref _cachedFieldCount, 0);
+        return new MappingSnapshot(version, serverMapping, fetched, _merge, _timeProvider.GetUtcNow().UtcDateTime);
     }
 
     public void Dispose()
@@ -383,59 +227,55 @@ internal sealed class MappingCache : IDisposable
             return;
 
         _disposed = true;
-        _refreshSemaphore.Dispose();
+        _loadSemaphore.Dispose();
     }
 }
 
 /// <summary>
-/// An immutable point-in-time view of the mapping. Published by reference swap so that readers never need a
-/// lock and always observe a consistent mapping plus version pair.
+/// A point-in-time view of the mapping, its merged property tree, and successful field resolutions made
+/// against it. Publishing a new snapshot atomically invalidates everything derived from the old mapping.
 /// </summary>
 internal sealed class MappingSnapshot
 {
-    private readonly Lazy<Properties?> _properties;
+    private readonly Lazy<MergedProperties?> _properties;
+    private readonly ConcurrentDictionary<string, FieldMapping> _fields = new(StringComparer.Ordinal);
 
-    public MappingSnapshot(long version, bool hasServerMapping, bool fetched, Func<Properties?> propertiesFactory, DateTime createdUtc)
+    public MappingSnapshot(long version, TypeMapping? serverMapping, bool fetched, Func<TypeMapping?, MergedProperties?> merge, DateTime createdUtc)
     {
         Version = version;
-        HasServerMapping = hasServerMapping;
+        HasServerMapping = serverMapping is not null;
         Fetched = fetched;
         CreatedUtc = createdUtc;
-        _properties = new Lazy<Properties?>(propertiesFactory, LazyThreadSafetyMode.ExecutionAndPublication);
+        _properties = new Lazy<MergedProperties?>(() => merge(serverMapping), LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
-    /// <summary>Monotonically increasing version used to detect field cache entries from older mappings.</summary>
     public long Version { get; }
 
-    /// <summary>Whether the server returned a mapping (as opposed to no mapping being available).</summary>
     public bool HasServerMapping { get; }
 
-    /// <summary>Whether a server mapping fetch has been attempted for this snapshot.</summary>
     public bool Fetched { get; }
 
     public DateTime CreatedUtc { get; }
 
-    /// <summary>Code and server properties merged once, on first use.</summary>
-    public Properties? Properties => _properties.Value;
+    public MergedProperties? Properties => _properties.Value;
+
+    public bool TryGetField(string field, out FieldMapping mapping) => _fields.TryGetValue(field, out mapping!);
+
+    /// <summary>
+    /// Memoizes successful resolutions by canonical path. Unknown names are caller controlled and remain
+    /// uncached so they can drive the bounded mapping-refresh path without growing process state.
+    /// </summary>
+    public void CacheField(FieldMapping mapping)
+    {
+        if (mapping.Found)
+            _fields.TryAdd(mapping.FullPath, mapping);
+    }
 }
 
 internal enum MappingRefreshResult
 {
-    /// <summary>No refresh was attempted (no fetch function, or the cache was disposed).</summary>
-    Skipped,
-
-    /// <summary>A refresh was warranted but suppressed by a throttle.</summary>
+    Unavailable,
     Throttled,
-
-    /// <summary>
-    /// A refresh was already in flight but did not complete within the wait timeout, so the loaded mapping is
-    /// known to be stale.
-    /// </summary>
     WaitTimedOut,
-
-    /// <summary>The server mapping was reloaded and a new snapshot published.</summary>
-    Updated,
-
-    /// <summary>The refresh was attempted but did not produce a usable mapping.</summary>
-    Failed
+    Updated
 }

--- a/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
@@ -250,7 +250,10 @@ internal sealed class MappingCache : IDisposable
 
         if (_getServerMappingAsync is not null)
         {
-            _ = FetchAsync(operation);
+            // A synchronous caller cannot safely block on an async callback started on its own synchronization
+            // context. Isolate only this compatibility path on the thread pool; normal async callers invoke the
+            // callback directly above.
+            _ = Task.Run(() => FetchAsync(operation));
             return;
         }
 

--- a/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
@@ -95,16 +95,14 @@ internal sealed class MappingCache : IDisposable
         if (HasNewerMapping(observedSnapshot.Version))
             return MappingRefreshResult.Updated;
 
-        if (!IsLoadAllowed())
-            return MappingRefreshResult.Throttled;
-
         bool acquired;
         try
         {
             // Wait for an in-flight load rather than continuing with a stale mapping or issuing a second
             // fetch. That load is exactly the work this resolution needs, so waiting is never more expensive
-            // than doing it here. The wait is bounded because the callback is user supplied and does blocking
-            // network I/O, and an unresponsive cluster must not pin request threads forever.
+            // than doing it here. With no load in flight this acquires immediately. The wait is bounded
+            // because the callback is user supplied and does blocking network I/O, and an unresponsive
+            // cluster must not pin request threads forever.
             acquired = _loadSemaphore.Wait(RefreshWaitTimeout);
         }
         catch (ObjectDisposedException)
@@ -125,6 +123,8 @@ internal sealed class MappingCache : IDisposable
             if (HasNewerMapping(observedSnapshot.Version))
                 return MappingRefreshResult.Updated;
 
+            // The throttle only gates issuing a new fetch; a caller whose field is missing still joins any
+            // load that was already running above.
             if (!IsLoadAllowed())
                 return MappingRefreshResult.Throttled;
 
@@ -262,8 +262,10 @@ internal sealed class MappingSnapshot
     public bool TryGetField(string field, out FieldMapping mapping) => _fields.TryGetValue(field, out mapping!);
 
     /// <summary>
-    /// Memoizes successful resolutions by canonical path. Unknown names are caller controlled and remain
-    /// uncached so they can drive the bounded mapping-refresh path without growing process state.
+    /// Memoizes successful resolutions by canonical path. Keying by path keeps this snapshot's cache bounded
+    /// by the mapping itself no matter how many distinct spellings callers ask for. Unknown names are caller
+    /// controlled and remain uncached so they can drive the bounded mapping-refresh path without growing
+    /// process state.
     /// </summary>
     public void CacheField(FieldMapping mapping)
     {

--- a/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch.Mapping;
 using Microsoft.Extensions.Logging;
 
@@ -18,21 +19,35 @@ namespace Foundatio.Parsers.ElasticQueries;
 internal sealed class MappingCache : IDisposable
 {
     private readonly Func<TypeMapping?>? _getServerMapping;
+    private readonly Func<CancellationToken, Task<TypeMapping?>>? _getServerMappingAsync;
     private readonly Func<TypeMapping?, MergedProperties?> _merge;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger _logger;
-    private readonly SemaphoreSlim _loadSemaphore = new(1, 1);
-    private readonly object _publishLock = new();
+    private readonly object _stateLock = new();
+    private readonly CancellationTokenSource _lifetimeCancellation = new();
 
     private MappingSnapshot _snapshot;
+    private MappingLoadOperation? _inFlightLoad;
     private long _snapshotVersion;
     private long _lastLoadAttemptTimestamp;
     private int _hasLoadAttempt;
-    private volatile bool _disposed;
+    private bool _disposed;
 
     public MappingCache(Func<TypeMapping?>? getServerMapping, Func<TypeMapping?, MergedProperties?> merge, TimeProvider timeProvider, ILogger logger)
+        : this(getServerMapping, null, merge, timeProvider, logger)
+    {
+    }
+
+    public MappingCache(Func<CancellationToken, Task<TypeMapping?>>? getServerMappingAsync, Func<TypeMapping?, MergedProperties?> merge, TimeProvider timeProvider, ILogger logger)
+        : this(null, getServerMappingAsync, merge, timeProvider, logger)
+    {
+    }
+
+    public MappingCache(Func<TypeMapping?>? getServerMapping, Func<CancellationToken, Task<TypeMapping?>>? getServerMappingAsync,
+        Func<TypeMapping?, MergedProperties?> merge, TimeProvider timeProvider, ILogger logger)
     {
         _getServerMapping = getServerMapping;
+        _getServerMappingAsync = getServerMappingAsync;
         _merge = merge;
         _timeProvider = timeProvider;
         _logger = logger;
@@ -43,11 +58,12 @@ internal sealed class MappingCache : IDisposable
 
     /// <summary>
     /// How long a load waits to join one already in flight. Validated by the resolver to be positive and
-    /// within the range <see cref="SemaphoreSlim"/> accepts, so it is passed through unclamped.
+    /// within the range <see cref="Task.WaitAsync(TimeSpan, CancellationToken)"/> accepts, so it is passed
+    /// through unclamped.
     /// </summary>
     public TimeSpan RefreshWaitTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
-    public bool HasServerMappingFunc => _getServerMapping is not null;
+    public bool HasServerMappingFunc => _getServerMapping is not null || _getServerMappingAsync is not null;
 
     /// <summary>The currently published mapping. Never null; read without locking.</summary>
     public MappingSnapshot Current => Volatile.Read(ref _snapshot);
@@ -58,7 +74,7 @@ internal sealed class MappingCache : IDisposable
     /// </summary>
     public void Reset()
     {
-        lock (_publishLock)
+        lock (_stateLock)
         {
             ClearThrottle();
             Volatile.Write(ref _snapshot, CreateSnapshot(null, fetched: false));
@@ -79,6 +95,9 @@ internal sealed class MappingCache : IDisposable
     /// </summary>
     public MappingRefreshResult LoadInitial(MappingSnapshot observedSnapshot) => Load(observedSnapshot, armThrottleOnSuccess: false);
 
+    public ValueTask<MappingRefreshResult> LoadInitialAsync(MappingSnapshot observedSnapshot, CancellationToken cancellationToken = default) =>
+        LoadAsync(observedSnapshot, armThrottleOnSuccess: false, cancellationToken);
+
     /// <summary>
     /// Reloads the mapping because a field could not be resolved from the loaded one. A resolution failure is
     /// the strongest available signal that the mapping changed, but it is also caller-triggered, so it is rate
@@ -86,100 +105,254 @@ internal sealed class MappingCache : IDisposable
     /// </summary>
     public MappingRefreshResult ReloadForMissingField(MappingSnapshot observedSnapshot) => Load(observedSnapshot, armThrottleOnSuccess: true);
 
+    public ValueTask<MappingRefreshResult> ReloadForMissingFieldAsync(MappingSnapshot observedSnapshot, CancellationToken cancellationToken = default) =>
+        LoadAsync(observedSnapshot, armThrottleOnSuccess: true, cancellationToken);
+
     private MappingRefreshResult Load(MappingSnapshot observedSnapshot, bool armThrottleOnSuccess)
     {
-        var getServerMapping = _getServerMapping;
-        if (getServerMapping is null || _disposed)
-            return MappingRefreshResult.Unavailable;
-
-        if (HasNewerMapping(observedSnapshot.Version))
-            return MappingRefreshResult.Updated;
-
-        bool acquired;
-        try
+        while (true)
         {
-            // Wait for an in-flight load rather than continuing with a stale mapping or issuing a second
-            // fetch. That load is exactly the work this resolution needs, so waiting is never more expensive
-            // than doing it here. With no load in flight this acquires immediately. The wait is bounded
-            // because the callback is user supplied and does blocking network I/O, and an unresponsive
-            // cluster must not pin request threads forever.
-            acquired = _loadSemaphore.Wait(RefreshWaitTimeout);
-        }
-        catch (ObjectDisposedException)
-        {
-            return MappingRefreshResult.Unavailable;
-        }
+            if (!TryGetOrCreateLoad(observedSnapshot, armThrottleOnSuccess, preferAsync: false,
+                out var operation, out bool isOwner, out var immediateResult))
+                return immediateResult;
 
-        if (!acquired)
-        {
-            // The in-flight load may have published while we were giving up, in which case adopt it.
-            return HasNewerMapping(observedSnapshot.Version) ? MappingRefreshResult.Updated : MappingRefreshResult.WaitTimedOut;
-        }
+            if (isOwner)
+                StartLoad(operation!);
 
-        try
-        {
-            // Another caller published while we waited, so adopt its result rather than refetching. A snapshot
-            // that has not been fetched means Reset() ran while we waited, so we still have to load.
-            if (HasNewerMapping(observedSnapshot.Version))
-                return MappingRefreshResult.Updated;
-
-            // The throttle only gates issuing a new fetch; a caller whose field is missing still joins any
-            // load that was already running above.
-            if (!IsLoadAllowed())
-                return MappingRefreshResult.Throttled;
-
-            return Fetch(getServerMapping, armThrottleOnSuccess, Current.Version);
-        }
-        finally
-        {
-            try
+            MappingRefreshResult result;
+            if (isOwner)
             {
-                _loadSemaphore.Release();
+                result = operation!.Task.GetAwaiter().GetResult();
             }
-            catch (ObjectDisposedException)
+            else if (!operation!.Task.Wait(RefreshWaitTimeout))
             {
-                // the resolver was disposed while the user supplied callback was running
+                return HasNewerMapping(observedSnapshot.Version) ? MappingRefreshResult.Updated : MappingRefreshResult.WaitTimedOut;
             }
+            else
+            {
+                result = operation.Task.GetAwaiter().GetResult();
+            }
+
+            if (result != MappingRefreshResult.Superseded)
+                return result;
+
+            if (observedSnapshot.Version == operation.ExpectedVersion)
+                return MappingRefreshResult.Unavailable;
+
+            observedSnapshot = Current;
+            armThrottleOnSuccess = armThrottleOnSuccess && observedSnapshot.Fetched;
         }
     }
 
-    private MappingRefreshResult Fetch(Func<TypeMapping?> getServerMapping, bool armThrottleOnSuccess, long expectedVersion)
+    private ValueTask<MappingRefreshResult> LoadAsync(MappingSnapshot observedSnapshot, bool armThrottleOnSuccess, CancellationToken cancellationToken)
     {
-        TypeMapping? newMapping;
+        if (!TryGetOrCreateLoad(observedSnapshot, armThrottleOnSuccess, preferAsync: true,
+            out var operation, out bool isOwner, out var immediateResult))
+            return ValueTask.FromResult(immediateResult);
+
+        if (isOwner)
+            StartLoad(operation!);
+
+        if (operation!.Task.IsCompletedSuccessfully)
+        {
+            if (operation.Task.Result != MappingRefreshResult.Superseded)
+                return ValueTask.FromResult(operation.Task.Result);
+
+            if (observedSnapshot.Version == operation.ExpectedVersion)
+                return ValueTask.FromResult(MappingRefreshResult.Unavailable);
+
+            var snapshot = Current;
+            return LoadAsync(snapshot, armThrottleOnSuccess && snapshot.Fetched, cancellationToken);
+        }
+
+        return AwaitLoadAsync(operation, isOwner, observedSnapshot.Version, armThrottleOnSuccess, cancellationToken);
+    }
+
+    private async ValueTask<MappingRefreshResult> AwaitLoadAsync(MappingLoadOperation operation, bool isOwner,
+        long observedVersion, bool armThrottleOnSuccess, CancellationToken cancellationToken)
+    {
+        MappingRefreshResult result;
         try
         {
-            newMapping = getServerMapping();
+            result = isOwner
+                ? await operation.Task.WaitAsync(cancellationToken).ConfigureAwait(false)
+                : await operation.Task.WaitAsync(RefreshWaitTimeout, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+        catch (TimeoutException)
         {
-            // Record the attempt so a failing cluster is not retried for every unresolved field. The mapping
-            // is deliberately left unfetched so a failed cold start is retried once the interval elapses.
-            RecordAttemptUnlessSuperseded(expectedVersion);
-            _logger.LogError(ex, "Error getting server mapping: {Message}", ex.Message);
+            return HasNewerMapping(observedVersion) ? MappingRefreshResult.Updated : MappingRefreshResult.WaitTimedOut;
+        }
+
+        if (result != MappingRefreshResult.Superseded)
+            return result;
+
+        if (observedVersion == operation.ExpectedVersion)
             return MappingRefreshResult.Unavailable;
+
+        var snapshot = Current;
+        return await LoadAsync(snapshot, armThrottleOnSuccess && snapshot.Fetched, cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool TryGetOrCreateLoad(MappingSnapshot observedSnapshot, bool armThrottleOnSuccess, bool preferAsync,
+        out MappingLoadOperation? operation, out bool isOwner, out MappingRefreshResult result)
+    {
+        lock (_stateLock)
+        {
+            operation = null;
+            isOwner = false;
+
+            if ((_getServerMapping is null && _getServerMappingAsync is null) || _disposed)
+            {
+                result = MappingRefreshResult.Unavailable;
+                return false;
+            }
+
+            if (HasNewerMapping(observedSnapshot.Version))
+            {
+                result = MappingRefreshResult.Updated;
+                return false;
+            }
+
+            if (_inFlightLoad is not null)
+            {
+                operation = _inFlightLoad;
+                result = default;
+                return true;
+            }
+
+            if (!IsLoadAllowed())
+            {
+                result = MappingRefreshResult.Throttled;
+                return false;
+            }
+
+            operation = new MappingLoadOperation(Current.Version, armThrottleOnSuccess, preferAsync);
+            _inFlightLoad = operation;
+            isOwner = true;
+            result = default;
+            return true;
+        }
+    }
+
+    private void StartLoad(MappingLoadOperation operation)
+    {
+        if (operation.PreferAsync && _getServerMappingAsync is not null)
+        {
+            _ = FetchAsync(operation);
+            return;
         }
 
-        if (newMapping is null)
+        if (!operation.PreferAsync && _getServerMapping is not null)
         {
-            // Keep the last known good mapping and its resolved fields rather than regressing to no mapping.
-            RecordAttemptUnlessSuperseded(expectedVersion);
-            return MappingRefreshResult.Unavailable;
+            Fetch(operation);
+            return;
         }
 
-        lock (_publishLock)
+        if (_getServerMappingAsync is not null)
         {
-            // A Reset() during the fetch means this result may predate the change the caller knows about, so
-            // discard it and let the next resolution load again.
-            if (Current.Version != expectedVersion)
-                return MappingRefreshResult.Unavailable;
+            _ = FetchAsync(operation);
+            return;
+        }
 
-            Volatile.Write(ref _snapshot, CreateSnapshot(newMapping, fetched: true));
-            if (armThrottleOnSuccess)
+        Fetch(operation);
+    }
+
+    private void Fetch(MappingLoadOperation operation)
+    {
+        TypeMapping? mapping;
+        try
+        {
+            mapping = _getServerMapping!();
+        }
+        catch (Exception ex)
+        {
+            if (ex is OutOfMemoryException or StackOverflowException)
+            {
+                CompleteFaultedLoad(operation, ex);
+                return;
+            }
+
+            CompleteFailedLoad(operation, ex);
+            return;
+        }
+
+        CompleteLoad(operation, mapping);
+    }
+
+    private async Task FetchAsync(MappingLoadOperation operation)
+    {
+        TypeMapping? mapping;
+        try
+        {
+            mapping = await _getServerMappingAsync!(_lifetimeCancellation.Token).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            if (ex is OutOfMemoryException or StackOverflowException)
+            {
+                CompleteFaultedLoad(operation, ex);
+                return;
+            }
+
+            CompleteFailedLoad(operation, ex);
+            return;
+        }
+
+        CompleteLoad(operation, mapping);
+    }
+
+    private void CompleteFailedLoad(MappingLoadOperation operation, Exception exception)
+    {
+        FinalizeLoad(operation, null);
+        if (exception is not OperationCanceledException || !_lifetimeCancellation.IsCancellationRequested)
+            _logger.LogError(exception, "Error getting server mapping: {Message}", exception.Message);
+    }
+
+    private void CompleteLoad(MappingLoadOperation operation, TypeMapping? mapping)
+    {
+        FinalizeLoad(operation, mapping);
+    }
+
+    private void CompleteFaultedLoad(MappingLoadOperation operation, Exception exception)
+    {
+        lock (_stateLock)
+        {
+            operation.SetException(exception);
+            if (ReferenceEquals(_inFlightLoad, operation))
+                _inFlightLoad = null;
+        }
+    }
+
+    private void FinalizeLoad(MappingLoadOperation operation, TypeMapping? mapping)
+    {
+        MappingRefreshResult result;
+
+        lock (_stateLock)
+        {
+            if (_disposed || Current.Version != operation.ExpectedVersion)
+            {
+                result = MappingRefreshResult.Superseded;
+            }
+            else if (mapping is null)
+            {
                 RecordLoadAttempt();
+                result = MappingRefreshResult.Unavailable;
+            }
+            else
+            {
+                Volatile.Write(ref _snapshot, CreateSnapshot(mapping, fetched: true));
+                if (operation.ArmThrottleOnSuccess)
+                    RecordLoadAttempt();
+                result = MappingRefreshResult.Updated;
+            }
+
+            operation.SetResult(result);
+            if (ReferenceEquals(_inFlightLoad, operation))
+                _inFlightLoad = null;
         }
 
-        _logger.LogInformation("Got server mapping");
-        return MappingRefreshResult.Updated;
+        if (result == MappingRefreshResult.Updated)
+            _logger.LogInformation("Got server mapping");
     }
 
     private bool HasNewerMapping(long version)
@@ -190,29 +363,14 @@ internal sealed class MappingCache : IDisposable
 
     private bool IsLoadAllowed()
     {
-        // A separate flag rather than a timestamp sentinel: TimeProvider.GetTimestamp can legitimately return
-        // zero, and nudging the stored value off zero would shorten the very first interval.
-        return Volatile.Read(ref _hasLoadAttempt) == 0
-            || _timeProvider.GetElapsedTime(Interlocked.Read(ref _lastLoadAttemptTimestamp)) >= UnmappedFieldRefreshInterval;
-    }
-
-    /// <summary>
-    /// Arms the throttle unless an explicit refresh landed during the fetch, in which case the caller asked
-    /// for a reload after this attempt started and must not be made to wait out an interval for it.
-    /// </summary>
-    private void RecordAttemptUnlessSuperseded(long expectedVersion)
-    {
-        lock (_publishLock)
-        {
-            if (Current.Version == expectedVersion)
-                RecordLoadAttempt();
-        }
+        return _hasLoadAttempt == 0
+            || _timeProvider.GetElapsedTime(_lastLoadAttemptTimestamp) >= UnmappedFieldRefreshInterval;
     }
 
     private void RecordLoadAttempt()
     {
-        Interlocked.Exchange(ref _lastLoadAttemptTimestamp, _timeProvider.GetTimestamp());
-        Volatile.Write(ref _hasLoadAttempt, 1);
+        _lastLoadAttemptTimestamp = _timeProvider.GetTimestamp();
+        _hasLoadAttempt = 1;
     }
 
     private MappingSnapshot CreateSnapshot(TypeMapping? serverMapping, bool fetched)
@@ -223,11 +381,35 @@ internal sealed class MappingCache : IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
-            return;
+        lock (_stateLock)
+            _disposed = true;
 
-        _disposed = true;
-        _loadSemaphore.Dispose();
+        _lifetimeCancellation.Cancel();
+    }
+
+    private sealed class MappingLoadOperation
+    {
+        private readonly TaskCompletionSource<MappingRefreshResult> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public MappingLoadOperation(long expectedVersion, bool armThrottleOnSuccess, bool preferAsync)
+        {
+            ExpectedVersion = expectedVersion;
+            ArmThrottleOnSuccess = armThrottleOnSuccess;
+            PreferAsync = preferAsync;
+        }
+
+        public long ExpectedVersion { get; }
+
+        public bool ArmThrottleOnSuccess { get; }
+
+        public bool PreferAsync { get; }
+
+        public Task<MappingRefreshResult> Task => _completion.Task;
+
+        public void SetResult(MappingRefreshResult result) => _completion.TrySetResult(result);
+
+        public void SetException(Exception exception) => _completion.TrySetException(exception);
     }
 }
 
@@ -279,5 +461,6 @@ internal enum MappingRefreshResult
     Unavailable,
     Throttled,
     WaitTimedOut,
+    Superseded,
     Updated
 }

--- a/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
@@ -60,8 +60,8 @@ internal sealed class MappingCache : IDisposable
     {
         lock (_publishLock)
         {
-            Volatile.Write(ref _snapshot, CreateSnapshot(null, fetched: false));
             ClearThrottle();
+            Volatile.Write(ref _snapshot, CreateSnapshot(null, fetched: false));
         }
     }
 

--- a/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
@@ -56,6 +56,8 @@ internal sealed class MappingCache : IDisposable
 
     public TimeSpan UnmappedFieldRefreshInterval { get; set; } = TimeSpan.FromSeconds(5);
 
+    public Func<TypeMapping, string?>? ServerMappingRevisionResolver { get; set; }
+
     /// <summary>
     /// How long a load waits to join one already in flight. Validated by the resolver to be positive and
     /// within the range <see cref="Task.WaitAsync(TimeSpan, CancellationToken)"/> accepts, so it is passed
@@ -277,9 +279,11 @@ internal sealed class MappingCache : IDisposable
     private void Fetch(MappingLoadOperation operation)
     {
         TypeMapping? mapping;
+        string? revision;
         try
         {
             mapping = _getServerMapping!();
+            revision = mapping is null ? null : ServerMappingRevisionResolver?.Invoke(mapping);
         }
         catch (Exception ex)
         {
@@ -293,15 +297,17 @@ internal sealed class MappingCache : IDisposable
             return;
         }
 
-        CompleteLoad(operation, mapping);
+        FinalizeLoad(operation, mapping, revision);
     }
 
     private async Task FetchAsync(MappingLoadOperation operation)
     {
         TypeMapping? mapping;
+        string? revision;
         try
         {
             mapping = await _getServerMappingAsync!(_lifetimeCancellation.Token).AnyContext();
+            revision = mapping is null ? null : ServerMappingRevisionResolver?.Invoke(mapping);
         }
         catch (Exception ex)
         {
@@ -315,7 +321,7 @@ internal sealed class MappingCache : IDisposable
             return;
         }
 
-        CompleteLoad(operation, mapping);
+        FinalizeLoad(operation, mapping, revision);
     }
 
     private void CompleteFailedLoad(MappingLoadOperation operation, Exception exception)
@@ -323,11 +329,6 @@ internal sealed class MappingCache : IDisposable
         FinalizeLoad(operation, null);
         if (exception is not OperationCanceledException || !_lifetimeCancellation.IsCancellationRequested)
             _logger.LogError(exception, "Error getting server mapping: {Message}", exception.Message);
-    }
-
-    private void CompleteLoad(MappingLoadOperation operation, TypeMapping? mapping)
-    {
-        FinalizeLoad(operation, mapping);
     }
 
     private void CompleteFaultedLoad(MappingLoadOperation operation, Exception exception)
@@ -340,7 +341,7 @@ internal sealed class MappingCache : IDisposable
         }
     }
 
-    private void FinalizeLoad(MappingLoadOperation operation, TypeMapping? mapping)
+    private void FinalizeLoad(MappingLoadOperation operation, TypeMapping? mapping, string? revision = null)
     {
         MappingRefreshResult result;
 
@@ -357,7 +358,7 @@ internal sealed class MappingCache : IDisposable
             }
             else
             {
-                Volatile.Write(ref _snapshot, CreateSnapshot(mapping, fetched: true));
+                Volatile.Write(ref _snapshot, CreateSnapshot(mapping, fetched: true, revision));
                 if (operation.ArmThrottleOnSuccess)
                     RecordLoadAttempt();
                 result = MappingRefreshResult.Updated;
@@ -390,10 +391,14 @@ internal sealed class MappingCache : IDisposable
         _hasLoadAttempt = 1;
     }
 
-    private MappingSnapshot CreateSnapshot(TypeMapping? serverMapping, bool fetched)
+    private MappingSnapshot CreateSnapshot(TypeMapping? serverMapping, bool fetched, string? revision = null)
     {
         long version = Interlocked.Increment(ref _snapshotVersion);
-        return new MappingSnapshot(version, serverMapping, fetched, _merge, _timeProvider.GetUtcNow().UtcDateTime);
+        DateTime createdUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        if (fetched && !String.IsNullOrEmpty(revision) && String.Equals(revision, Current.ServerRevision, StringComparison.Ordinal))
+            return Current.WithVersion(version, createdUtc);
+
+        return new MappingSnapshot(version, serverMapping, fetched, _merge, createdUtc, revision);
     }
 
     public void Dispose()
@@ -437,15 +442,29 @@ internal sealed class MappingCache : IDisposable
 internal sealed class MappingSnapshot
 {
     private readonly Lazy<MergedProperties?> _properties;
-    private readonly ConcurrentDictionary<string, FieldMapping> _fields = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, FieldMapping> _fields;
 
-    public MappingSnapshot(long version, TypeMapping? serverMapping, bool fetched, Func<TypeMapping?, MergedProperties?> merge, DateTime createdUtc)
+    public MappingSnapshot(long version, TypeMapping? serverMapping, bool fetched, Func<TypeMapping?, MergedProperties?> merge,
+        DateTime createdUtc, string? serverRevision)
     {
         Version = version;
         HasServerMapping = serverMapping is not null;
         Fetched = fetched;
         CreatedUtc = createdUtc;
+        ServerRevision = serverRevision;
         _properties = new Lazy<MergedProperties?>(() => merge(serverMapping), LazyThreadSafetyMode.ExecutionAndPublication);
+        _fields = new ConcurrentDictionary<string, FieldMapping>(StringComparer.Ordinal);
+    }
+
+    private MappingSnapshot(MappingSnapshot previous, long version, DateTime createdUtc)
+    {
+        Version = version;
+        HasServerMapping = previous.HasServerMapping;
+        Fetched = previous.Fetched;
+        CreatedUtc = createdUtc;
+        ServerRevision = previous.ServerRevision;
+        _properties = previous._properties;
+        _fields = previous._fields;
     }
 
     public long Version { get; }
@@ -455,6 +474,10 @@ internal sealed class MappingSnapshot
     public bool Fetched { get; }
 
     public DateTime CreatedUtc { get; }
+
+    public string? ServerRevision { get; }
+
+    public MappingSnapshot WithVersion(long version, DateTime createdUtc) => new(this, version, createdUtc);
 
     public MergedProperties? Properties => _properties.Value;
 

--- a/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingCache.cs
@@ -175,8 +175,8 @@ internal sealed class MappingCache : IDisposable
         try
         {
             result = isOwner
-                ? await operation.Task.WaitAsync(cancellationToken).ConfigureAwait(false)
-                : await operation.Task.WaitAsync(RefreshWaitTimeout, cancellationToken).ConfigureAwait(false);
+                ? await operation.Task.WaitAsync(cancellationToken).AnyContext()
+                : await operation.Task.WaitAsync(RefreshWaitTimeout, cancellationToken).AnyContext();
         }
         catch (TimeoutException)
         {
@@ -190,7 +190,7 @@ internal sealed class MappingCache : IDisposable
             return MappingRefreshResult.Unavailable;
 
         var snapshot = Current;
-        return await LoadAsync(snapshot, armThrottleOnSuccess && snapshot.Fetched, cancellationToken).ConfigureAwait(false);
+        return await LoadAsync(snapshot, armThrottleOnSuccess && snapshot.Fetched, cancellationToken).AnyContext();
     }
 
     private bool TryGetOrCreateLoad(MappingSnapshot observedSnapshot, bool armThrottleOnSuccess, bool preferAsync,
@@ -287,7 +287,7 @@ internal sealed class MappingCache : IDisposable
         TypeMapping? mapping;
         try
         {
-            mapping = await _getServerMappingAsync!(_lifetimeCancellation.Token).ConfigureAwait(false);
+            mapping = await _getServerMappingAsync!(_lifetimeCancellation.Token).AnyContext();
         }
         catch (Exception ex)
         {

--- a/src/Foundatio.Parsers.ElasticQueries/MappingProperty.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingProperty.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Elastic.Clients.Elasticsearch.Mapping;
+using Foundatio.Parsers.ElasticQueries.Extensions;
+
+namespace Foundatio.Parsers.ElasticQueries;
+
+internal static class MappingProperty
+{
+    public static Properties? GetChildren(IProperty property) => property switch
+    {
+        ObjectProperty p => p.Properties,
+        NestedProperty p => p.Properties,
+        _ => property.GetFields()
+    };
+
+    public static IProperty WithChildren(IProperty property, MergedProperties? children)
+    {
+        if (children is null)
+            return property;
+
+        var original = GetChildren(property);
+        if (original is not null && original.Count() == children.Count
+            && original.All(pair => children.TryGetNode(pair.Key.Name!, out var child)
+                && child.Name == pair.Key.Name && ReferenceEquals(pair.Value, child.Property)))
+            return property;
+
+        var properties = new Properties();
+        foreach (var child in children.Nodes)
+            properties.Add(child.Name, child.Property);
+
+        // SDK properties have no copy constructor. A shallow copy preserves all client settings and field
+        // expressions; only the child collection is replaced, without mutating the loader-owned property.
+        var copy = (IProperty)MemberwiseClone(property);
+        switch (copy)
+        {
+            case ObjectProperty p: p.Properties = properties; break;
+            case NestedProperty p: p.Properties = properties; break;
+            case AggregateMetricDoubleProperty p: p.Fields = properties; break;
+            case BinaryProperty p: p.Fields = properties; break;
+            case BooleanProperty p: p.Fields = properties; break;
+            case ByteNumberProperty p: p.Fields = properties; break;
+            case CompletionProperty p: p.Fields = properties; break;
+            case ConstantKeywordProperty p: p.Fields = properties; break;
+            case CountedKeywordProperty p: p.Fields = properties; break;
+            case DateNanosProperty p: p.Fields = properties; break;
+            case DateProperty p: p.Fields = properties; break;
+            case DateRangeProperty p: p.Fields = properties; break;
+            case DenseVectorProperty p: p.Fields = properties; break;
+            case DoubleNumberProperty p: p.Fields = properties; break;
+            case DoubleRangeProperty p: p.Fields = properties; break;
+            case DynamicProperty p: p.Fields = properties; break;
+            case FieldAliasProperty p: p.Fields = properties; break;
+            case FlattenedProperty p: p.Fields = properties; break;
+            case FloatNumberProperty p: p.Fields = properties; break;
+            case FloatRangeProperty p: p.Fields = properties; break;
+            case GeoPointProperty p: p.Fields = properties; break;
+            case GeoShapeProperty p: p.Fields = properties; break;
+            case HalfFloatNumberProperty p: p.Fields = properties; break;
+            case HistogramProperty p: p.Fields = properties; break;
+            case IcuCollationProperty p: p.Fields = properties; break;
+            case IntegerNumberProperty p: p.Fields = properties; break;
+            case IntegerRangeProperty p: p.Fields = properties; break;
+            case IpProperty p: p.Fields = properties; break;
+            case IpRangeProperty p: p.Fields = properties; break;
+            case JoinProperty p: p.Fields = properties; break;
+            case KeywordProperty p: p.Fields = properties; break;
+            case LongNumberProperty p: p.Fields = properties; break;
+            case LongRangeProperty p: p.Fields = properties; break;
+            case MatchOnlyTextProperty p: p.Fields = properties; break;
+            case Murmur3HashProperty p: p.Fields = properties; break;
+            case PassthroughObjectProperty p: p.Fields = properties; break;
+            case PercolatorProperty p: p.Fields = properties; break;
+            case PointProperty p: p.Fields = properties; break;
+            case RankFeatureProperty p: p.Fields = properties; break;
+            case RankFeaturesProperty p: p.Fields = properties; break;
+            case RankVectorProperty p: p.Fields = properties; break;
+            case ScaledFloatNumberProperty p: p.Fields = properties; break;
+            case SearchAsYouTypeProperty p: p.Fields = properties; break;
+            case SemanticTextProperty p: p.Fields = properties; break;
+            case ShapeProperty p: p.Fields = properties; break;
+            case ShortNumberProperty p: p.Fields = properties; break;
+            case SparseVectorProperty p: p.Fields = properties; break;
+            case TextProperty p: p.Fields = properties; break;
+            case TokenCountProperty p: p.Fields = properties; break;
+            case UnsignedLongNumberProperty p: p.Fields = properties; break;
+            case VersionProperty p: p.Fields = properties; break;
+            case WildcardProperty p: p.Fields = properties; break;
+#if ELASTICSEARCH9
+            case ExponentialHistogramProperty p: p.Fields = properties; break;
+#endif
+            default: throw new NotSupportedException($"Cannot merge children of mapping property {property.GetType().Name}.");
+        }
+
+        return copy;
+    }
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "MemberwiseClone")]
+    private static extern object MemberwiseClone(object instance);
+}

--- a/src/Foundatio.Parsers.ElasticQueries/MappingProperty.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/MappingProperty.cs
@@ -22,8 +22,8 @@ internal static class MappingProperty
 
         var original = GetChildren(property);
         if (original is not null && original.Count() == children.Count
-            && original.All(pair => children.TryGetNode(pair.Key.Name!, out var child)
-                && child.Name == pair.Key.Name && ReferenceEquals(pair.Value, child.Property)))
+            && original.All(pair => pair.Key.Name is { } name && children.TryGetNode(name, out var child)
+                && child.Name == name && ReferenceEquals(pair.Value, child.Property)))
             return property;
 
         var properties = new Properties();

--- a/src/Foundatio.Parsers.ElasticQueries/NestedPathResolver.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/NestedPathResolver.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.Linq;
+using Foundatio.Parsers.ElasticQueries.Extensions;
+using Foundatio.Parsers.LuceneQueries.Visitors;
 
 namespace Foundatio.Parsers.ElasticQueries;
 
@@ -37,6 +40,14 @@ public static class NestedPathResolver
         return deepestNestedPath;
     }
 
+    internal static string? GetDeepestNestedPath(string fullName, IQueryVisitorContext context)
+    {
+        if (context.TryGetMappingResult(fullName, out var mapping))
+            return mapping?.NestedPathChain.LastOrDefault();
+
+        return GetDeepestNestedPath(fullName, context.GetMappingResolver());
+    }
+
     /// <summary>
     /// Returns the complete chain of nested paths from outermost to innermost
     /// for a given deepest nested path. Each entry in the returned list is a
@@ -57,5 +68,20 @@ public static class NestedPathResolver
         }
 
         return nestedPaths.Count > 0 ? nestedPaths : [deepestPath];
+    }
+
+    internal static IReadOnlyList<string> GetNestedPathChain(string deepestPath, IQueryVisitorContext context)
+    {
+        if (context.TryGetMappingResult(deepestPath, out var mapping)
+            && mapping?.NestedPathChain is { Count: > 0 } nestedPathChain)
+        {
+            for (int i = 0; i < nestedPathChain.Count; i++)
+            {
+                if (nestedPathChain[i] == deepestPath)
+                    return nestedPathChain.Take(i + 1).ToArray();
+            }
+        }
+
+        return GetNestedPathChain(deepestPath, context.GetMappingResolver());
     }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineAggregationsVisitor.cs
@@ -210,19 +210,19 @@ public class CombineAggregationsVisitor : ChainableQueryVisitor
 
     private static IReadOnlyList<string> GetNestedPathChain(string deepestPath, IQueryVisitorContext context)
     {
-        if (context is not IElasticQueryVisitorContext elasticContext)
+        if (context is not IElasticQueryVisitorContext)
             return [deepestPath];
 
-        return NestedPathResolver.GetNestedPathChain(deepestPath, elasticContext.MappingResolver);
+        return NestedPathResolver.GetNestedPathChain(deepestPath, context);
     }
 
     private static string BuildHierarchicalBucketPathPrefix(
         string deepestPath, IQueryVisitorContext context)
     {
-        if (context is not IElasticQueryVisitorContext elasticContext)
+        if (context is not IElasticQueryVisitorContext)
             return NestedPathResolver.GetNestedAggName(deepestPath) + BucketPathSeparator;
 
-        var nestedPaths = NestedPathResolver.GetNestedPathChain(deepestPath, elasticContext.MappingResolver);
+        var nestedPaths = NestedPathResolver.GetNestedPathChain(deepestPath, context);
 
         if (nestedPaths.Count <= 1)
             return NestedPathResolver.GetNestedAggName(deepestPath) + BucketPathSeparator;

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -132,7 +132,7 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
         var ancestorUseCounts = new Dictionary<string, int>();
         foreach (var path in originalPaths)
         {
-            var chain = NestedPathResolver.GetNestedPathChain(path, elasticContext.MappingResolver);
+            var chain = NestedPathResolver.GetNestedPathChain(path, context);
             foreach (var ancestor in chain.Take(chain.Count - 1))
                 ancestorUseCounts[ancestor] = ancestorUseCounts.GetValueOrDefault(ancestor) + 1;
         }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/CombineQueriesVisitor.cs
@@ -303,7 +303,7 @@ public class CombineQueriesVisitor : ChainableQueryVisitor
             && existingBool.MustNot is null or { Count: 0 })
         {
             existingBool.Filter = existingBool.Filter is { Count: > 0 }
-                ? [..existingBool.Filter, filter]
+                ? [.. existingBool.Filter, filter]
                 : [filter];
             return query;
         }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Mapping;
 using Elastic.Clients.Elasticsearch.QueryDsl;
 using Foundatio.Parsers.ElasticQueries.Extensions;
 using Foundatio.Parsers.LuceneQueries;
@@ -24,7 +25,8 @@ public class GeoVisitor : ChainableQueryVisitor
             return;
 
         string? fieldName = node.Field;
-        if (String.IsNullOrEmpty(fieldName) || !elasticContext.MappingResolver.IsGeoPropertyType(fieldName))
+        if (String.IsNullOrEmpty(fieldName)
+            || (await context.GetMappingResultAsync(fieldName).AnyContext())?.Property is not GeoPointProperty)
             return;
 
         string? location = null;
@@ -43,13 +45,14 @@ public class GeoVisitor : ChainableQueryVisitor
         node.SetQuery(query);
     }
 
-    public override void Visit(TermRangeNode node, IQueryVisitorContext context)
+    public override async Task VisitAsync(TermRangeNode node, IQueryVisitorContext context)
     {
-        if (context is not IElasticQueryVisitorContext elasticContext)
+        if (context is not IElasticQueryVisitorContext)
             return;
 
         string? fieldName = node.Field;
-        if (String.IsNullOrEmpty(fieldName) || !elasticContext.MappingResolver.IsGeoPropertyType(fieldName))
+        if (String.IsNullOrEmpty(fieldName)
+            || (await context.GetMappingResultAsync(fieldName).AnyContext())?.Property is not GeoPointProperty)
             return;
 
         if (node.Min is null || node.Max is null)

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GeoVisitor.cs
@@ -47,12 +47,21 @@ public class GeoVisitor : ChainableQueryVisitor
 
     public override async Task VisitAsync(TermRangeNode node, IQueryVisitorContext context)
     {
+        using var mappingScope = context.BeginMappingScope();
+        if (context is IElasticQueryVisitorContext && !String.IsNullOrEmpty(node.Field))
+            await context.GetMappingResultAsync(node.Field).AnyContext();
+
+        Visit(node, context);
+    }
+
+    public override void Visit(TermRangeNode node, IQueryVisitorContext context)
+    {
         if (context is not IElasticQueryVisitorContext)
             return;
 
         string? fieldName = node.Field;
         if (String.IsNullOrEmpty(fieldName)
-            || (await context.GetMappingResultAsync(fieldName).AnyContext())?.Property is not GeoPointProperty)
+            || context.GetMappingResult(fieldName)?.Property is not GeoPointProperty)
             return;
 
         if (node.Min is null || node.Max is null)

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
@@ -11,6 +11,16 @@ namespace Foundatio.Parsers.ElasticQueries.Visitors;
 public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<ICollection<SortOptions>>
 {
     private readonly List<SortOptions> _fields = new();
+    private readonly bool _resolveMappingsAsync;
+
+    public GetSortFieldsVisitor() : this(resolveMappingsAsync: true)
+    {
+    }
+
+    private GetSortFieldsVisitor(bool resolveMappingsAsync)
+    {
+        _resolveMappingsAsync = resolveMappingsAsync;
+    }
 
     public override void Visit(TermNode node, IQueryVisitorContext context)
     {
@@ -22,6 +32,24 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<ICollection<S
             return;
 
         // Check if the sort has a valid Field property set (discriminated union)
+        if (sort.Field is null && sort.GeoDistance is null && sort.Score is null && sort.Script is null)
+            return;
+
+        _fields.Add(sort);
+    }
+
+    public override async Task VisitAsync(TermNode node, IQueryVisitorContext context)
+    {
+        if (!_resolveMappingsAsync)
+        {
+            Visit(node, context);
+            return;
+        }
+
+        if (String.IsNullOrEmpty(node.Field))
+            return;
+
+        var sort = node.GetSort() ?? await node.GetDefaultSortAsync(context).AnyContext();
         if (sort.Field is null && sort.GeoDistance is null && sort.Score is null && sort.Script is null)
             return;
 
@@ -42,6 +70,7 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<ICollection<S
 
     public static ICollection<SortOptions> Run(IQueryNode node, IQueryVisitorContext? context = null)
     {
-        return RunAsync(node, context).GetAwaiter().GetResult();
+        context ??= new QueryVisitorContext();
+        return new GetSortFieldsVisitor(resolveMappingsAsync: false).AcceptAsync(node, context).GetAwaiter().GetResult();
     }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
@@ -41,7 +41,8 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<ICollection<S
     public override async Task VisitAsync(TermNode node, IQueryVisitorContext context)
     {
         using var mappingScope = context.BeginMappingScope();
-        if (_resolveMappingsAsync && !String.IsNullOrEmpty(node.Field) && node.GetSort() is null)
+        if (_resolveMappingsAsync && context is IElasticQueryVisitorContext
+            && !String.IsNullOrEmpty(node.Field) && node.GetSort() is null)
             await node.PrepareSortMappingAsync(context).AnyContext();
 
         Visit(node, context);

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/GetSortFieldsVisitor.cs
@@ -40,24 +40,16 @@ public class GetSortFieldsVisitor : QueryNodeVisitorWithResultBase<ICollection<S
 
     public override async Task VisitAsync(TermNode node, IQueryVisitorContext context)
     {
-        if (!_resolveMappingsAsync)
-        {
-            Visit(node, context);
-            return;
-        }
+        using var mappingScope = context.BeginMappingScope();
+        if (_resolveMappingsAsync && !String.IsNullOrEmpty(node.Field) && node.GetSort() is null)
+            await node.PrepareSortMappingAsync(context).AnyContext();
 
-        if (String.IsNullOrEmpty(node.Field))
-            return;
-
-        var sort = node.GetSort() ?? await node.GetDefaultSortAsync(context).AnyContext();
-        if (sort.Field is null && sort.GeoDistance is null && sort.Score is null && sort.Script is null)
-            return;
-
-        _fields.Add(sort);
+        Visit(node, context);
     }
 
     public override async Task<ICollection<SortOptions>> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
     {
+        using var mappingScope = context.BeginMappingScope();
         await node.AcceptAsync(this, context).AnyContext();
         return _fields;
     }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/MappingValidationVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/MappingValidationVisitor.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading.Tasks;
+using Foundatio.Parsers.ElasticQueries.Extensions;
+using Foundatio.Parsers.LuceneQueries;
+using Foundatio.Parsers.LuceneQueries.Extensions;
+using Foundatio.Parsers.LuceneQueries.Nodes;
+using Foundatio.Parsers.LuceneQueries.Visitors;
+
+namespace Foundatio.Parsers.ElasticQueries.Visitors;
+
+internal sealed class MappingValidationVisitor : ChainableQueryVisitor
+{
+    public override async Task<IQueryNode?> AcceptAsync(IQueryNode node, IQueryVisitorContext context)
+    {
+        if (context.GetValidationOptions().AllowUnresolvedFields
+            || !context.GetValidationResult().IsValid
+            || context is not IElasticQueryVisitorContext elasticContext
+            || ReferenceEquals(elasticContext.MappingResolver, ElasticMappingResolver.NullInstance))
+        {
+            return node;
+        }
+
+        using var mappingScope = context.BeginMappingScope();
+        return await base.AcceptAsync(node, context).AnyContext();
+    }
+
+    public override async Task VisitAsync(GroupNode node, IQueryVisitorContext context)
+    {
+        await ValidateFieldsAsync(node, context).AnyContext();
+        await base.VisitAsync(node, context).AnyContext();
+    }
+
+    public override Task VisitAsync(TermNode node, IQueryVisitorContext context) => ValidateFieldsAsync(node, context);
+
+    public override Task VisitAsync(TermRangeNode node, IQueryVisitorContext context) => ValidateFieldsAsync(node, context);
+
+    public override Task VisitAsync(ExistsNode node, IQueryVisitorContext context) => ValidateFieldsAsync(node, context);
+
+    public override Task VisitAsync(MissingNode node, IQueryVisitorContext context) => ValidateFieldsAsync(node, context);
+
+    private static async Task ValidateFieldsAsync(IFieldQueryNode node, IQueryVisitorContext context)
+    {
+        if (!String.IsNullOrEmpty(node.Field))
+        {
+            await ValidateFieldAsync(node.Field, node.GetOriginalField() ?? node.Field, context).AnyContext();
+        }
+        else if (node is not GroupNode && context.QueryType is QueryTypes.Query
+            && node.GetDefaultFields(context.DefaultFields) is { } defaultFields)
+        {
+            foreach (string field in defaultFields)
+                await ValidateFieldAsync(field, field, context).AnyContext();
+        }
+    }
+
+    private static async Task ValidateFieldAsync(string field, string originalField, IQueryVisitorContext context)
+    {
+        if (String.IsNullOrEmpty(field) || (context.QueryType is QueryTypes.Aggregation && field.StartsWith("@"))
+            || context.GetValidationResult().UnresolvedFields.Contains(originalField))
+            return;
+
+        try
+        {
+            if (await ElasticQueryParser.ResolveMappingFieldAsync(field, context).AnyContext() is null)
+                context.GetValidationResult().UnresolvedFields.Add(originalField);
+        }
+        catch (Exception ex)
+        {
+            context.AddValidationError($"Error in field resolver callback when resolving field ({originalField}): {ex.Message}");
+        }
+    }
+}

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch.QueryDsl;
 using Foundatio.Parsers.ElasticQueries.Extensions;
@@ -20,6 +21,7 @@ public class NestedVisitor : ChainableQueryVisitor
 
     public override async Task VisitAsync(GroupNode node, IQueryVisitorContext context)
     {
+        using var mappingScope = context.BeginMappingScope();
         if (String.IsNullOrEmpty(node.Field))
         {
             await base.VisitAsync(node, context).AnyContext();
@@ -86,6 +88,7 @@ public class NestedVisitor : ChainableQueryVisitor
 
     private async Task HandleNestedFieldNodeAsync(IFieldQueryNode node, IQueryVisitorContext context)
     {
+        using var mappingScope = context.BeginMappingScope();
         string? nestedProperty = await GetNestedPropertyAsync(node.Field, context).AnyContext();
         if (nestedProperty is null)
             return;
@@ -167,7 +170,7 @@ public class NestedVisitor : ChainableQueryVisitor
         if (fullName is null || context is not IElasticQueryVisitorContext)
             return null;
 
-        await context.GetMappingResultAsync(fullName).AnyContext();
-        return NestedPathResolver.GetDeepestNestedPath(fullName, context);
+        var mapping = await context.GetMappingResultAsync(fullName).AnyContext();
+        return mapping?.NestedPathChain.LastOrDefault();
     }
 }

--- a/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
+++ b/src/Foundatio.Parsers.ElasticQueries/Visitors/NestedVisitor.cs
@@ -18,23 +18,32 @@ public class NestedVisitor : ChainableQueryVisitor
         _filterResolver = filterResolver;
     }
 
-    public override Task VisitAsync(GroupNode node, IQueryVisitorContext context)
+    public override async Task VisitAsync(GroupNode node, IQueryVisitorContext context)
     {
         if (String.IsNullOrEmpty(node.Field))
-            return base.VisitAsync(node, context);
+        {
+            await base.VisitAsync(node, context).AnyContext();
+            return;
+        }
 
-        string? nestedProperty = GetNestedProperty(node.Field, context);
+        string? nestedProperty = await GetNestedPropertyAsync(node.Field, context).AnyContext();
         if (nestedProperty is null)
-            return base.VisitAsync(node, context);
+        {
+            await base.VisitAsync(node, context).AnyContext();
+            return;
+        }
 
         node.SetNestedPath(nestedProperty);
         if (context.QueryType is not QueryTypes.Aggregation and not QueryTypes.Sort)
             node.SetQuery(new NestedQuery { Path = nestedProperty, Query = new MatchAllQuery() });
 
         if (_filterResolver is not null)
-            return VisitGroupWithFilterAsync(node, nestedProperty, context);
+        {
+            await VisitGroupWithFilterAsync(node, nestedProperty, context).AnyContext();
+            return;
+        }
 
-        return base.VisitAsync(node, context);
+        await base.VisitAsync(node, context).AnyContext();
     }
 
     private async Task VisitGroupWithFilterAsync(GroupNode node, string nestedProperty, IQueryVisitorContext context)
@@ -75,28 +84,29 @@ public class NestedVisitor : ChainableQueryVisitor
         return HandleNestedFieldNodeAsync(node, context);
     }
 
-    private Task HandleNestedFieldNodeAsync(IFieldQueryNode node, IQueryVisitorContext context)
+    private async Task HandleNestedFieldNodeAsync(IFieldQueryNode node, IQueryVisitorContext context)
     {
-        string? nestedProperty = GetNestedProperty(node.Field, context);
+        string? nestedProperty = await GetNestedPropertyAsync(node.Field, context).AnyContext();
         if (nestedProperty is null)
-            return Task.CompletedTask;
+            return;
 
         if (IsInsideMatchingNestedGroup(node, nestedProperty))
-            return Task.CompletedTask;
+            return;
 
         if (_filterResolver is not null)
-            return HandleNestedFieldWithFilterAsync(node, nestedProperty, context);
+        {
+            await HandleNestedFieldWithFilterAsync(node, nestedProperty, context).AnyContext();
+            return;
+        }
 
         if (context.QueryType is QueryTypes.Aggregation or QueryTypes.Sort)
         {
             node.SetNestedPath(nestedProperty);
-            return Task.CompletedTask;
+            return;
         }
 
         if (context.QueryType is QueryTypes.Query)
-            return WrapInNestedQueryAsync(node, nestedProperty, context);
-
-        return Task.CompletedTask;
+            await WrapInNestedQueryAsync(node, nestedProperty, context).AnyContext();
     }
 
     private async Task HandleNestedFieldWithFilterAsync(IFieldQueryNode node, string nestedProperty, IQueryVisitorContext context)
@@ -152,11 +162,12 @@ public class NestedVisitor : ChainableQueryVisitor
         return false;
     }
 
-    private static string? GetNestedProperty(string? fullName, IQueryVisitorContext context)
+    private static async ValueTask<string?> GetNestedPropertyAsync(string? fullName, IQueryVisitorContext context)
     {
-        if (fullName is null || context is not IElasticQueryVisitorContext elasticContext)
+        if (fullName is null || context is not IElasticQueryVisitorContext)
             return null;
 
-        return NestedPathResolver.GetDeepestNestedPath(fullName, elasticContext.MappingResolver);
+        await context.GetMappingResultAsync(fullName).AnyContext();
+        return NestedPathResolver.GetDeepestNestedPath(fullName, context);
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -15,6 +16,9 @@ public partial class LuceneQueryParser : IQueryParser
 
     public IQueryNode? Parse(string query, IQueryVisitorContext? context)
     {
+        if (SynchronizationContext.Current is not null || TaskScheduler.Current != TaskScheduler.Default)
+            return Task.Run(() => ParseAsync(query, context)).GetAwaiter().GetResult();
+
         return ParseAsync(query, context).GetAwaiter().GetResult();
     }
 }

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Parsers.LuceneQueries.Visitors;
@@ -16,9 +15,6 @@ public partial class LuceneQueryParser : IQueryParser
 
     public IQueryNode? Parse(string query, IQueryVisitorContext? context)
     {
-        if (SynchronizationContext.Current is not null || TaskScheduler.Current != TaskScheduler.Default)
-            return Task.Run(() => ParseAsync(query, context)).GetAwaiter().GetResult();
-
         return ParseAsync(query, context).GetAwaiter().GetResult();
     }
 }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/DirectMappingVisitorTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/DirectMappingVisitorTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Mapping;
+using Foundatio.Parsers.ElasticQueries.Extensions;
+using Foundatio.Parsers.ElasticQueries.Visitors;
+using Foundatio.Parsers.LuceneQueries;
+using Foundatio.Parsers.LuceneQueries.Nodes;
+using Foundatio.Parsers.LuceneQueries.Visitors;
+using Xunit;
+
+namespace Foundatio.Parsers.ElasticQueries.Tests;
+
+public class DirectMappingVisitorTests
+{
+    [Theory]
+    [InlineData("term", false)]
+    [InlineData("term", true)]
+    [InlineData("range", true)]
+    [InlineData("exists", true)]
+    [InlineData("missing", true)]
+    [InlineData("group", false)]
+    [InlineData("group", true)]
+    public async Task NestedVisitor_WithColdMissingField_DoesNotBlockOrRepeatLoad(string nodeType, bool knownParent)
+    {
+        var firstLoad = new TaskCompletionSource<TypeMapping?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var unexpectedLoad = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseUnexpectedLoad = new TaskCompletionSource<TypeMapping?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var returned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int loads = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ =>
+            Interlocked.Increment(ref loads) == 1 ? firstLoad.Task : UnexpectedLoadAsync());
+        Task<TypeMapping?> UnexpectedLoadAsync()
+        {
+            unexpectedLoad.TrySetResult();
+            return releaseUnexpectedLoad.Task;
+        }
+        var context = new ElasticQueryVisitorContext { MappingResolver = resolver, QueryType = QueryTypes.Query };
+        IQueryNode node = nodeType switch
+        {
+            "range" => new TermRangeNode { Field = "items.missing", Min = "1", Max = "2" },
+            "exists" => new ExistsNode { Field = "items.missing" },
+            "missing" => new MissingNode { Field = "items.missing" },
+            "group" => new GroupNode { Field = "items.missing", HasParens = true },
+            _ => new TermNode { Field = "items.missing", Term = "value" }
+        };
+        var visitor = new NestedVisitor();
+        var operation = Task.Run(async () =>
+        {
+            var visit = visitor.VisitAsync(node, context);
+            returned.TrySetResult();
+            await visit;
+        }, TestContext.Current.CancellationToken);
+
+        try
+        {
+            await returned.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.False(operation.IsCompleted);
+            firstLoad.SetResult(new TypeMapping
+            {
+                Properties = knownParent ? new Properties { { "items", new NestedProperty { Properties = new Properties() } } } : new Properties()
+            });
+            var completed = await Task.WhenAny(operation, unexpectedLoad.Task).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.Same(operation, completed);
+        }
+        finally
+        {
+            firstLoad.TrySetResult(null);
+            releaseUnexpectedLoad.TrySetResult(null);
+            await operation.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+
+        Assert.Equal(1, loads);
+        if (knownParent)
+            Assert.NotNull((await node.GetQueryAsync())?.Nested);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task NestedVisitor_WithReusedContext_ReleasesMappingsAfterReturnOrException(bool throws)
+    {
+        TypeMapping mapping = new() { Properties = new Properties { { "items", new NestedProperty() } } };
+        using var resolver = new ElasticMappingResolver(() => mapping);
+        var context = new ElasticQueryVisitorContext { MappingResolver = resolver, QueryType = QueryTypes.Query };
+        var visitor = new NestedVisitor((_, _, _, _) => throws ? Task.FromException<Elastic.Clients.Elasticsearch.QueryDsl.Query?>(new InvalidOperationException("filter")) : Task.FromResult<Elastic.Clients.Elasticsearch.QueryDsl.Query?>(null));
+        var first = new GroupNode { Field = "items", HasParens = true };
+        if (throws)
+            await Assert.ThrowsAsync<InvalidOperationException>(() => visitor.VisitAsync(first, context));
+        else
+            await visitor.VisitAsync(first, context);
+
+        mapping = new TypeMapping { Properties = new Properties { { "items", new TextProperty() } } };
+        resolver.RefreshMapping();
+        var second = new GroupNode { Field = "items", HasParens = true };
+        await visitor.VisitAsync(second, context);
+
+        Assert.Null(second.GetNestedPath());
+        Assert.Null(await second.GetQueryAsync());
+    }
+
+    [Fact]
+    public async Task GetSortFieldsVisitor_WithCustomOverrideAndOrdinaryContext_PreservesDispatch()
+    {
+        var visitor = new CustomSortVisitor();
+
+        var sorts = await visitor.AcceptAsync(new TermNode { Field = "custom" }, new QueryVisitorContext());
+
+        Assert.Equal("computed", Assert.Single(sorts).Field!.Field!.Name);
+        Assert.Equal(1, visitor.Visits);
+    }
+
+    [Fact]
+    public async Task GetSortFieldsVisitor_WithPrecomputedSort_DoesNotLoadMappings()
+    {
+        int loads = 0;
+        using var resolver = new ElasticMappingResolver(() => { loads++; return null; });
+        var node = new TermNode { Field = "custom" };
+        var sort = new SortOptions { Field = new FieldSort("computed") };
+        node.SetSort(sort);
+
+        var sorts = await GetSortFieldsVisitor.RunAsync(node, new ElasticQueryVisitorContext { MappingResolver = resolver });
+
+        Assert.Same(sort, Assert.Single(sorts));
+        Assert.Equal(0, loads);
+    }
+
+    private sealed class CustomSortVisitor : GetSortFieldsVisitor
+    {
+        public int Visits { get; private set; }
+
+        public override void Visit(TermNode node, IQueryVisitorContext context)
+        {
+            Visits++;
+            node.SetSort(new SortOptions { Field = new FieldSort("computed") });
+            base.Visit(node, context);
+        }
+    }
+}

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/DirectMappingVisitorTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/DirectMappingVisitorTests.cs
@@ -42,7 +42,12 @@ public class DirectMappingVisitorTests
             "range" => new TermRangeNode { Field = "items.missing", Min = "1", Max = "2" },
             "exists" => new ExistsNode { Field = "items.missing" },
             "missing" => new MissingNode { Field = "items.missing" },
-            "group" => new GroupNode { Field = "items.missing", HasParens = true },
+            "group" => new GroupNode
+            {
+                Field = "items.missing",
+                HasParens = true,
+                Left = new GroupNode { Field = "items.missing", HasParens = true, Left = new TermNode { Field = "items.missing", Term = "value" } }
+            },
             _ => new TermNode { Field = "items.missing", Term = "value" }
         };
         var visitor = new NestedVisitor();
@@ -74,6 +79,11 @@ public class DirectMappingVisitorTests
         Assert.Equal(1, loads);
         if (knownParent)
             Assert.NotNull((await node.GetQueryAsync())?.Nested);
+        if (node is GroupNode { Left: GroupNode child })
+        {
+            Assert.Equal(knownParent ? "items" : null, child.GetNestedPath());
+            Assert.Null(await child.Left!.GetQueryAsync());
+        }
     }
 
     [Theory]

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -187,6 +188,70 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
     private static Expression GetObjectPath(Expression<Func<MyNestedType, object>> objectPath)
     {
         return objectPath;
+    }
+
+    private static void MapDynamicCustomFieldType(TypeMappingDescriptor<MyNestedType> m)
+    {
+        // Mirrors how Foundatio.Repositories maps custom fields: the idx.<type>-<slot> fields only exist
+        // in the index mapping after the first document that uses them has been indexed.
+        m.Dynamic(DynamicMapping.True)
+            .DynamicTemplates(dt => dt
+                .Add("idx_nested", d => d.PathMatch("idx.*").Match("nested-*").Mapping(dm => dm.Nested(o => o.Dynamic(DynamicMapping.True))))
+                .Add("idx_string", d => d.PathMatch("idx.*").Match("string-*").Mapping(dm => dm.Text(o => o.AddKeywordAndSortFields()))))
+            .Properties(p => p
+                .Text(p1 => p1.Field1, o => o.AddKeywordAndSortFields())
+            );
+    }
+
+    [Fact]
+    public async Task GetMapping_WithCustomFieldCreatedAfterMappingWasLoaded_ResolvesNewField()
+    {
+        // Arrange - resolve an existing field first so the resolver has already loaded the server mapping,
+        // exactly like a long lived per index resolver in a running process.
+        string index = await CreateRandomIndexAsync<MyNestedType>(MapDynamicCustomFieldType);
+        var resolver = ElasticMappingResolver.Create<MyNestedType>(MapDynamicCustomFieldType, Client, index, _logger);
+        Assert.Equal("field1.sort", resolver.GetSortFieldName("field1"));
+
+        // Act - index a document that materializes the custom fields through the dynamic templates
+        await Client.IndexAsync(new Dictionary<string, object>
+        {
+            { "field1", "value1" },
+            {
+                "idx", new Dictionary<string, object>
+                {
+                    { "nested-000001", new[] { new Dictionary<string, object> { { "value", "banana" } } } },
+                    { "string-000001", "apple" }
+                }
+            }
+        }, d => d.Index(index), TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, cancellationToken: TestCancellationToken);
+
+        // Assert
+        Assert.True(resolver.IsNestedPropertyType("idx.nested-000001"));
+        Assert.Equal("idx.nested-000001.value", resolver.GetResolvedField("idx.nested-000001.value"));
+        Assert.Equal("idx.string-000001.sort", resolver.GetSortFieldName("idx.string-000001"));
+        Assert.Equal("idx.string-000001.keyword", resolver.GetAggregationsFieldName("idx.string-000001"));
+    }
+
+    [Fact]
+    public async Task GetMapping_WithCustomFieldCachedAsUnmappedBeforeItWasCreated_ResolvesNewField()
+    {
+        // Arrange - the field is queried (and cached as unmapped) before it exists in the index mapping
+        string index = await CreateRandomIndexAsync<MyNestedType>(MapDynamicCustomFieldType);
+        var resolver = ElasticMappingResolver.Create<MyNestedType>(MapDynamicCustomFieldType, Client, index, _logger);
+        resolver.UnmappedFieldRefreshInterval = TimeSpan.Zero;
+        Assert.False(resolver.IsNestedPropertyType("idx.nested-000001"));
+
+        // Act
+        await Client.IndexAsync(new Dictionary<string, object>
+        {
+            { "field1", "value1" },
+            { "idx", new Dictionary<string, object> { { "nested-000001", new[] { new Dictionary<string, object> { { "value", "banana" } } } } } }
+        }, d => d.Index(index), TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, cancellationToken: TestCancellationToken);
+
+        // Assert
+        Assert.True(resolver.IsNestedPropertyType("idx.nested-000001"));
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Mapping;
 using Foundatio.Parsers.ElasticQueries.Extensions;
+using Foundatio.Parsers.ElasticQueries.Visitors;
 using Xunit;
 
 namespace Foundatio.Parsers.ElasticQueries.Tests;
@@ -226,7 +227,16 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
         }, d => d.Index(index), TestCancellationToken);
         await Client.Indices.RefreshAsync(index, cancellationToken: TestCancellationToken);
 
-        // Assert
+        // Act
+        var parser = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(resolver).UseNested());
+        var query = await parser.BuildQueryAsync("idx.nested-000001.value:banana", new ElasticQueryVisitorContext { UseScoring = true });
+        var sort = await parser.BuildSortAsync("idx.string-000001");
+        var response = await Client.SearchAsync<object>(d => d.Indices(index).Query(query).Sort(sort), TestCancellationToken);
+
+        // Assert - execute the generated nested query and dynamic text sort, rather than only inspecting
+        // resolver metadata. A stale mapping would flatten the query or sort on the analyzed text field.
+        Assert.True(response.IsValidResponse);
+        Assert.Equal(1, response.Total);
         Assert.True(resolver.IsNestedPropertyType("idx.nested-000001"));
         Assert.Equal("idx.nested-000001.value", resolver.GetResolvedField("idx.nested-000001.value"));
         Assert.Equal("idx.string-000001.sort", resolver.GetSortFieldName("idx.string-000001"));
@@ -234,12 +244,12 @@ public class ElasticMappingResolverTests : ElasticsearchTestBase
     }
 
     [Fact]
-    public async Task GetMapping_WithCustomFieldCachedAsUnmappedBeforeItWasCreated_ResolvesNewField()
+    public async Task GetMapping_WithCustomFieldQueriedBeforeItWasCreated_ResolvesNewField()
     {
-        // Arrange - the field is queried (and cached as unmapped) before it exists in the index mapping
+        // Arrange - the field is queried before it exists in the index mapping.
         string index = await CreateRandomIndexAsync<MyNestedType>(MapDynamicCustomFieldType);
         var resolver = ElasticMappingResolver.Create<MyNestedType>(MapDynamicCustomFieldType, Client, index, _logger);
-        resolver.UnmappedFieldRefreshInterval = TimeSpan.Zero;
+        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromMilliseconds(1);
         Assert.False(resolver.IsNestedPropertyType("idx.nested-000001"));
 
         // Act

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -624,6 +624,60 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         Assert.Equal(TimeSpan.FromMinutes(1), resolver.MappingRefreshInterval);
     }
 
+    [Theory]
+    [InlineData("keyword")]
+    [InlineData("date")]
+    [InlineData("long")]
+    [InlineData("boolean")]
+    [InlineData("ip")]
+    public void GetMapping_WithMultiFieldOnNonTextProperty_ResolvesSubField(string propertyType)
+    {
+        // Arrange - every Elasticsearch property type can carry multi-fields, not just text. Resolving them
+        // for text only silently reports "field.subfield" as unmapped for every other type.
+        IProperty property = propertyType switch
+        {
+            "keyword" => new KeywordProperty(),
+            "date" => new DateProperty(),
+            "long" => new LongNumberProperty(),
+            "boolean" => new BooleanProperty(),
+            "ip" => new IpProperty(),
+            _ => throw new ArgumentOutOfRangeException(nameof(propertyType))
+        };
+
+        var subFields = new Properties();
+        subFields.Add("sort", new KeywordProperty());
+        SetMultiFields(property, subFields);
+
+        var properties = new Properties();
+        properties.Add("code", property);
+        using var resolver = new ElasticMappingResolver(() => new TypeMapping { Properties = properties }, _inferrer, logger: _logger);
+
+        // Act
+        var parent = resolver.GetMapping("code");
+        var subField = resolver.GetMapping("code.sort");
+
+        // Assert
+        Assert.NotNull(parent);
+        Assert.True(parent.Found);
+        Assert.NotNull(subField);
+        Assert.True(subField.Found);
+        Assert.Equal("code.sort", subField.FullPath);
+        Assert.IsType<KeywordProperty>(subField.Property);
+    }
+
+    private static void SetMultiFields(IProperty property, Properties fields)
+    {
+        switch (property)
+        {
+            case KeywordProperty p: p.Fields = fields; break;
+            case DateProperty p: p.Fields = fields; break;
+            case LongNumberProperty p: p.Fields = fields; break;
+            case BooleanProperty p: p.Fields = fields; break;
+            case IpProperty p: p.Fields = fields; break;
+            default: throw new ArgumentOutOfRangeException(nameof(property));
+        }
+    }
+
     [Fact]
     public async Task GetMapping_WithConcurrentLookupsOfSameUnmappedField_BacksOffOncePerReload()
     {

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -249,47 +249,390 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public void GetServerMapping_WhenThrottled_DoesNotRefetchWithinOneMinute()
+    public void GetMapping_WithResolvedFieldWithinRefreshInterval_DoesNotRefetchServerMapping()
     {
         // Arrange
         var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
         int fetchCount = 0;
-        var resolver = new ElasticMappingResolver(() =>
+        using var resolver = new ElasticMappingResolver(() =>
         {
             Interlocked.Increment(ref fetchCount);
             return CreateTextWithKeywordMapping("name");
         }, _inferrer, timeProvider: timeProvider, logger: _logger);
 
-        // Act - first call triggers initial server fetch
+        // Act
         resolver.GetNonAnalyzedFieldName("name", "keyword");
-        int afterFirst = fetchCount;
-        Assert.True(afterFirst >= 1, "First call should trigger at least one fetch");
+        int afterColdStart = fetchCount;
 
-        // Act - second call within throttle window should use cache, no new fetch
-        resolver.GetNonAnalyzedFieldName("name", "keyword");
-        Assert.Equal(afterFirst, fetchCount);
-
-        // Act - advance 30s (still within 1-minute window), query unknown field to bypass cache
         timeProvider.Advance(TimeSpan.FromSeconds(30));
-        resolver.GetNonAnalyzedFieldName("unknown_field", "keyword");
-        Assert.Equal(afterFirst, fetchCount);
+        resolver.GetNonAnalyzedFieldName("name", "keyword");
 
-        // Act - RefreshMapping bypasses throttle even within window
+        // Assert
+        Assert.Equal(1, afterColdStart);
+        Assert.Equal(afterColdStart, fetchCount);
+    }
+
+    [Fact]
+    public void RefreshMapping_WithinRefreshInterval_BypassesThrottleAndRefetchesServerMapping()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        resolver.GetNonAnalyzedFieldName("name", "keyword");
+        int afterColdStart = fetchCount;
+
+        // Act
         resolver.RefreshMapping();
         resolver.GetNonAnalyzedFieldName("name", "keyword");
-        int afterRefresh = fetchCount;
-        Assert.True(afterRefresh > afterFirst, "Refresh should allow a new fetch");
 
-        // Act - call again without refresh, should be throttled
-        resolver.GetNonAnalyzedFieldName("name", "keyword");
-        Assert.Equal(afterRefresh, fetchCount);
+        // Assert
+        Assert.Equal(afterColdStart + 1, fetchCount);
+    }
 
-        // Act - advance past the 1-minute throttle window; resolve an uncached field
-        // WITHOUT calling RefreshMapping() to prove time-based expiry works on its own.
-        timeProvider.Advance(TimeSpan.FromMinutes(2));
-        resolver.GetNonAnalyzedFieldName("another_unknown_field", "keyword");
-        int afterTimeAdvance = fetchCount;
-        Assert.True(afterTimeAdvance > afterRefresh, "Fetch should happen after time advances past throttle without RefreshMapping");
+    [Fact]
+    public void IsNestedPropertyType_WithNestedFieldCreatedAfterColdStartFetch_ReturnsTrue()
+    {
+        // Arrange - a dynamic template creates idx.nested-000001 only after the first document is indexed,
+        // which is always after the resolver has already loaded the mapping at least once.
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var serverMapping = CreateTextWithKeywordMapping("field1");
+        using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        Assert.Equal("field1.keyword", resolver.GetNonAnalyzedFieldName("field1", "keyword"));
+
+        // Act
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        serverMapping = CreateDynamicCustomFieldMapping("field1", "nested-000001", new NestedProperty { Properties = CreateProperties(("value", new KeywordProperty())) });
+
+        // Assert
+        Assert.True(resolver.IsNestedPropertyType("idx.nested-000001"));
+        Assert.Equal("idx.nested-000001.value", resolver.GetResolvedField("idx.nested-000001.value"));
+    }
+
+    [Fact]
+    public void GetSortFieldName_WithKeywordSubFieldCreatedAfterColdStartFetch_ReturnsKeywordSubField()
+    {
+        // Arrange - sorting on a text field without resolving its keyword sub field produces an
+        // "Fielddata is disabled" error from Elasticsearch, so a stale mapping is a hard failure here.
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var serverMapping = CreateTextWithKeywordMapping("field1");
+        using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        resolver.GetNonAnalyzedFieldName("field1", "keyword");
+
+        // Act
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        serverMapping = CreateDynamicCustomFieldMapping("field1", "string-000001",
+            new TextProperty { Fields = CreateProperties(("keyword", new KeywordProperty { IgnoreAbove = 256 })) });
+
+        // Assert
+        Assert.Equal("idx.string-000001.keyword", resolver.GetSortFieldName("idx.string-000001"));
+    }
+
+    [Fact]
+    public void GetMapping_WithUnmappedFieldWithinUnmappedRefreshInterval_DoesNotRefetchServerMapping()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        resolver.GetMapping("name");
+        Assert.Equal(1, fetchCount);
+
+        // Act
+        resolver.GetMapping("missing_one");
+        int afterFirstMiss = fetchCount;
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        resolver.GetMapping("missing_two");
+
+        // Assert
+        Assert.Equal(2, afterFirstMiss);
+        Assert.Equal(afterFirstMiss, fetchCount);
+    }
+
+    [Fact]
+    public void GetMapping_WithRepeatedlyUnresolvableFields_BacksOffServerMappingReloads()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        resolver.GetMapping("name");
+        resolver.GetMapping("missing_1");
+        Assert.Equal(2, fetchCount);
+
+        // Act + Assert - a reload that did not resolve the field doubles the interval to 10s
+        timeProvider.Advance(TimeSpan.FromSeconds(9));
+        resolver.GetMapping("missing_2");
+        Assert.Equal(2, fetchCount);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        resolver.GetMapping("missing_3");
+        Assert.Equal(3, fetchCount);
+
+        // Act + Assert - and again to 20s
+        timeProvider.Advance(TimeSpan.FromSeconds(19));
+        resolver.GetMapping("missing_4");
+        Assert.Equal(3, fetchCount);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        resolver.GetMapping("missing_5");
+        Assert.Equal(4, fetchCount);
+    }
+
+    [Fact]
+    public void GetMapping_WithFieldResolvedByReload_ResetsUnmappedRefreshBackoff()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        var serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return serverMapping;
+        }, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        resolver.GetMapping("name");
+        resolver.GetMapping("missing_1");
+        resolver.GetMapping("missing_2");
+        int afterBackoff = fetchCount;
+
+        // Act - the field now exists, so the reload that finds it must reset the backoff
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
+        var created = resolver.GetMapping("idx.keyword-000001");
+
+        timeProvider.Advance(TimeSpan.FromSeconds(5));
+        resolver.GetMapping("missing_3");
+
+        // Assert
+        Assert.NotNull(created);
+        Assert.True(created.Found);
+        Assert.Equal(afterBackoff + 2, fetchCount);
+    }
+
+    [Fact]
+    public void GetMapping_WithCachedMissAfterFieldIsCreated_ResolvesFieldOnNextLookup()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        var beforeCreate = resolver.GetMapping("idx.keyword-000001");
+        Assert.NotNull(beforeCreate);
+        Assert.False(beforeCreate.Found);
+
+        // Act
+        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+        var afterCreate = resolver.GetMapping("idx.keyword-000001");
+
+        // Assert
+        Assert.NotNull(afterCreate);
+        Assert.True(afterCreate.Found);
+        Assert.Equal("idx.keyword-000001", afterCreate.FullPath);
+    }
+
+    [Fact]
+    public void InvalidateFieldMapping_WithCachedMissForNewlyCreatedField_ResolvesFieldWithoutWaitingForThrottle()
+    {
+        // Arrange - arm the unmapped field throttle so the cached miss cannot refresh itself
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        Assert.False(resolver.GetMapping("name.missing")!.Found);
+        Assert.False(resolver.GetMapping("idx.keyword-000001")!.Found);
+
+        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
+        Assert.False(resolver.GetMapping("idx.keyword-000001")!.Found);
+
+        // Act
+        resolver.InvalidateFieldMapping("idx.keyword-000001");
+        var mapping = resolver.GetMapping("idx.keyword-000001");
+
+        // Assert
+        Assert.NotNull(mapping);
+        Assert.True(mapping.Found);
+    }
+
+    [Fact]
+    public void GetMapping_WhenServerMappingFuncThrows_DoesNotRefetchOnEveryLookup()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            throw new InvalidOperationException("Elasticsearch is unavailable");
+        }, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        // Act
+        for (int i = 0; i < 25; i++)
+            Assert.False(resolver.GetMapping($"field_{i}")!.Found);
+
+        // Assert - one cold start attempt plus one miss driven attempt, then throttled
+        Assert.Equal(2, fetchCount);
+    }
+
+    [Fact]
+    public async Task GetMapping_WithConcurrentUnmappedLookups_FetchesServerMappingOnce()
+    {
+        // Arrange
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            Thread.Sleep(100);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+
+        resolver.GetMapping("name");
+        int afterColdStart = fetchCount;
+
+        // Act
+        var lookups = Enumerable.Range(0, 16)
+            .Select(_ => Task.Run(() => resolver.GetMapping("idx.keyword-000001")))
+            .ToArray();
+        await Task.WhenAll(lookups);
+
+        // Assert
+        Assert.Equal(1, afterColdStart);
+        Assert.Equal(afterColdStart + 1, fetchCount);
+        Assert.All(lookups, t => Assert.False(t.Result!.Found));
+    }
+
+    [Fact]
+    public async Task GetMapping_WithConcurrentLookupsOfSameUnmappedField_BacksOffOncePerReload()
+    {
+        // Arrange - every one of these lookups adopts the result of a single reload, so the backoff must
+        // only advance one step rather than being ratcheted to the ceiling by the burst.
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        resolver.GetMapping("name");
+        int afterColdStart = fetchCount;
+
+        // Act
+        await Task.WhenAll(Enumerable.Range(0, 32).Select(_ => Task.Run(() => resolver.GetMapping("idx.keyword-000001"))));
+        int afterBurst = fetchCount;
+
+        timeProvider.Advance(TimeSpan.FromSeconds(10));
+        resolver.GetMapping("idx.keyword-000002");
+
+        // Assert - one reload for the burst, then one more after a single 10s backoff step
+        Assert.Equal(1, afterColdStart);
+        Assert.Equal(2, afterBurst);
+        Assert.Equal(3, fetchCount);
+    }
+
+    [Fact]
+    public void GetMapping_WithMoreDistinctFieldsThanMaxCachedFields_BoundsCachedFieldCount()
+    {
+        // Arrange
+        using var resolver = new ElasticMappingResolver(CreateTextWithKeywordMapping("name"), _inferrer, () => null, logger: _logger)
+        {
+            MaxCachedFields = 16
+        };
+
+        // Act
+        for (int i = 0; i < 500; i++)
+            resolver.GetMapping($"unknown_field_{i}");
+
+        // Assert
+        Assert.True(resolver.CachedFieldCount <= 16, $"Expected at most 16 cached fields but found {resolver.CachedFieldCount}");
+    }
+
+    [Fact]
+    public void GetMapping_WithCodeSubPropertyUnderServerNestedProperty_ResolvesCodeSubProperty()
+    {
+        // Arrange - the server mapping only knows the sub fields that have actually been indexed, so
+        // code declared sub properties of a nested property must still be merged in.
+        var codeMapping = new TypeMapping
+        {
+            Properties = CreateProperties(("items", new NestedProperty { Properties = CreateProperties(("code_only", new KeywordProperty())) }))
+        };
+        var serverMapping = new TypeMapping
+        {
+            Properties = CreateProperties(("items", new NestedProperty { Properties = CreateProperties(("server_only", new KeywordProperty())) }))
+        };
+        using var resolver = new ElasticMappingResolver(codeMapping, _inferrer, () => serverMapping, logger: _logger);
+
+        // Act
+        var codeOnly = resolver.GetMapping("items.code_only");
+        var serverOnly = resolver.GetMapping("items.server_only");
+
+        // Assert
+        Assert.NotNull(codeOnly);
+        Assert.True(codeOnly.Found);
+        Assert.IsType<KeywordProperty>(codeOnly.Property);
+        Assert.NotNull(serverOnly);
+        Assert.True(serverOnly.Found);
+        Assert.True(resolver.IsNestedPropertyType("items"));
+    }
+
+    [Fact]
+    public void GetResolvedField_WithPropertyInstanceSharedByMultipleFields_ResolvesEachFieldName()
+    {
+        // Arrange - reusing a single IProperty instance for multiple fields is legal and used to make
+        // every one of those fields resolve to the name of the first one.
+        var shared = new KeywordProperty();
+        var serverMapping = new TypeMapping { Properties = CreateProperties(("alpha", shared), ("beta", shared)) };
+        using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer, logger: _logger);
+
+        // Act
+        string? alpha = resolver.GetResolvedField("alpha");
+        string? beta = resolver.GetResolvedField("beta");
+
+        // Assert
+        Assert.Equal("alpha", alpha);
+        Assert.Equal("beta", beta);
+    }
+
+    private static Properties CreateProperties(params (string Name, IProperty Property)[] properties)
+    {
+        var props = new Properties();
+        foreach ((string name, var property) in properties)
+            props.Add(name, property);
+
+        return props;
+    }
+
+    /// <summary>
+    /// Builds a mapping containing the original field plus an <c>idx.&lt;name&gt;</c> custom field of the
+    /// kind created at runtime by an <c>idx.*</c> dynamic template.
+    /// </summary>
+    private static TypeMapping CreateDynamicCustomFieldMapping(string existingFieldName, string customFieldName, IProperty customField)
+    {
+        var mapping = CreateTextWithKeywordMapping(existingFieldName);
+        mapping.Properties!.Add("idx", new ObjectProperty { Properties = CreateProperties((customFieldName, customField)) });
+
+        return mapping;
     }
 
     private static TypeMapping CreateTextWithKeywordMapping(string fieldName)

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -346,7 +346,6 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             Interlocked.Increment(ref fetchCount);
             return CreateTextWithKeywordMapping("name");
         }, _inferrer, timeProvider: timeProvider, logger: _logger);
-        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(5);
 
         resolver.GetMapping("name");
         Assert.Equal(1, fetchCount);
@@ -374,7 +373,6 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             Interlocked.Increment(ref fetchCount);
             return CreateTextWithKeywordMapping("name");
         }, _inferrer, timeProvider: timeProvider, logger: _logger);
-        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(5);
 
         resolver.GetMapping("name");
         resolver.GetMapping("missing_1");
@@ -411,7 +409,6 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             Interlocked.Increment(ref fetchCount);
             return serverMapping;
         }, _inferrer, timeProvider: timeProvider, logger: _logger);
-        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(5);
 
         resolver.GetMapping("name");
         resolver.GetMapping("missing_1");
@@ -552,12 +549,12 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
 
         // Act - this lookup gives up joining the in-flight fetch
-        resolver.FetchJoinTimeout = TimeSpan.FromMilliseconds(50);
+        resolver.MappingRefreshWaitTimeout = TimeSpan.FromMilliseconds(50);
         var timedOutLookup = resolver.GetMapping("idx.keyword-000001");
 
         // Act - a later lookup, still while that same fetch is running, must join it rather than be served
         // the unmapped result the timed out lookup just produced
-        resolver.FetchJoinTimeout = TimeSpan.FromSeconds(30);
+        resolver.MappingRefreshWaitTimeout = TimeSpan.FromSeconds(30);
         var joiningLookup = Task.Run(() => resolver.GetMapping("idx.keyword-000001"));
         await Task.Delay(200, TestContext.Current.CancellationToken);
         releaseFetch.Set();
@@ -612,15 +609,15 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public void FetchJoinTimeout_ByDefault_ExceedsTypicalMappingFetchLatency()
+    public void MappingRefreshWaitTimeout_ByDefault_ExceedsTypicalMappingFetchLatency()
     {
         // Arrange + Act
         using var resolver = new ElasticMappingResolver(() => CreateTextWithKeywordMapping("name"), _inferrer, logger: _logger);
 
         // Assert - waiting for an in-flight fetch is never more expensive than performing it, so the default
         // must leave plenty of headroom above a normal get mapping round trip
-        Assert.Equal(TimeSpan.FromSeconds(30), resolver.FetchJoinTimeout);
-        Assert.Equal(TimeSpan.FromSeconds(1), resolver.UnmappedFieldRefreshInterval);
+        Assert.Equal(TimeSpan.FromSeconds(30), resolver.MappingRefreshWaitTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(5), resolver.UnmappedFieldRefreshInterval);
         Assert.Equal(TimeSpan.FromMinutes(1), resolver.MappingRefreshInterval);
     }
 
@@ -634,15 +631,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     {
         // Arrange - every Elasticsearch property type can carry multi-fields, not just text. Resolving them
         // for text only silently reports "field.subfield" as unmapped for every other type.
-        IProperty property = propertyType switch
-        {
-            "keyword" => new KeywordProperty(),
-            "date" => new DateProperty(),
-            "long" => new LongNumberProperty(),
-            "boolean" => new BooleanProperty(),
-            "ip" => new IpProperty(),
-            _ => throw new ArgumentOutOfRangeException(nameof(propertyType))
-        };
+        var property = CreateProperty(propertyType);
 
         var subFields = new Properties();
         subFields.Add("sort", new KeywordProperty());
@@ -663,6 +652,326 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         Assert.True(subField.Found);
         Assert.Equal("code.sort", subField.FullPath);
         Assert.IsType<KeywordProperty>(subField.Property);
+    }
+
+
+    [Theory]
+    [InlineData("keyword")]
+    [InlineData("date")]
+    [InlineData("long")]
+    [InlineData("boolean")]
+    [InlineData("ip")]
+    public void GetMapping_WithCodeDeclaredMultiFieldOnNonTextServerProperty_ResolvesSubField(string propertyType)
+    {
+        // Arrange - the server reports the property without the multi-field the code mapping declares.
+        // Merging has to layer the code declared sub-field on for every property type, not just text.
+        IProperty codeProperty = CreateProperty(propertyType);
+        var codeSubFields = new Properties();
+        codeSubFields.Add("sort", new KeywordProperty());
+        SetMultiFields(codeProperty, codeSubFields);
+
+        var codeProperties = new Properties();
+        codeProperties.Add("code", codeProperty);
+
+        var serverProperties = new Properties();
+        serverProperties.Add("code", CreateProperty(propertyType));
+
+        using var resolver = new ElasticMappingResolver(new TypeMapping { Properties = codeProperties }, _inferrer,
+            () => new TypeMapping { Properties = serverProperties }, logger: _logger);
+
+        // Act
+        var subField = resolver.GetMapping("code.sort");
+
+        // Assert
+        Assert.NotNull(subField);
+        Assert.True(subField.Found);
+        Assert.Equal("code.sort", subField.FullPath);
+        Assert.IsType<KeywordProperty>(subField.Property);
+    }
+
+    [Fact]
+    public void GetMapping_WithCodeAndServerMappings_DoesNotMutateServerMapping()
+    {
+        // Arrange - the merged view must not be written back into the mapping the callback returned,
+        // otherwise a caller that caches or shares that instance sees it grow sub-fields over time.
+        var codeProperty = new KeywordProperty();
+        var codeSubFields = new Properties();
+        codeSubFields.Add("sort", new KeywordProperty());
+        codeProperty.Fields = codeSubFields;
+
+        var codeProperties = new Properties();
+        codeProperties.Add("code", codeProperty);
+
+        var serverProperty = new KeywordProperty();
+        var serverProperties = new Properties();
+        serverProperties.Add("code", serverProperty);
+
+        using var resolver = new ElasticMappingResolver(new TypeMapping { Properties = codeProperties }, _inferrer,
+            () => new TypeMapping { Properties = serverProperties }, logger: _logger);
+
+        // Act
+        var subField = resolver.GetMapping("code.sort");
+
+        // Assert
+        Assert.True(subField?.Found);
+        Assert.Null(serverProperty.Fields);
+    }
+
+    [Fact]
+    public void GetNonAnalyzedFieldName_WithCodeDeclaredKeywordSubField_UsesCodeDeclaredSubField()
+    {
+        // Arrange - sorting on an analyzed field fails unless the non analyzed sub-field is found, and the
+        // sub-field may only be declared in code.
+        var codeProperty = new TextProperty();
+        var codeSubFields = new Properties();
+        codeSubFields.Add("keyword", new KeywordProperty());
+        codeProperty.Fields = codeSubFields;
+
+        var codeProperties = new Properties();
+        codeProperties.Add("name", codeProperty);
+
+        var serverProperties = new Properties();
+        serverProperties.Add("name", new TextProperty());
+
+        using var resolver = new ElasticMappingResolver(new TypeMapping { Properties = codeProperties }, _inferrer,
+            () => new TypeMapping { Properties = serverProperties }, logger: _logger);
+
+        // Act
+        string? resolved = resolver.GetNonAnalyzedFieldName("name");
+
+        // Assert
+        Assert.Equal("name.keyword", resolved);
+    }
+
+    [Fact]
+    public void MaxCachedFields_WhenExceededByUnmappedFields_EvictsMissesAndKeepsResolvedFields()
+    {
+        // Arrange - field names come from user supplied queries, so a caller probing many non-existent
+        // fields must not be able to displace the resolutions real queries depend on.
+        var properties = new Properties();
+        properties.Add("name", new KeywordProperty());
+        properties.Add("status", new KeywordProperty());
+        properties.Add("created", new DateProperty());
+        properties.Add("count", new LongNumberProperty());
+        string[] realFields = ["name", "status", "created", "count"];
+
+        using var resolver = new ElasticMappingResolver(() => new TypeMapping { Properties = properties }, _inferrer,
+            new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+        resolver.MaxCachedFields = 8;
+        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromHours(1);
+
+        // Arm both reload throttles before caching anything worth keeping. The first lookup triggers the
+        // cold start load and the second arms the separate unmapped field throttle, so the flood below
+        // exercises cache eviction rather than snapshot replacement.
+        Assert.False(resolver.GetMapping("warmup1")?.Found);
+        Assert.False(resolver.GetMapping("warmup2")?.Found);
+
+        foreach (string realField in realFields)
+            Assert.True(resolver.GetMapping(realField)?.Found);
+
+        // Act
+        for (int i = 0; i < 100; i++)
+            resolver.GetMapping($"missing{i}");
+
+        long countAfterFlood = resolver.CachedFieldCount;
+        foreach (string realField in realFields)
+            Assert.True(resolver.GetMapping(realField)?.Found);
+
+        // Assert - re-resolving the real fields added nothing, so they were still cached.
+        Assert.Equal(countAfterFlood, resolver.CachedFieldCount);
+        Assert.True(countAfterFlood <= resolver.MaxCachedFields,
+            $"Expected cache to stay bounded but it held {countAfterFlood} fields.");
+    }
+
+    [Fact]
+    public void MaxCachedFields_WhenSetToZero_DisablesCachingWithoutBreakingResolution()
+    {
+        // Arrange
+        using var resolver = new ElasticMappingResolver(() => CreateTextWithKeywordMapping("name"), _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+        resolver.MaxCachedFields = 0;
+
+        // Act
+        var first = resolver.GetMapping("name");
+        var second = resolver.GetMapping("name");
+
+        // Assert
+        Assert.True(first?.Found);
+        Assert.True(second?.Found);
+        Assert.Equal(0, resolver.CachedFieldCount);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-60)]
+    public void MappingRefreshInterval_WithNegativeValue_ThrowsArgumentOutOfRangeException(int seconds)
+    {
+        // Arrange
+        using var resolver = new ElasticMappingResolver(() => null, _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+
+        // Act
+        var exception = Record.Exception(() => resolver.MappingRefreshInterval = TimeSpan.FromSeconds(seconds));
+
+        // Assert
+        var argumentException = Assert.IsType<ArgumentOutOfRangeException>(exception);
+        Assert.Equal("value", argumentException.ParamName);
+    }
+
+    [Fact]
+    public void UnmappedFieldRefreshInterval_WithNegativeValue_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        using var resolver = new ElasticMappingResolver(() => null, _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+
+        // Act
+        var exception = Record.Exception(() => resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(-1));
+
+        // Assert
+        var argumentException = Assert.IsType<ArgumentOutOfRangeException>(exception);
+        Assert.Equal("value", argumentException.ParamName);
+    }
+
+    [Fact]
+    public void UnmappedFieldRefreshInterval_WithZero_AlwaysAllowsReload()
+    {
+        // Arrange - zero means "never throttle", which must be accepted rather than treated as invalid.
+        int callCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            callCount++;
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+        resolver.UnmappedFieldRefreshInterval = TimeSpan.Zero;
+
+        Assert.True(resolver.GetMapping("name")?.Found);
+        int callsAfterColdStart = callCount;
+
+        // Act
+        resolver.GetMapping("missing1");
+        resolver.GetMapping("missing2");
+
+        // Assert
+        Assert.True(callCount > callsAfterColdStart + 1,
+            $"Expected each unmapped lookup to reload but only {callCount - callsAfterColdStart} reloads occurred.");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void MappingRefreshWaitTimeout_WithNonPositiveValue_ThrowsArgumentOutOfRangeException(int seconds)
+    {
+        // Arrange - a zero or negative wait would silently resolve fields as unmapped while a reload that
+        // could resolve them is already running.
+        using var resolver = new ElasticMappingResolver(() => null, _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+
+        // Act
+        var exception = Record.Exception(() => resolver.MappingRefreshWaitTimeout = TimeSpan.FromSeconds(seconds));
+
+        // Assert
+        var argumentException = Assert.IsType<ArgumentOutOfRangeException>(exception);
+        Assert.Equal("value", argumentException.ParamName);
+    }
+
+    [Fact]
+    public void MappingRefreshWaitTimeout_WithInfiniteTimeSpan_IsAccepted()
+    {
+        // Arrange - waiting forever is safe when the fetch callback enforces its own timeout, and
+        // Timeout.InfiniteTimeSpan is the idiomatic way to express it.
+        using var resolver = new ElasticMappingResolver(() => CreateTextWithKeywordMapping("name"), _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+
+        // Act
+        resolver.MappingRefreshWaitTimeout = Timeout.InfiniteTimeSpan;
+
+        // Assert
+        Assert.Equal(Timeout.InfiniteTimeSpan, resolver.MappingRefreshWaitTimeout);
+        Assert.True(resolver.GetMapping("name")?.Found);
+    }
+
+    [Fact]
+    public void NullInstance_WhenResolvingAnyField_ReportsFieldAsUnmapped()
+    {
+        // Arrange - the shared null resolver never has a mapping, so every field resolves to its own name
+        // and callers fall back to the raw field name instead of failing.
+        var resolver = ElasticMappingResolver.NullInstance;
+
+        // Act
+        var mapping = resolver.GetMapping("name");
+
+        // Assert
+        Assert.NotNull(mapping);
+        Assert.False(mapping.Found);
+        Assert.Equal("name", mapping.FullPath);
+    }
+
+    [Fact]
+    public void GetMapping_WithoutAnyMappingSource_ThrowsInvalidOperationException()
+    {
+        // Arrange - a resolver constructed with neither a code mapping nor a server mapping callback is a
+        // configuration error and must fail loudly rather than reporting every field as unmapped.
+        using var resolver = new ElasticMappingResolver(null!, _inferrer, logger: _logger);
+
+        // Act
+        var exception = Record.Exception(() => resolver.GetMapping("name"));
+
+        // Assert
+        Assert.IsType<InvalidOperationException>(exception);
+    }
+
+    [Theory]
+    [InlineData("text", true)]
+    [InlineData("keyword", false)]
+    [InlineData("long", false)]
+    [InlineData("date", false)]
+    public void IsPropertyAnalyzed_ForPropertyType_ReportsWhetherFieldIsAnalyzed(string propertyType, bool expected)
+    {
+        // Arrange
+        var properties = new Properties();
+        properties.Add("field", propertyType == "text" ? new TextProperty() : CreateProperty(propertyType));
+        using var resolver = new ElasticMappingResolver(() => new TypeMapping { Properties = properties }, _inferrer, logger: _logger);
+
+        // Act
+        bool analyzed = resolver.IsPropertyAnalyzed("field");
+
+        // Assert
+        Assert.Equal(expected, analyzed);
+    }
+
+    [Fact]
+    public void PropertyTypePredicates_ForMatchingAndNonMatchingFields_ReportPropertyCategory()
+    {
+        // Arrange
+        var properties = new Properties();
+        properties.Add("location", new GeoPointProperty());
+        properties.Add("count", new LongNumberProperty());
+        properties.Add("enabled", new BooleanProperty());
+        properties.Add("created", new DateProperty());
+        properties.Add("name", new KeywordProperty());
+        using var resolver = new ElasticMappingResolver(() => new TypeMapping { Properties = properties }, _inferrer, logger: _logger);
+
+        // Act & Assert
+        Assert.True(resolver.IsGeoPropertyType("location"));
+        Assert.False(resolver.IsGeoPropertyType("name"));
+
+        Assert.True(resolver.IsNumericPropertyType("count"));
+        Assert.False(resolver.IsNumericPropertyType("name"));
+
+        Assert.True(resolver.IsBooleanPropertyType("enabled"));
+        Assert.False(resolver.IsBooleanPropertyType("name"));
+
+        Assert.True(resolver.IsDatePropertyType("created"));
+        Assert.False(resolver.IsDatePropertyType("name"));
+    }
+
+    private static IProperty CreateProperty(string propertyType)
+    {
+        return propertyType switch
+        {
+            "keyword" => new KeywordProperty(),
+            "date" => new DateProperty(),
+            "long" => new LongNumberProperty(),
+            "boolean" => new BooleanProperty(),
+            "ip" => new IpProperty(),
+            _ => throw new ArgumentOutOfRangeException(nameof(propertyType))
+        };
     }
 
     private static void SetMultiFields(IProperty property, Properties fields)
@@ -690,7 +999,6 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             Interlocked.Increment(ref fetchCount);
             return CreateTextWithKeywordMapping("name");
         }, _inferrer, timeProvider: timeProvider, logger: _logger);
-        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(5);
 
         resolver.GetMapping("name");
         int afterColdStart = fetchCount;

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -346,6 +346,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             Interlocked.Increment(ref fetchCount);
             return CreateTextWithKeywordMapping("name");
         }, _inferrer, timeProvider: timeProvider, logger: _logger);
+        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(5);
 
         resolver.GetMapping("name");
         Assert.Equal(1, fetchCount);
@@ -373,6 +374,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             Interlocked.Increment(ref fetchCount);
             return CreateTextWithKeywordMapping("name");
         }, _inferrer, timeProvider: timeProvider, logger: _logger);
+        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(5);
 
         resolver.GetMapping("name");
         resolver.GetMapping("missing_1");
@@ -409,6 +411,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             Interlocked.Increment(ref fetchCount);
             return serverMapping;
         }, _inferrer, timeProvider: timeProvider, logger: _logger);
+        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(5);
 
         resolver.GetMapping("name");
         resolver.GetMapping("missing_1");
@@ -523,6 +526,105 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
+    public async Task GetMapping_WithLookupDuringFetchThatOutlastedJoinTimeout_StillJoinsInFlightFetch()
+    {
+        // Arrange - a lookup that gives up joining an in-flight fetch reports the field as unmapped, but that
+        // must not stop later lookups from joining the same fetch and getting the real answer.
+        var fetchStarted = new ManualResetEventSlim(false);
+        var releaseFetch = new ManualResetEventSlim(false);
+        int fetchCount = 0;
+        var serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            if (Interlocked.Increment(ref fetchCount) > 1)
+            {
+                fetchStarted.Set();
+                releaseFetch.Wait(TimeSpan.FromSeconds(30));
+            }
+
+            return serverMapping;
+        }, _inferrer, logger: _logger);
+
+        resolver.GetMapping("name");
+        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
+
+        var inFlightFetch = Task.Run(() => resolver.GetMapping("idx.keyword-000001"));
+        Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
+
+        // Act - this lookup gives up joining the in-flight fetch
+        resolver.FetchJoinTimeout = TimeSpan.FromMilliseconds(50);
+        var timedOutLookup = resolver.GetMapping("idx.keyword-000001");
+
+        // Act - a later lookup, still while that same fetch is running, must join it rather than be served
+        // the unmapped result the timed out lookup just produced
+        resolver.FetchJoinTimeout = TimeSpan.FromSeconds(30);
+        var joiningLookup = Task.Run(() => resolver.GetMapping("idx.keyword-000001"));
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+        releaseFetch.Set();
+
+        // Assert
+        Assert.NotNull(timedOutLookup);
+        Assert.False(timedOutLookup.Found);
+
+        var joined = await joiningLookup;
+        Assert.NotNull(joined);
+        Assert.True(joined.Found);
+        Assert.Equal("idx.keyword-000001", joined.FullPath);
+
+        var completed = await inFlightFetch;
+        Assert.NotNull(completed);
+        Assert.True(completed.Found);
+    }
+
+    [Fact]
+    public async Task GetMapping_WithServerMappingFetchSlowerThanFiveSeconds_ResolvesFieldForAllConcurrentLookups()
+    {
+        // Arrange - the join timeout must comfortably exceed the mapping fetch latency, otherwise concurrent
+        // lookups give up on the very fetch that would have resolved their field and silently treat it as
+        // unmapped. Six seconds would have exceeded the previously hard coded five second join timeout.
+        int fetchCount = 0;
+        var serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            if (Interlocked.Increment(ref fetchCount) > 1)
+                Thread.Sleep(TimeSpan.FromSeconds(6));
+
+            return serverMapping;
+        }, _inferrer, logger: _logger);
+
+        resolver.GetMapping("name");
+        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
+
+        // Act
+        var lookups = Enumerable.Range(0, 8)
+            .Select(_ => Task.Run(() => resolver.GetMapping("idx.keyword-000001")))
+            .ToArray();
+        await Task.WhenAll(lookups);
+
+        // Assert - one fetch served them all and every caller got the real mapping
+        Assert.Equal(2, fetchCount);
+        Assert.All(lookups, t =>
+        {
+            Assert.NotNull(t.Result);
+            Assert.True(t.Result!.Found);
+            Assert.Equal("idx.keyword-000001", t.Result.FullPath);
+        });
+    }
+
+    [Fact]
+    public void FetchJoinTimeout_ByDefault_ExceedsTypicalMappingFetchLatency()
+    {
+        // Arrange + Act
+        using var resolver = new ElasticMappingResolver(() => CreateTextWithKeywordMapping("name"), _inferrer, logger: _logger);
+
+        // Assert - waiting for an in-flight fetch is never more expensive than performing it, so the default
+        // must leave plenty of headroom above a normal get mapping round trip
+        Assert.Equal(TimeSpan.FromSeconds(30), resolver.FetchJoinTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(1), resolver.UnmappedFieldRefreshInterval);
+        Assert.Equal(TimeSpan.FromMinutes(1), resolver.MappingRefreshInterval);
+    }
+
+    [Fact]
     public async Task GetMapping_WithConcurrentLookupsOfSameUnmappedField_BacksOffOncePerReload()
     {
         // Arrange - every one of these lookups adopts the result of a single reload, so the backoff must
@@ -534,6 +636,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             Interlocked.Increment(ref fetchCount);
             return CreateTextWithKeywordMapping("name");
         }, _inferrer, timeProvider: timeProvider, logger: _logger);
+        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromSeconds(5);
 
         resolver.GetMapping("name");
         int afterColdStart = fetchCount;

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -912,6 +912,110 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         Assert.Equal(1, fetchCount);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetMapping_WithUnchangedServerRevision_PreservesResolvedFields(bool asynchronous)
+    {
+        var timeProvider = new FakeTimeProvider();
+        int fetches = 0;
+        TypeMapping Load()
+        {
+            fetches++;
+            return CreateTextWithKeywordMapping("name");
+        }
+
+        using var resolver = asynchronous
+            ? ElasticMappingResolver.CreateWithAsyncLoader(_ => Task.FromResult<TypeMapping?>(Load()), _inferrer, timeProvider)
+            : new ElasticMappingResolver(Load, _inferrer, timeProvider);
+        resolver.ServerMappingRevisionResolver = _ => "index-uuid:1";
+
+        var original = await ResolveAsync("name.keyword");
+        Assert.True(original?.Found);
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.False((await ResolveAsync("missing"))?.Found);
+            Assert.Same(original, await ResolveAsync("name.keyword"));
+            Assert.False((await ResolveAsync("another-missing"))?.Found);
+            Assert.Equal(i + 2, fetches);
+            timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+        }
+
+        async ValueTask<FieldMapping?> ResolveAsync(string field) => asynchronous
+            ? await resolver.GetMappingAsync(field, cancellationToken: TestCancellationToken)
+            : resolver.GetMapping(field);
+    }
+
+    [Theory]
+    [InlineData("index-uuid:2", false)]
+    [InlineData("new-index-uuid:1", false)]
+    [InlineData("INDEX-UUID:1", false)]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("index-uuid:1", true)]
+    public async Task GetMapping_WithChangedOrInvalidatedServerRevision_RebuildsMapping(string? revision, bool explicitRefresh)
+    {
+        var mapping = CreateTextWithKeywordMapping("name");
+        string? currentRevision = "index-uuid:1";
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ => Task.FromResult<TypeMapping?>(mapping), _inferrer);
+        resolver.ServerMappingRevisionResolver = _ => currentRevision;
+        var original = await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken);
+
+        mapping = new TypeMapping { Properties = CreateProperties(("name", new KeywordProperty()), ("new-field", new BooleanProperty())) };
+        currentRevision = revision;
+        if (explicitRefresh)
+            resolver.RefreshMapping();
+
+        Assert.True((await resolver.GetMappingAsync("new-field", cancellationToken: TestCancellationToken))?.Found);
+        var updated = await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken);
+        Assert.NotSame(original, updated);
+        Assert.IsType<KeywordProperty>(updated?.Property);
+    }
+
+    [Fact]
+    public void GetMapping_WithoutServerRevision_RebuildsMutatedMapping()
+    {
+        var mapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() => mapping, _inferrer);
+        var original = resolver.GetMapping("name");
+
+        mapping.Properties!["name"] = new KeywordProperty();
+        mapping.Properties.Add("new-field", new BooleanProperty());
+
+        Assert.True(resolver.GetMapping("new-field")?.Found);
+        Assert.NotSame(original, resolver.GetMapping("name"));
+        Assert.IsType<KeywordProperty>(resolver.GetMappingProperty("name"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetMapping_WithFailingServerRevisionResolver_PreservesMappingAndRetries(bool asynchronous)
+    {
+        var timeProvider = new FakeTimeProvider();
+        var mapping = CreateTextWithKeywordMapping("name");
+        using var resolver = asynchronous
+            ? ElasticMappingResolver.CreateWithAsyncLoader(_ => Task.FromResult<TypeMapping?>(mapping), _inferrer, timeProvider)
+            : new ElasticMappingResolver(() => mapping, _inferrer, timeProvider);
+        bool fail = false;
+        resolver.ServerMappingRevisionResolver = _ => fail ? throw new InvalidOperationException("Revision unavailable") : "index-uuid:1";
+        var original = await ResolveAsync("name");
+
+        fail = true;
+        mapping = new TypeMapping { Properties = CreateProperties(("new-field", new BooleanProperty())) };
+        Assert.False((await ResolveAsync("new-field"))?.Found);
+        Assert.Same(original, await ResolveAsync("name"));
+
+        fail = false;
+        resolver.ServerMappingRevisionResolver = _ => "index-uuid:2";
+        timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+        Assert.True((await ResolveAsync("new-field"))?.Found);
+
+        async ValueTask<FieldMapping?> ResolveAsync(string field) => asynchronous
+            ? await resolver.GetMappingAsync(field, cancellationToken: TestCancellationToken)
+            : resolver.GetMapping(field);
+    }
+
     [Fact]
     public void GetMapping_WithChangedResolvedField_RequiresExplicitRefresh()
     {
@@ -2086,6 +2190,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         // Arrange
         using var fetchStarted = new ManualResetEventSlim(false);
         using var releaseFetch = new ManualResetEventSlim(false);
+        using var callersStarted = new CountdownEvent(20);
         int fetchCount = 0;
         using var resolver = new ElasticMappingResolver(() =>
         {
@@ -2096,12 +2201,22 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         }, _inferrer, logger: _logger);
 
         // Act
-        var lookups = Enumerable.Range(0, 100)
-            .Select(_ => Task.Run(() => resolver.GetMapping("name")))
+        var lookups = Enumerable.Range(0, 20)
+            .Select(_ => Task.Factory.StartNew(() =>
+            {
+                callersStarted.Signal();
+                return resolver.GetMapping("name");
+            }, TestCancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default))
             .ToArray();
-        Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestCancellationToken));
-        await Task.Delay(200, TestCancellationToken);
-        releaseFetch.Set();
+        try
+        {
+            Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestCancellationToken));
+            Assert.True(callersStarted.Wait(TimeSpan.FromSeconds(10), TestCancellationToken));
+        }
+        finally
+        {
+            releaseFetch.Set();
+        }
         await Task.WhenAll(lookups);
 
         // Assert

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -78,6 +78,99 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
+    public async Task AsyncResolverHelpers_WithMappedFields_ReturnExpectedValues()
+    {
+        // Arrange
+        var mapping = CreateTextWithKeywordAndSortMapping("title");
+        mapping.Properties!.Add("created", new DateProperty());
+        using var resolver = new ElasticMappingResolver(
+            cancellationToken => Task.FromResult<TypeMapping?>(mapping), _inferrer, logger: _logger);
+
+        // Act + Assert
+        Assert.Equal("title", await resolver.GetResolvedFieldAsync("title", TestCancellationToken));
+        Assert.Equal("title.sort", await resolver.GetSortFieldNameAsync("title", TestCancellationToken));
+        Assert.Equal("title.keyword", await resolver.GetAggregationsFieldNameAsync("title", TestCancellationToken));
+        Assert.True(await resolver.IsPropertyAnalyzedAsync("title", TestCancellationToken));
+        Assert.True(await resolver.IsDatePropertyTypeAsync("created", TestCancellationToken));
+        Assert.Equal(FieldType.Date, await resolver.GetFieldTypeAsync("created", TestCancellationToken));
+    }
+
+    [Theory]
+    [InlineData("query")]
+    [InlineData("sort")]
+    [InlineData("aggregation")]
+    [InlineData("nested")]
+    [InlineData("geo")]
+    [InlineData("default-field")]
+    [InlineData("included-default-field")]
+    public async Task AsyncParserPath_WithBlockedMappingFetch_ReturnsControl(string path)
+    {
+        // Arrange
+        var loadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLoad = new TaskCompletionSource<TypeMapping?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var parser = new ElasticQueryParser(configuration =>
+        {
+            configuration.UseMappings(async cancellationToken =>
+            {
+                loadStarted.TrySetResult();
+                return await releaseLoad.Task;
+            }, _inferrer);
+            if (path == "nested")
+                configuration.UseNested();
+            if (path == "geo")
+                configuration.UseGeo(location => location);
+            if (path is "default-field" or "included-default-field")
+                configuration.SetDefaultFields(["title"]);
+            if (path == "included-default-field")
+                configuration.UseIncludes(new Dictionary<string, string> { { "value", "included" } });
+        });
+        using var resolver = parser.Configuration.MappingResolver!;
+
+        // Act
+        Task operation = path switch
+        {
+            "query" => parser.BuildQueryAsync("title:value"),
+            "sort" => parser.BuildSortAsync("title"),
+            "aggregation" => parser.BuildAggregationsAsync("terms:title"),
+            "nested" => parser.BuildQueryAsync("items.status:active"),
+            "geo" => parser.BuildQueryAsync("location:41,-87"),
+            "default-field" => parser.BuildQueryAsync("value"),
+            "included-default-field" => parser.BuildQueryAsync("@include:value"),
+            _ => throw new ArgumentOutOfRangeException(nameof(path))
+        };
+        await loadStarted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestCancellationToken);
+
+        // Assert
+        Assert.False(operation.IsCompleted);
+        releaseLoad.SetResult(CreateAsyncParserMapping());
+        await operation.WaitAsync(TimeSpan.FromSeconds(1), TestCancellationToken);
+    }
+
+    [Fact]
+    public async Task BuildQueryAsync_WithUnusedMissingDefaultField_DoesNotRefreshMapping()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return Task.FromResult<TypeMapping?>(CreateTextOnlyMapping("title"));
+        }, _inferrer, timeProvider, _logger);
+        var parser = new ElasticQueryParser(configuration => configuration
+            .UseMappings(resolver)
+            .SetDefaultFields(["missing-default"]));
+
+        // Act
+        await parser.BuildQueryAsync("title:first");
+        timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+        await parser.BuildQueryAsync("title:second");
+
+        // Assert
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
     public void GetNonAnalyzedFieldName_WithKeywordProperty_ReturnsBareFieldName()
     {
         // Arrange
@@ -317,6 +410,45 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         // Act
         var staleResult = await staleLookup;
         var refreshedResult = resolver.GetMapping("idx.keyword-000001");
+
+        // Assert
+        Assert.False(staleResult?.Found);
+        Assert.True(refreshedResult?.Found);
+        Assert.Equal(3, fetchCount);
+    }
+
+    [Fact]
+    public async Task RefreshMapping_DuringAsyncRefresh_DiscardsSupersededResult()
+    {
+        // Arrange
+        var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fetchCount = 0;
+        TypeMapping serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        {
+            int callNumber = Interlocked.Increment(ref fetchCount);
+            TypeMapping capturedMapping = serverMapping;
+            if (callNumber == 2)
+            {
+                fetchStarted.TrySetResult();
+                await releaseFetch.Task.WaitAsync(cancellationToken);
+            }
+
+            return capturedMapping;
+        }, _inferrer, logger: _logger);
+
+        Assert.True((await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken))?.Found);
+        var staleLookup = resolver.GetMappingAsync("idx.keyword-000001", cancellationToken: TestCancellationToken).AsTask();
+        await fetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestCancellationToken);
+
+        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
+        resolver.RefreshMapping();
+        releaseFetch.TrySetResult();
+
+        // Act
+        var staleResult = await staleLookup;
+        var refreshedResult = await resolver.GetMappingAsync("idx.keyword-000001", cancellationToken: TestCancellationToken);
 
         // Assert
         Assert.False(staleResult?.Found);
@@ -808,6 +940,297 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
 
         // Assert
         Assert.False(mapping?.Found);
+        Assert.Equal(2, fetchCount);
+    }
+
+    [Fact]
+    public async Task GetMappingAsync_WithConcurrentInitialLookups_SharesOneFetch()
+    {
+        // Arrange
+        var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            fetchStarted.TrySetResult();
+            await releaseFetch.Task.WaitAsync(cancellationToken);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+
+        // Act
+        var lookups = Enumerable.Range(0, 100)
+            .Select(_ => resolver.GetMappingAsync("name").AsTask())
+            .ToArray();
+        await fetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestCancellationToken);
+
+        // Assert
+        Assert.Equal(1, Volatile.Read(ref fetchCount));
+        Assert.All(lookups, task => Assert.False(task.IsCompleted));
+
+        releaseFetch.TrySetResult();
+        await Task.WhenAll(lookups);
+
+        Assert.Equal(1, fetchCount);
+        Assert.All(lookups, task => Assert.True(task.Result?.Found));
+    }
+
+    [Fact]
+    public async Task GetMappingAsync_WithConcurrentMissingFields_SharesOneFetch()
+    {
+        // Arrange
+        var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        {
+            if (Interlocked.Increment(ref fetchCount) > 1)
+            {
+                fetchStarted.TrySetResult();
+                await releaseFetch.Task.WaitAsync(cancellationToken);
+            }
+
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+        Assert.True((await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken))?.Found);
+
+        // Act
+        var lookups = Enumerable.Range(0, 100)
+            .Select(index => resolver.GetMappingAsync($"missing_{index}", cancellationToken: TestCancellationToken).AsTask())
+            .ToArray();
+        await fetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestCancellationToken);
+
+        // Assert
+        Assert.Equal(2, Volatile.Read(ref fetchCount));
+        Assert.All(lookups, task => Assert.False(task.IsCompleted));
+        releaseFetch.TrySetResult();
+        await Task.WhenAll(lookups);
+
+        Assert.Equal(2, fetchCount);
+        Assert.All(lookups, task => Assert.False(task.Result?.Found));
+    }
+
+    [Fact]
+    public async Task GetMappingAsync_WhenCallerCancels_DoesNotCancelSharedFetch()
+    {
+        // Arrange
+        var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            fetchStarted.TrySetResult();
+            await releaseFetch.Task.WaitAsync(cancellationToken);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+        using var cancellationSource = new CancellationTokenSource();
+
+        // Act
+        var cancelledLookup = resolver.GetMappingAsync("name", cancellationToken: cancellationSource.Token).AsTask();
+        await fetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestCancellationToken);
+        cancellationSource.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => cancelledLookup);
+
+        var joiningLookup = resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken).AsTask();
+        Assert.False(joiningLookup.IsCompleted);
+        releaseFetch.TrySetResult();
+
+        // Assert
+        var mapping = await joiningLookup;
+        Assert.True(mapping?.Found);
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task Dispose_DuringAsyncFetch_CancelsResolverLifetimeLoad()
+    {
+        // Arrange
+        var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var fetchCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var resolver = new ElasticMappingResolver(async cancellationToken =>
+        {
+            fetchStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                fetchCancelled.TrySetResult();
+                throw;
+            }
+
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+        var lookup = resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken).AsTask();
+        await fetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestCancellationToken);
+
+        // Act
+        resolver.Dispose();
+
+        // Assert
+        await fetchCancelled.Task.WaitAsync(TimeSpan.FromSeconds(10), TestCancellationToken);
+        Assert.False((await lookup)?.Found);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetMappingAsync_WithContinuousFailedRefreshes_AttemptsAtMostOncePerRefreshInterval(bool throwException)
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        bool failRefresh = false;
+        using var resolver = new ElasticMappingResolver(cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            if (!failRefresh)
+                return Task.FromResult<TypeMapping?>(CreateTextWithKeywordMapping("name"));
+
+            return throwException
+                ? Task.FromException<TypeMapping?>(new InvalidOperationException("Elasticsearch is unavailable"))
+                : Task.FromResult<TypeMapping?>(null);
+        }, _inferrer, timeProvider, _logger);
+
+        Assert.True((await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken))?.Found);
+        failRefresh = true;
+
+        // Act - twelve five-second windows model one minute of continuous attacker-controlled misses.
+        for (int interval = 0; interval < 12; interval++)
+        {
+            for (int miss = 0; miss < 25; miss++)
+                Assert.False((await resolver.GetMappingAsync($"missing_{interval}_{miss}", cancellationToken: TestCancellationToken))?.Found);
+
+            Assert.True((await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken))?.Found);
+            if (interval < 11)
+                timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+        }
+
+        // Assert - one cold start plus at most twelve automatic attempts, including null and exceptions.
+        Assert.Equal(13, fetchCount);
+    }
+
+    [Fact]
+    public async Task GetMappingAsync_WithCachedKnownField_CompletesSynchronously()
+    {
+        // Arrange
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return Task.FromResult<TypeMapping?>(CreateTextWithKeywordMapping("name"));
+        }, _inferrer, logger: _logger);
+        Assert.True((await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken))?.Found);
+
+        // Act
+        var cachedLookup = resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken);
+
+        // Assert
+        Assert.True(cachedLookup.IsCompletedSuccessfully);
+        Assert.True((await cachedLookup)?.Found);
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task GetMappingAsync_WithCachedKnownFieldDuringBlockedRefresh_CompletesSynchronously()
+    {
+        // Arrange
+        var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRefresh = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        {
+            if (Interlocked.Increment(ref fetchCount) > 1)
+            {
+                refreshStarted.TrySetResult();
+                await releaseRefresh.Task.WaitAsync(cancellationToken);
+            }
+
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+        Assert.True((await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken))?.Found);
+        var blockedMiss = resolver.GetMappingAsync("missing", cancellationToken: TestCancellationToken).AsTask();
+        await refreshStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestCancellationToken);
+
+        // Act
+        var cachedLookup = resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken);
+
+        // Assert
+        Assert.True(cachedLookup.IsCompletedSuccessfully);
+        Assert.True((await cachedLookup)?.Found);
+        releaseRefresh.TrySetResult();
+        Assert.False((await blockedMiss)?.Found);
+    }
+
+    [Fact]
+    public async Task GetMapping_WithConcurrentSyncAndAsyncLookups_SharesOneFetch()
+    {
+        // Arrange
+        var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            fetchStarted.TrySetResult();
+            await releaseFetch.Task.WaitAsync(cancellationToken);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+
+        // Act
+        var asyncLookup = resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken).AsTask();
+        await fetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestCancellationToken);
+        var syncLookup = Task.Run(() => resolver.GetMapping("name"), TestCancellationToken);
+
+        Assert.False(asyncLookup.IsCompleted);
+        Assert.False(syncLookup.IsCompleted);
+        releaseFetch.TrySetResult();
+
+        // Assert
+        Assert.True((await asyncLookup)?.Found);
+        Assert.True((await syncLookup)?.Found);
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task GetMappingAsync_WhenJoinTimesOut_LaterCallerStillJoinsSharedFetch()
+    {
+        // Arrange
+        var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fetchCount = 0;
+        TypeMapping serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        {
+            if (Interlocked.Increment(ref fetchCount) > 1)
+            {
+                fetchStarted.TrySetResult();
+                await releaseFetch.Task.WaitAsync(cancellationToken);
+            }
+
+            return serverMapping;
+        }, _inferrer, logger: _logger);
+        Assert.True((await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken))?.Found);
+        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
+
+        var inFlightLookup = resolver.GetMappingAsync("idx.keyword-000001", cancellationToken: TestCancellationToken).AsTask();
+        await fetchStarted.Task.WaitAsync(TimeSpan.FromSeconds(10), TestCancellationToken);
+
+        // Act
+        resolver.MappingRefreshWaitTimeout = TimeSpan.FromMilliseconds(50);
+        var timedOut = await resolver.GetMappingAsync("idx.keyword-000001", cancellationToken: TestCancellationToken);
+
+        resolver.MappingRefreshWaitTimeout = TimeSpan.FromSeconds(30);
+        var joiningLookup = resolver.GetMappingAsync("idx.keyword-000001", cancellationToken: TestCancellationToken).AsTask();
+        Assert.False(joiningLookup.IsCompleted);
+        releaseFetch.TrySetResult();
+
+        // Assert
+        Assert.False(timedOut?.Found);
+        Assert.True((await inFlightLookup)?.Found);
+        Assert.True((await joiningLookup)?.Found);
         Assert.Equal(2, fetchCount);
     }
 
@@ -1408,7 +1831,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public void MappingRefreshWaitTimeout_WithValueExceedingSemaphoreLimit_ThrowsArgumentOutOfRangeException()
+    public void MappingRefreshWaitTimeout_WithValueExceedingSupportedLimit_ThrowsArgumentOutOfRangeException()
     {
         // Arrange - a value a semaphore cannot accept was previously clamped silently on every wait, so the
         // configured timeout and the effective one disagreed.
@@ -1471,7 +1894,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     {
         // Arrange - a resolver constructed with neither a code mapping nor a server mapping callback is a
         // configuration error and must fail loudly rather than reporting every field as unmapped.
-        using var resolver = new ElasticMappingResolver(null!, _inferrer, logger: _logger);
+        using var resolver = new ElasticMappingResolver((Func<TypeMapping?>)null!, _inferrer, logger: _logger);
 
         // Act
         var exception = Record.Exception(() => resolver.GetMapping("name"));
@@ -1755,6 +2178,15 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var mapping = CreateTextWithKeywordMapping(existingFieldName);
         mapping.Properties!.Add("idx", new ObjectProperty { Properties = CreateProperties((customFieldName, customField)) });
 
+        return mapping;
+    }
+
+    private static TypeMapping CreateAsyncParserMapping()
+    {
+        var items = new Properties { { "status", new KeywordProperty() } };
+        var mapping = CreateTextWithKeywordAndSortMapping("title");
+        mapping.Properties!.Add("items", new NestedProperty { Properties = items });
+        mapping.Properties.Add("location", new GeoPointProperty());
         return mapping;
     }
 

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -120,6 +121,20 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         // Assert
         Assert.Null(first);
         Assert.Null(cached);
+    }
+
+    [Fact]
+    public void FieldMapping_LegacyConstructor_RemainsAvailable()
+    {
+        // Arrange
+        var property = new KeywordProperty();
+
+        // Act
+        var mapping = new FieldMapping("name", property, DateTime.UtcNow, 1);
+
+        // Assert
+        Assert.Equal("name", mapping.FullPath);
+        Assert.Same(property, mapping.Property);
     }
 
     [Fact]
@@ -329,6 +344,25 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         // Assert
         Assert.Equal(1, afterColdStart);
         Assert.Equal(afterColdStart, fetchCount);
+    }
+
+    [Fact]
+    public void GetMapping_WithUnknownFieldOnColdStart_FetchesServerMappingOnce()
+    {
+        // Arrange
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+
+        // Act
+        var mapping = resolver.GetMapping("missing");
+
+        // Assert
+        Assert.False(mapping?.Found);
+        Assert.Equal(1, fetchCount);
     }
 
     [Fact]
@@ -820,6 +854,45 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         // Assert
         Assert.Equal(1, fetchCount);
         Assert.All(lookups, task => Assert.True(task.Result?.Found));
+    }
+
+    [Fact]
+    public async Task GetMapping_WhenInitialFetchOutlastsJoinTimeout_WaitsOnlyOnce()
+    {
+        // Arrange
+        using var fetchStarted = new ManualResetEventSlim(false);
+        using var releaseFetch = new ManualResetEventSlim(false);
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            fetchStarted.Set();
+            releaseFetch.Wait(TimeSpan.FromSeconds(30));
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger)
+        {
+            MappingRefreshWaitTimeout = TimeSpan.FromSeconds(1)
+        };
+
+        var initialLookup = Task.Run(() => resolver.GetMapping("name"));
+        Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestCancellationToken));
+
+        // Act
+        FieldMapping? timedOutLookup;
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            timedOutLookup = resolver.GetMapping("missing");
+        }
+        finally
+        {
+            stopwatch.Stop();
+            releaseFetch.Set();
+            await initialLookup;
+        }
+
+        // Assert
+        Assert.False(timedOutLookup?.Found);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromMilliseconds(1750),
+            $"Lookup waited {stopwatch.Elapsed} even though the configured join timeout was {resolver.MappingRefreshWaitTimeout}.");
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -10,6 +11,7 @@ using Foundatio.Parsers.ElasticQueries.Visitors;
 using Foundatio.Xunit;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
+using MEL = Microsoft.Extensions.Logging;
 
 namespace Foundatio.Parsers.ElasticQueries.Tests;
 
@@ -1456,6 +1458,119 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         Assert.Equal("body.keyword", resolved);
     }
 
+    [Fact]
+    public void GetMapping_WithDifferentFieldCasing_ResolvesCanonicalNameFromEverySpelling()
+    {
+        // Arrange - resolution falls back to an ordinal ignore case name comparison, so every spelling of a
+        // mapped field must resolve to the same canonical path, including repeat lookups that hit the cache.
+        var serverMapping = new TypeMapping { Properties = CreateProperties(("MixedCase", new KeywordProperty())) };
+        using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer, logger: _logger);
+
+        // Act
+        var exact = resolver.GetMapping("MixedCase");
+        var lower = resolver.GetMapping("mixedcase");
+        var upper = resolver.GetMapping("MIXEDCASE");
+
+        // Assert
+        Assert.True(exact?.Found);
+        Assert.True(lower?.Found);
+        Assert.True(upper?.Found);
+        Assert.Equal("MixedCase", exact!.FullPath);
+        Assert.Equal("MixedCase", lower!.FullPath);
+        Assert.Equal("MixedCase", upper!.FullPath);
+        Assert.IsType<KeywordProperty>(exact.Property);
+    }
+
+    [Fact]
+    public void GetMapping_WithAlias_FollowsToTargetOnFreshAndCachedLookups()
+    {
+        // Arrange
+        var serverMapping = new TypeMapping
+        {
+            Properties = CreateProperties(
+            ("alias", new FieldAliasProperty { Path = "target" }),
+            ("target", new KeywordProperty()))
+        };
+        using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer, logger: _logger);
+
+        // Act
+        var followed = resolver.GetMapping("alias", followAlias: true);
+        var cachedFollowed = resolver.GetMapping("alias", followAlias: true);
+        var unfollowed = resolver.GetMapping("alias");
+
+        // Assert
+        Assert.NotNull(followed);
+        Assert.True(followed.Found);
+        Assert.Equal("target", followed.FullPath);
+        Assert.IsType<KeywordProperty>(followed.Property);
+
+        Assert.NotNull(cachedFollowed);
+        Assert.True(cachedFollowed.Found);
+        Assert.Equal("target", cachedFollowed.FullPath);
+        Assert.IsType<KeywordProperty>(cachedFollowed.Property);
+
+        Assert.NotNull(unfollowed);
+        Assert.True(unfollowed.Found);
+        Assert.IsType<FieldAliasProperty>(unfollowed.Property);
+    }
+
+    [Fact]
+    public void Dispose_OnNullInstance_IsNoOpAndInstanceRemainsUsable()
+    {
+        // Arrange - NullInstance is shared process wide, so disposing it must not poison it for other consumers.
+        var resolver = ElasticMappingResolver.NullInstance;
+        Assert.False(resolver.GetMapping("name")?.Found);
+
+        // Act
+        resolver.Dispose();
+
+        // Assert
+        Assert.False(resolver.GetMapping("name")?.Found);
+    }
+
+    [Fact]
+    public void GetMapping_WithSuppressedReloads_LogsAtMostOneWarningPerWarningInterval()
+    {
+        // Arrange - a flood of lookups against fields missing from a current mapping is throttled; the
+        // resulting warnings must be rate limited so query traffic cannot flood the log.
+        var capturingLogger = new CapturingLogger();
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, timeProvider, capturingLogger);
+
+        // A reload interval longer than the warning rate limit window keeps every later miss suppressed,
+        // making the warning cadence deterministic.
+        resolver.UnmappedFieldRefreshInterval = TimeSpan.FromMinutes(5);
+
+        Assert.True(resolver.GetMapping("name")?.Found);
+
+        // Act - the first miss reloads and arms the throttle; every later miss is suppressed by it.
+        Assert.False(resolver.GetMapping("missing1")?.Found);
+        resolver.GetMapping("missing2");
+        int warningsAfterFirstSuppression = CountUnresolvedFieldWarnings(capturingLogger);
+
+        resolver.GetMapping("missing3");
+        timeProvider.Advance(TimeSpan.FromSeconds(45));
+        resolver.GetMapping("missing4");
+
+        timeProvider.Advance(TimeSpan.FromSeconds(16));
+        resolver.GetMapping("missing5");
+
+        // Assert
+        Assert.Equal(2, fetchCount);
+        Assert.Equal(1, warningsAfterFirstSuppression);
+        Assert.Equal(2, CountUnresolvedFieldWarnings(capturingLogger));
+    }
+
+    private static int CountUnresolvedFieldWarnings(CapturingLogger logger)
+    {
+        return logger.Entries.Count(e => e.Level == MEL.LogLevel.Warning && e.Message.Contains("Unable to resolve mapping for field"));
+    }
+
     private static Properties CreateProperties(params (string Name, IProperty Property)[] properties)
     {
         var props = new Properties();
@@ -2370,6 +2485,22 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             _releaseTimestampRead.Set();
             _timestampReadBlocked.Dispose();
             _releaseTimestampRead.Dispose();
+        }
+    }
+
+    private sealed class CapturingLogger : MEL.ILogger
+    {
+        public List<(MEL.LogLevel Level, string Message)> Entries { get; } = new();
+        private readonly object _lock = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(MEL.LogLevel logLevel) => true;
+
+        public void Log<TState>(MEL.LogLevel logLevel, MEL.EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            lock (_lock)
+                Entries.Add((logLevel, formatter(state, exception)));
         }
     }
 }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -7,7 +7,9 @@ using System.Threading.Tasks;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Mapping;
 using Elastic.Clients.Elasticsearch.QueryDsl;
+using Foundatio.Parsers.ElasticQueries.Extensions;
 using Foundatio.Parsers.ElasticQueries.Visitors;
+using Foundatio.Parsers.LuceneQueries.Nodes;
 using Foundatio.Xunit;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
@@ -976,6 +978,26 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
+    public async Task GetMappingAsync_WithAsyncOnlyLoader_StartsLoadInline()
+    {
+        // Arrange
+        int callerThread = Environment.CurrentManagedThreadId;
+        int loaderThread = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(cancellationToken =>
+        {
+            loaderThread = Environment.CurrentManagedThreadId;
+            return Task.FromResult<TypeMapping?>(CreateTextWithKeywordMapping("name"));
+        }, _inferrer, logger: _logger);
+
+        // Act
+        var mapping = await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken);
+
+        // Assert
+        Assert.True(mapping?.Found);
+        Assert.Equal(callerThread, loaderThread);
+    }
+
+    [Fact]
     public async Task GetMappingAsync_WithConcurrentMissingFields_SharesOneFetch()
     {
         // Arrange
@@ -1198,36 +1220,100 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     public async Task GetMapping_WithAsyncOnlyLoaderAndSynchronizationContext_DoesNotDeadlock()
     {
         // Arrange
-        var completion = new TaskCompletionSource<FieldMapping?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var thread = new Thread(() =>
+        Task<FieldMapping?> lookup = RunWithNonPumpingSynchronizationContext(() =>
         {
-            SynchronizationContext.SetSynchronizationContext(new NonPumpingSynchronizationContext());
-
-            try
+            using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
             {
-                using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
-                {
-                    await Task.Yield();
-                    return CreateTextWithKeywordMapping("name");
-                }, _inferrer, logger: _logger);
+                await Task.Yield();
+                return CreateTextWithKeywordMapping("name");
+            }, _inferrer, logger: _logger);
 
-                completion.TrySetResult(resolver.GetMapping("name"));
-            }
-            catch (Exception ex)
-            {
-                completion.TrySetException(ex);
-            }
-        })
-        {
-            IsBackground = true
-        };
+            return resolver.GetMapping("name");
+        });
 
         // Act
-        thread.Start();
-        var mapping = await completion.Task.WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
+        var mapping = await lookup.WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
 
         // Assert
         Assert.True(mapping?.Found);
+    }
+
+    [Fact]
+    public async Task GetDefaultQuery_WithAsyncOnlyMappingLoaderAndSynchronizationContext_DoesNotDeadlock()
+    {
+        // Arrange
+        Task<Query?> queryTask = RunWithNonPumpingSynchronizationContext(() =>
+        {
+            using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
+            {
+                await Task.Yield();
+                return CreateTextWithKeywordMapping("name");
+            }, _inferrer, logger: _logger);
+            var context = new ElasticQueryVisitorContext
+            {
+                DefaultFields = ["name"],
+                MappingResolver = resolver
+            };
+
+#pragma warning disable CS0618 // Exercise the synchronous compatibility API.
+            return new TermNode { Term = "value" }.GetDefaultQuery(context);
+#pragma warning restore CS0618
+        });
+
+        // Act
+        var query = await queryTask.WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
+
+        // Assert
+        Assert.NotNull(query);
+    }
+
+    [Fact]
+    public async Task Parse_WithAsyncOnlyMappingLoaderAndSynchronizationContext_DoesNotDeadlock()
+    {
+        // Arrange
+        Task<IQueryNode?> parseTask = RunWithNonPumpingSynchronizationContext(() =>
+        {
+            using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
+            {
+                await Task.Yield();
+                return CreateTextWithKeywordMapping("name");
+            }, _inferrer, logger: _logger);
+            var parser = new ElasticQueryParser(configuration => configuration.UseMappings(resolver));
+
+            return parser.Parse("name:value", new ElasticQueryVisitorContext());
+        });
+
+        // Act
+        var query = await parseTask.WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
+
+        // Assert
+        Assert.NotNull(query);
+    }
+
+    [Fact]
+    public async Task Parse_WithAsyncOnlyMappingLoaderAndSingleThreadTaskScheduler_DoesNotDeadlock()
+    {
+        // Arrange
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
+        {
+            await Task.Yield();
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+        var parser = new ElasticQueryParser(configuration => configuration.UseMappings(resolver));
+        var scheduler = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, maxConcurrencyLevel: 1);
+
+        // Act
+        var parseTask = Task.Factory.StartNew(
+            () => parser.Parse("name:value", new ElasticQueryVisitorContext()),
+            CancellationToken.None,
+            TaskCreationOptions.DenyChildAttach,
+            scheduler.ExclusiveScheduler);
+        var query = await parseTask.WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
+        scheduler.Complete();
+
+        // Assert
+        Assert.NotNull(query);
+        await scheduler.Completion.WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
     }
 
     [Fact]
@@ -3121,6 +3207,30 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         public override void Post(SendOrPostCallback d, object? state)
         {
         }
+    }
+
+    private static Task<T> RunWithNonPumpingSynchronizationContext<T>(Func<T> action)
+    {
+        var completion = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            SynchronizationContext.SetSynchronizationContext(new NonPumpingSynchronizationContext());
+
+            try
+            {
+                completion.TrySetResult(action());
+            }
+            catch (Exception ex)
+            {
+                completion.TrySetException(ex);
+            }
+        })
+        {
+            IsBackground = true
+        };
+
+        thread.Start();
+        return completion.Task;
     }
 
     private sealed class CapturingLogger : MEL.ILogger

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -1079,6 +1079,31 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
+    public void GetMapping_WithIncompatibleCodeAndServerScalarTypes_DoesNotFabricateChildField()
+    {
+        // Arrange - a server scalar with a different type must not inherit code-only multi-fields.
+        var codeMapping = new TypeMapping
+        {
+            Properties = CreateProperties(("value", new TextProperty
+            {
+                Fields = CreateProperties(("keyword", new KeywordProperty()))
+            }))
+        };
+        var serverMapping = new TypeMapping
+        {
+            Properties = CreateProperties(("value", new KeywordProperty()))
+        };
+        using var resolver = new ElasticMappingResolver(codeMapping, _inferrer, () => serverMapping, logger: _logger);
+
+        // Act
+        var mapping = resolver.GetMapping("value.keyword");
+
+        // Assert
+        Assert.False(mapping?.Found);
+        Assert.Equal("value.keyword", mapping?.FullPath);
+    }
+
+    [Fact]
     public void GetNonAnalyzedFieldName_WithCodeDeclaredKeywordSubField_UsesCodeDeclaredSubField()
     {
         // Arrange - sorting on an analyzed field fails unless the non analyzed sub-field is found, and the

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -486,6 +486,34 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
+    public void GetMapping_WithContinuousDistinctMisses_AttemptsAtMostOncePerRefreshInterval()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        Assert.True(resolver.GetMapping("name")?.Found);
+
+        // Act - twelve five-second windows model one minute of continuous attacker-controlled misses.
+        for (int interval = 0; interval < 12; interval++)
+        {
+            for (int miss = 0; miss < 25; miss++)
+                Assert.False(resolver.GetMapping($"missing_{interval}_{miss}")?.Found);
+
+            if (interval < 11)
+                timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+        }
+
+        // Assert - one cold-start fetch plus at most twelve automatic reload attempts.
+        Assert.Equal(13, fetchCount);
+    }
+
+    [Fact]
     public void GetMapping_WhenTimeProviderTimestampStartsAtZero_ThrottlesRepeatedMisses()
     {
         // Arrange
@@ -602,6 +630,93 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
 
         // Assert - the failed cold start also arms the miss throttle, so one lookup cannot immediately retry.
         Assert.Equal(1, fetchCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetMapping_WithContinuousFailedRefreshes_AttemptsAtMostOncePerRefreshInterval(bool throwException)
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        bool failRefresh = false;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            if (!failRefresh)
+                return CreateTextWithKeywordMapping("name");
+
+            if (throwException)
+                throw new InvalidOperationException("Elasticsearch is unavailable");
+
+            return null;
+        }, _inferrer, timeProvider, _logger);
+
+        Assert.True(resolver.GetMapping("name")?.Found);
+        failRefresh = true;
+
+        // Act
+        for (int interval = 0; interval < 12; interval++)
+        {
+            for (int miss = 0; miss < 25; miss++)
+                Assert.False(resolver.GetMapping($"missing_{interval}_{miss}")?.Found);
+
+            Assert.True(resolver.GetMapping("name")?.Found);
+            if (interval < 11)
+                timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+        }
+
+        // Assert - failures preserve the known mapping and obey the same ceiling as successful reloads.
+        Assert.Equal(13, fetchCount);
+    }
+
+    [Fact]
+    public void RefreshMapping_WithinMissCooldown_PerformsUnthrottledHardRefresh()
+    {
+        // Arrange
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+
+        // Act
+        Assert.True(resolver.GetMapping("name")?.Found); // cold start
+        Assert.False(resolver.GetMapping("missing")?.Found); // automatic miss reload
+        resolver.RefreshMapping();
+        Assert.True(resolver.GetMapping("name")?.Found); // explicit hard refresh
+
+        // Assert
+        Assert.Equal(3, fetchCount);
+    }
+
+    [Fact]
+    public void RefreshMapping_AfterTargetRecreation_DiscardsLastKnownGoodMapping()
+    {
+        // Arrange
+        TypeMapping? serverMapping = CreateTextOnlyMapping("name");
+        using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer,
+            new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+
+        Assert.Equal("name", resolver.GetNonAnalyzedFieldName("name", "keyword"));
+
+        // Automatic failure during the deletion gap retains mapping A.
+        serverMapping = null;
+        Assert.False(resolver.GetMapping("missing")?.Found);
+        Assert.Equal("name", resolver.GetNonAnalyzedFieldName("name", "keyword"));
+
+        // Act - deletion invalidation discards A, and recreation invalidation bypasses the failed-miss cooldown.
+        resolver.RefreshMapping();
+        Assert.False(resolver.GetMapping("name")?.Found);
+
+        serverMapping = CreateTextWithKeywordMapping("name");
+        resolver.RefreshMapping();
+        string? recreatedField = resolver.GetNonAnalyzedFieldName("name", "keyword");
+
+        // Assert
+        Assert.Equal("name.keyword", recreatedField);
     }
 
     [Fact]
@@ -729,6 +844,44 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         Assert.Equal(1, afterColdStart);
         Assert.Equal(afterColdStart + 1, fetchCount);
         Assert.All(lookups, t => Assert.False(t.Result!.Found));
+    }
+
+    [Fact]
+    public async Task GetMapping_WithCachedKnownFieldDuringBlockedRefresh_ReturnsImmediately()
+    {
+        // Arrange
+        using var fetchStarted = new ManualResetEventSlim(false);
+        using var releaseFetch = new ManualResetEventSlim(false);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            if (Interlocked.Increment(ref fetchCount) > 1)
+            {
+                fetchStarted.Set();
+                releaseFetch.Wait(TimeSpan.FromSeconds(30));
+            }
+
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+
+        Assert.True(resolver.GetMapping("name")?.Found);
+        var blockedMiss = Task.Run(() => resolver.GetMapping("missing"));
+        Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestCancellationToken));
+
+        // Act
+        var cachedLookup = Task.Run(() => resolver.GetMapping("name"));
+
+        // Assert
+        try
+        {
+            var cachedMapping = await cachedLookup.WaitAsync(TimeSpan.FromSeconds(1), TestCancellationToken);
+            Assert.True(cachedMapping?.Found);
+        }
+        finally
+        {
+            releaseFetch.Set();
+            await blockedMiss;
+        }
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -148,6 +148,212 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         await operation.WaitAsync(TimeSpan.FromSeconds(1), TestCancellationToken);
     }
 
+    [Theory]
+    [InlineData("query")]
+    [InlineData("sort")]
+    [InlineData("aggregation")]
+    [InlineData("nested")]
+    [InlineData("geo")]
+    [InlineData("default-field")]
+    [InlineData("included-default-field")]
+    public async Task AsyncParserPath_WithMissingField_UsesOneMappingFetchPerParse(string path)
+    {
+        // Arrange
+        var unexpectedLoad = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseUnexpectedLoad = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fetchCount = 0;
+        var parser = new ElasticQueryParser(configuration =>
+        {
+            configuration.UseMappingsWithAsyncLoader(async cancellationToken =>
+            {
+                if (Interlocked.Increment(ref fetchCount) == 1)
+                {
+                    return new TypeMapping
+                    {
+                        Properties = CreateProperties(("items", new NestedProperty { Properties = new Properties() }))
+                    };
+                }
+
+                unexpectedLoad.TrySetResult();
+                await releaseUnexpectedLoad.Task.WaitAsync(cancellationToken);
+                return null;
+            }, _inferrer);
+            if (path == "nested")
+                configuration.UseNested();
+            if (path == "geo")
+                configuration.UseGeo(location => location);
+            if (path is "default-field" or "included-default-field")
+                configuration.SetDefaultFields(["title"]);
+            if (path == "included-default-field")
+                configuration.UseIncludes(new Dictionary<string, string> { { "value", "included" } });
+        });
+        using var resolver = parser.Configuration.MappingResolver!;
+
+        Task operation = path switch
+        {
+            "query" => parser.BuildQueryAsync("title:value"),
+            "sort" => parser.BuildSortAsync("title"),
+            "aggregation" => parser.BuildAggregationsAsync("terms:title"),
+            "nested" => parser.BuildQueryAsync("items.status:active"),
+            "geo" => parser.BuildQueryAsync("location:41,-87"),
+            "default-field" => parser.BuildQueryAsync("value"),
+            "included-default-field" => parser.BuildQueryAsync("@include:value"),
+            _ => throw new ArgumentOutOfRangeException(nameof(path))
+        };
+
+        // Act
+        Task completed = await Task.WhenAny(operation, unexpectedLoad.Task, Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken));
+        releaseUnexpectedLoad.TrySetResult();
+        await operation.WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
+
+        // Assert
+        Assert.Same(operation, completed);
+        Assert.False(unexpectedLoad.Task.IsCompleted);
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task ParseAsync_WhenContextIsReused_DoesNotRetainPriorParseMappingMiss()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        TypeMapping serverMapping = CreateTextOnlyMapping("title");
+        int fetchCount = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return Task.FromResult<TypeMapping?>(serverMapping);
+        }, _inferrer, timeProvider, _logger);
+        var parser = new ElasticQueryParser(configuration => configuration.UseMappings(resolver));
+        var context = new ElasticQueryVisitorContext();
+
+        await parser.BuildQueryAsync("dynamic:value", context);
+        serverMapping = CreateTextOnlyMapping("dynamic");
+        timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+
+        // Act
+        var query = await parser.BuildQueryAsync("dynamic:value", context);
+
+        // Assert
+        Assert.Contains("match", Serialize(query));
+        Assert.Equal(2, fetchCount);
+    }
+
+    [Fact]
+    public async Task BuildQueryAsync_WithFieldAlias_PreservesAliasAndUsesTargetType()
+    {
+        // Arrange
+        var mapping = CreateTextWithKeywordMapping("title");
+        mapping.Properties!.Add("heading", new FieldAliasProperty { Path = "title" });
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(
+            cancellationToken => Task.FromResult<TypeMapping?>(mapping), _inferrer, logger: _logger);
+        var parser = new ElasticQueryParser(configuration => configuration.UseMappings(resolver));
+
+        // Act
+        var query = await parser.BuildQueryAsync("heading:value");
+
+        // Assert
+        string json = Serialize(query);
+        Assert.Contains("match", json);
+        Assert.Contains("heading", json);
+        Assert.DoesNotContain("\"title\"", json);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task BuildQueryAsync_WithMissingNestedLeaf_UsesKnownNestedAncestorChain(bool doubleNested)
+    {
+        // Arrange
+        int fetchCount = 0;
+        IProperty nestedMapping = doubleNested
+            ? new NestedProperty
+            {
+                Properties = CreateProperties(("child", new NestedProperty { Properties = new Properties() }))
+            }
+            : new NestedProperty { Properties = new Properties() };
+        var mapping = new TypeMapping
+        {
+            Properties = CreateProperties(((doubleNested ? "parent" : "items"), nestedMapping))
+        };
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return Task.FromResult<TypeMapping?>(mapping);
+        }, _inferrer, logger: _logger);
+        var parser = new ElasticQueryParser(configuration => configuration.UseMappings(resolver).UseNested());
+        string field = doubleNested ? "parent.child.missing" : "items.missing";
+
+        // Act
+        var query = await parser.BuildQueryAsync($"{field}:value");
+
+        // Assert
+        string json = Serialize(query);
+        Assert.Contains(doubleNested ? "parent.child" : "items", json);
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task BuildQueryAsync_WithRepeatedMissingField_ResolvesMappingOncePerParse()
+    {
+        // Arrange
+        int fetchCount = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return Task.FromResult<TypeMapping?>(new TypeMapping { Properties = new Properties() });
+        }, _inferrer, logger: _logger);
+        var parser = new ElasticQueryParser(configuration => configuration.UseMappings(resolver));
+
+        // Act
+        await parser.BuildQueryAsync("missing:first OR missing:second");
+
+        // Assert
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task BuildQueryAsync_WithEscapedFieldName_UsesUnescapedMappingKey()
+    {
+        // Arrange
+        int fetchCount = 0;
+        var mapping = new TypeMapping
+        {
+            Properties = CreateProperties(("spaced field", new TextProperty()))
+        };
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return Task.FromResult<TypeMapping?>(mapping);
+        }, _inferrer, logger: _logger);
+        var parser = new ElasticQueryParser(configuration => configuration.UseMappings(resolver));
+
+        // Act
+        var query = await parser.BuildQueryAsync("spaced\\ field:value");
+
+        // Assert
+        Assert.Contains("spaced field", Serialize(query));
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task BuildAggregationsAsync_PreservesParentAndSelectedSubfieldMetadataSemantics()
+    {
+        // Arrange
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(
+            cancellationToken => Task.FromResult<TypeMapping?>(CreateTextWithKeywordMapping("title")),
+            _inferrer, logger: _logger);
+        var parser = new ElasticQueryParser(configuration => configuration.UseMappings(resolver));
+
+        // Act
+        var termAggregation = await parser.BuildAggregationsAsync("terms:title");
+        var groupAggregation = await parser.BuildAggregationsAsync("terms:(title)");
+
+        // Assert
+        Assert.Contains("\"@field_type\":\"text\"", Serialize(termAggregation));
+        Assert.Contains("\"@field_type\":\"keyword\"", Serialize(groupAggregation));
+    }
+
     [Fact]
     public async Task BuildQueryAsync_WithUnusedMissingDefaultField_DoesNotRefreshMapping()
     {
@@ -407,11 +613,19 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
 
         serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
         resolver.RefreshMapping();
-        releaseFetch.Set();
 
         // Act
-        var staleResult = await staleLookup;
-        var refreshedResult = resolver.GetMapping("idx.keyword-000001");
+        FieldMapping? staleResult;
+        FieldMapping? refreshedResult;
+        try
+        {
+            staleResult = await staleLookup;
+            refreshedResult = resolver.GetMapping("idx.keyword-000001");
+        }
+        finally
+        {
+            releaseFetch.Set();
+        }
 
         // Assert
         Assert.False(staleResult?.Found);
@@ -446,11 +660,19 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
 
         serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
         resolver.RefreshMapping();
-        releaseFetch.TrySetResult();
 
         // Act
-        var staleResult = await staleLookup;
-        var refreshedResult = await resolver.GetMappingAsync("idx.keyword-000001", cancellationToken: TestCancellationToken);
+        FieldMapping? staleResult;
+        FieldMapping? refreshedResult;
+        try
+        {
+            staleResult = await staleLookup;
+            refreshedResult = await resolver.GetMappingAsync("idx.keyword-000001", cancellationToken: TestCancellationToken);
+        }
+        finally
+        {
+            releaseFetch.TrySetResult();
+        }
 
         // Assert
         Assert.False(staleResult?.Found);
@@ -1065,6 +1287,51 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
+    public async Task GetMappingAsync_WhenAlreadyCancelled_DoesNotStartSharedFetch()
+    {
+        // Arrange
+        int fetchCount = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return Task.FromResult<TypeMapping?>(CreateTextWithKeywordMapping("name"));
+        }, _inferrer, logger: _logger);
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            resolver.GetMappingAsync("name", cancellationToken: cancellationSource.Token).AsTask());
+
+        // Assert
+        Assert.Equal(0, fetchCount);
+        Assert.True((await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken))?.Found);
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task GetMappingAsync_WhenMissingFieldLookupIsAlreadyCancelled_DoesNotStartRefresh()
+    {
+        // Arrange
+        int fetchCount = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return Task.FromResult<TypeMapping?>(CreateTextWithKeywordMapping("name"));
+        }, _inferrer, logger: _logger);
+        Assert.True((await resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken))?.Found);
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            resolver.GetMappingAsync("missing", cancellationToken: cancellationSource.Token).AsTask());
+
+        // Assert
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
     public async Task Dispose_DuringAsyncFetch_CancelsResolverLifetimeLoad()
     {
         // Arrange
@@ -1236,6 +1503,64 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
 
         // Assert
         Assert.True(mapping?.Found);
+    }
+
+    [Fact]
+    public async Task GetMapping_WhenAsyncOwnerUsesSynchronizationContext_SynchronousJoinerDoesNotDeadlock()
+    {
+        // Arrange
+        int fetchCount = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            await Task.Yield();
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+        resolver.MappingRefreshWaitTimeout = TimeSpan.FromMilliseconds(250);
+
+        // Act
+        var result = await RunWithNonPumpingSynchronizationContext(() =>
+        {
+            var asyncLookup = resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken).AsTask();
+            var syncLookup = resolver.GetMapping("name");
+            return (Async: asyncLookup, Sync: syncLookup);
+        }).WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
+
+        // Assert
+        Assert.True(result.Sync?.Found);
+        Assert.True((await result.Async)?.Found);
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task GetMapping_WhenAsyncOwnerUsesSingleThreadTaskScheduler_SynchronousJoinerDoesNotDeadlock()
+    {
+        // Arrange
+        int fetchCount = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            await Task.Yield();
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+        resolver.MappingRefreshWaitTimeout = TimeSpan.FromMilliseconds(250);
+        var scheduler = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, maxConcurrencyLevel: 1);
+
+        // Act
+        var lookup = Task.Factory.StartNew(() =>
+        {
+            var asyncLookup = resolver.GetMappingAsync("name", cancellationToken: TestCancellationToken).AsTask();
+            var syncLookup = resolver.GetMapping("name");
+            return (Async: asyncLookup, Sync: syncLookup);
+        }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, scheduler.ExclusiveScheduler);
+        var result = await lookup.WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
+        scheduler.Complete();
+
+        // Assert
+        Assert.True(result.Sync?.Found);
+        Assert.True((await result.Async)?.Found);
+        Assert.Equal(1, fetchCount);
+        await scheduler.Completion.WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
     }
 
     [Fact]
@@ -1525,6 +1850,45 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         // Assert
         Assert.Equal(1, fetchCount);
         Assert.All(lookups, task => Assert.False(task.Result?.Found));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetMapping_WhenInitialLoadFails_DoesNotCacheCodeOnlyResult(bool throwException)
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        var codeMapping = new TypeMapping
+        {
+            Properties = CreateProperties(("value", new TextProperty()))
+        };
+        using var resolver = new ElasticMappingResolver(codeMapping, _inferrer, () =>
+        {
+            if (Interlocked.Increment(ref fetchCount) == 1)
+            {
+                if (throwException)
+                    throw new InvalidOperationException("Elasticsearch is unavailable");
+
+                return null;
+            }
+
+            return new TypeMapping
+            {
+                Properties = CreateProperties(("value", new KeywordProperty()))
+            };
+        }, timeProvider, _logger);
+
+        Assert.IsType<TextProperty>(resolver.GetMapping("value")?.Property);
+        timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+
+        // Act
+        var recovered = resolver.GetMapping("value");
+
+        // Assert
+        Assert.IsType<KeywordProperty>(recovered?.Property);
+        Assert.Equal(2, fetchCount);
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -9,7 +9,9 @@ using Elastic.Clients.Elasticsearch.Mapping;
 using Elastic.Clients.Elasticsearch.QueryDsl;
 using Foundatio.Parsers.ElasticQueries.Extensions;
 using Foundatio.Parsers.ElasticQueries.Visitors;
+using Foundatio.Parsers.LuceneQueries.Extensions;
 using Foundatio.Parsers.LuceneQueries.Nodes;
+using Foundatio.Parsers.LuceneQueries.Visitors;
 using Foundatio.Xunit;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
@@ -237,6 +239,193 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         // Assert
         Assert.Contains("match", Serialize(query));
         Assert.Equal(2, fetchCount);
+    }
+
+    [Theory]
+    [InlineData("Name:abc AND name:42")]
+    [InlineData("name:42 AND Name:abc")]
+    public async Task BuildQueryAsync_WithDistinctExactCasedFields_PreservesNamesAndTypes(string input)
+    {
+        using var resolver = new ElasticMappingResolver(() => new TypeMapping
+        {
+            Properties = CreateProperties(("Name", new KeywordProperty()), ("name", new LongNumberProperty()))
+        });
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver));
+
+        string query = Serialize(await parser.BuildQueryAsync(input));
+
+        Assert.Contains("\"Name\":{\"value\":\"abc\"}", query);
+        Assert.Contains("\"name\":{\"value\":42}", query);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetDefaultSort_WithReusedContextAfterRefresh_UsesReplacementMapping(bool parseFirst)
+    {
+        TypeMapping mapping = CreateTextWithKeywordMapping("title");
+        using var resolver = new ElasticMappingResolver(() => mapping);
+        var context = new ElasticQueryVisitorContext { MappingResolver = resolver };
+        if (parseFirst)
+            await new ElasticQueryParser(c => c.UseMappings(resolver)).BuildSortAsync("title", context);
+
+        Assert.Equal("title.keyword", new TermNode { Field = "title" }.GetDefaultSort(context).Field!.Field!.Name);
+        mapping = CreateTextWithKeywordAndSortMapping("title");
+        resolver.RefreshMapping();
+
+        Assert.Equal("title.sort", new TermNode { Field = "title" }.GetDefaultSort(context).Field!.Field!.Name);
+    }
+
+    [Fact]
+    public async Task GetDefaultQueryAsync_WithReusedContext_DoesNotRetainMissingMapping()
+    {
+        var timeProvider = new FakeTimeProvider();
+        TypeMapping mapping = CreateTextOnlyMapping("other");
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ => Task.FromResult<TypeMapping?>(mapping), timeProvider: timeProvider);
+        var context = new ElasticQueryVisitorContext { MappingResolver = resolver };
+        Assert.Contains("\"term\"", Serialize(await new TermNode { Field = "title", Term = "value" }.GetDefaultQueryAsync(context)));
+
+        mapping = CreateTextOnlyMapping("title");
+        timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+
+        Assert.Contains("\"match\"", Serialize(await new TermNode { Field = "title", Term = "value" }.GetDefaultQueryAsync(context)));
+    }
+
+    [Fact]
+    public async Task GetDefaultAggregationAsync_WithMissingField_FetchesOncePerOperation()
+    {
+        int fetchCount = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ =>
+        {
+            fetchCount++;
+            return Task.FromResult<TypeMapping?>(CreateTextOnlyMapping("other"));
+        });
+        var context = new ElasticQueryVisitorContext { MappingResolver = resolver };
+        var node = new GroupNode { Field = "title", HasParens = true };
+        node.SetOperationType("terms");
+
+        Assert.NotNull(await node.GetDefaultAggregationAsync(context));
+
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ParseAsync_WhenVisitorThrows_DiscardsOperationMappings(bool formatException)
+    {
+        TypeMapping mapping = CreateAsyncParserMapping();
+        using var resolver = new ElasticMappingResolver(() => mapping);
+        var context = new ElasticQueryVisitorContext();
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver).UseGeo(_ =>
+            Task.FromException<string>(formatException ? new FormatException("Invalid location") : new InvalidOperationException("Unavailable location"))));
+
+        if (formatException)
+            Assert.Null(await parser.ParseAsync("location:here", context));
+        else
+            await Assert.ThrowsAsync<InvalidOperationException>(() => parser.ParseAsync("location:here", context));
+
+        mapping = CreateTextWithKeywordMapping("location");
+        resolver.RefreshMapping();
+
+        Assert.Equal("location.keyword", new TermNode { Field = "location" }.GetDefaultSort(context).Field!.Field!.Name);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetDefaultQueryAsync_WithBlockedExplicitFieldLoader_ReturnsControl(bool mapped)
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<TypeMapping?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var returned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int fetchCount = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            started.TrySetResult();
+            return release.Task;
+        });
+        var context = new ElasticQueryVisitorContext { MappingResolver = resolver };
+        var operation = Task.Run(async () =>
+        {
+            var query = new TermNode { Field = "title", Term = "value" }.GetDefaultQueryAsync(context);
+            returned.TrySetResult();
+            return await query;
+        }, TestCancellationToken);
+
+        try
+        {
+            await started.Task.WaitAsync(TimeSpan.FromSeconds(5), TestCancellationToken);
+            await returned.Task.WaitAsync(TimeSpan.FromSeconds(1), TestCancellationToken);
+            Assert.False(operation.IsCompleted);
+        }
+        finally
+        {
+            release.TrySetResult(CreateTextOnlyMapping(mapped ? "title" : "other"));
+            await operation.WaitAsync(TimeSpan.FromSeconds(5), TestCancellationToken);
+        }
+
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task GeoVisitor_WithRange_PreservesSynchronousOverride()
+    {
+        using var resolver = new ElasticMappingResolver(CreateAsyncParserMapping);
+        var context = new ElasticQueryVisitorContext { MappingResolver = resolver };
+        var syncNode = new TermRangeNode { Field = "location", Min = "40,-70", Max = "30,-60" };
+        var asyncNode = new TermRangeNode { Field = "location", Min = "40,-70", Max = "30,-60" };
+        var visitor = new TrackingGeoVisitor();
+
+        visitor.Visit(syncNode, context);
+        await visitor.VisitAsync(asyncNode, context);
+
+        Assert.Equal(2, visitor.VisitCount);
+        Assert.NotNull(await syncNode.GetQueryAsync());
+        Assert.Equal(Serialize(await syncNode.GetQueryAsync()), Serialize(await asyncNode.GetQueryAsync()));
+    }
+
+    [Fact]
+    public async Task GetSortFieldsVisitor_WithDerivedOverride_DispatchesAfterAsyncMappingLoad()
+    {
+        var release = new TaskCompletionSource<TypeMapping?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ => release.Task);
+        var context = new ElasticQueryVisitorContext { MappingResolver = resolver };
+        var visitor = new TrackingSortVisitor();
+        var node = new TermNode { Field = "title" };
+
+        var operation = visitor.AcceptAsync(node, context);
+        Assert.False(operation.IsCompleted);
+        release.SetResult(CreateTextWithKeywordMapping("title"));
+        var sorts = await operation.WaitAsync(TimeSpan.FromSeconds(5), TestCancellationToken);
+
+        Assert.Equal(1, visitor.VisitCount);
+        Assert.Equal(SortOrder.Desc, Assert.Single(sorts).Field!.Order);
+        Assert.Null(node.GetSort());
+    }
+
+    private sealed class TrackingGeoVisitor : GeoVisitor
+    {
+        public int VisitCount { get; private set; }
+
+        public override void Visit(TermRangeNode node, IQueryVisitorContext context)
+        {
+            VisitCount++;
+            base.Visit(node, context);
+        }
+    }
+
+    private sealed class TrackingSortVisitor : GetSortFieldsVisitor
+    {
+        public int VisitCount { get; private set; }
+
+        public override void Visit(TermNode node, IQueryVisitorContext context)
+        {
+            VisitCount++;
+            node.IsNegated = true;
+            base.Visit(node, context);
+        }
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -107,6 +107,22 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
+    public void GetMapping_WithAliasMissingPath_ReturnsNullConsistently()
+    {
+        // Arrange
+        var properties = CreateProperties(("alias", new FieldAliasProperty()));
+        using var resolver = new ElasticMappingResolver(() => new TypeMapping { Properties = properties }, _inferrer, logger: _logger);
+
+        // Act
+        var first = resolver.GetMapping("alias", followAlias: true);
+        var cached = resolver.GetMapping("alias", followAlias: true);
+
+        // Assert
+        Assert.Null(first);
+        Assert.Null(cached);
+    }
+
+    [Fact]
     public void RefreshMapping_WhenCalled_ClearsCachedMappings()
     {
         // Arrange
@@ -248,8 +264,51 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         await Task.WhenAll(readerTask, aggregationReaderTask, refreshTask);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RefreshMapping_DuringInFlightRefresh_DiscardsSupersededResult(bool throwException)
+    {
+        // Arrange
+        using var fetchStarted = new ManualResetEventSlim(false);
+        using var releaseFetch = new ManualResetEventSlim(false);
+        int fetchCount = 0;
+        TypeMapping serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            int callNumber = Interlocked.Increment(ref fetchCount);
+            TypeMapping capturedMapping = serverMapping;
+            if (callNumber == 2)
+            {
+                fetchStarted.Set();
+                releaseFetch.Wait(TimeSpan.FromSeconds(30));
+                if (throwException)
+                    throw new InvalidOperationException("Elasticsearch is unavailable");
+            }
+
+            return capturedMapping;
+        }, _inferrer, logger: _logger);
+
+        Assert.True(resolver.GetMapping("name")?.Found);
+        var staleLookup = Task.Run(() => resolver.GetMapping("idx.keyword-000001"));
+        Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestCancellationToken));
+
+        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
+        resolver.RefreshMapping();
+        releaseFetch.Set();
+
+        // Act
+        var staleResult = await staleLookup;
+        var refreshedResult = resolver.GetMapping("idx.keyword-000001");
+
+        // Assert
+        Assert.False(staleResult?.Found);
+        Assert.True(refreshedResult?.Found);
+        Assert.Equal(3, fetchCount);
+    }
+
     [Fact]
-    public void GetMapping_WithResolvedFieldWithinRefreshInterval_DoesNotRefetchServerMapping()
+    public void GetMapping_WithResolvedField_DoesNotRefetchServerMapping()
     {
         // Arrange
         var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
@@ -273,7 +332,35 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public void RefreshMapping_WithinRefreshInterval_BypassesThrottleAndRefetchesServerMapping()
+    public void GetMapping_WithChangedResolvedField_RequiresExplicitRefresh()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        var serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return serverMapping;
+        }, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        Assert.IsType<TextProperty>(resolver.GetMappingProperty("name"));
+        serverMapping = new TypeMapping { Properties = CreateProperties(("name", new KeywordProperty())) };
+        timeProvider.Advance(TimeSpan.FromHours(1));
+
+        // Act
+        var staleProperty = resolver.GetMappingProperty("name");
+        resolver.RefreshMapping();
+        var refreshedProperty = resolver.GetMappingProperty("name");
+
+        // Assert
+        Assert.IsType<TextProperty>(staleProperty);
+        Assert.IsType<KeywordProperty>(refreshedProperty);
+        Assert.Equal(2, fetchCount);
+    }
+
+    [Fact]
+    public void RefreshMapping_WhenCalled_RefetchesServerMapping()
     {
         // Arrange
         var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
@@ -363,42 +450,33 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public void GetMapping_WithRepeatedlyUnresolvableFields_BacksOffServerMappingReloads()
+    public void GetMapping_WhenTimeProviderTimestampStartsAtZero_ThrottlesRepeatedMisses()
     {
         // Arrange
-        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var timeProvider = new ZeroOriginTimeProvider();
         int fetchCount = 0;
         using var resolver = new ElasticMappingResolver(() =>
         {
             Interlocked.Increment(ref fetchCount);
             return CreateTextWithKeywordMapping("name");
-        }, _inferrer, timeProvider: timeProvider, logger: _logger);
+        }, _inferrer, timeProvider, _logger);
 
-        resolver.GetMapping("name");
-        resolver.GetMapping("missing_1");
+        Assert.True(resolver.GetMapping("name")?.Found);
+
+        // Act
+        Assert.False(resolver.GetMapping("missing1")?.Found);
+        Assert.False(resolver.GetMapping("missing2")?.Found);
+
+        // Assert
         Assert.Equal(2, fetchCount);
 
-        // Act + Assert - a reload that did not resolve the field doubles the interval to 10s
-        timeProvider.Advance(TimeSpan.FromSeconds(9));
-        resolver.GetMapping("missing_2");
-        Assert.Equal(2, fetchCount);
-
-        timeProvider.Advance(TimeSpan.FromSeconds(1));
-        resolver.GetMapping("missing_3");
+        timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+        Assert.False(resolver.GetMapping("missing3")?.Found);
         Assert.Equal(3, fetchCount);
-
-        // Act + Assert - and again to 20s
-        timeProvider.Advance(TimeSpan.FromSeconds(19));
-        resolver.GetMapping("missing_4");
-        Assert.Equal(3, fetchCount);
-
-        timeProvider.Advance(TimeSpan.FromSeconds(1));
-        resolver.GetMapping("missing_5");
-        Assert.Equal(4, fetchCount);
     }
 
     [Fact]
-    public void GetMapping_WithFieldResolvedByReload_ResetsUnmappedRefreshBackoff()
+    public void GetMapping_WithNewFieldAfterUnrelatedMiss_RefreshesAtUnmappedFieldInterval()
     {
         // Arrange
         var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
@@ -410,23 +488,18 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             return serverMapping;
         }, _inferrer, timeProvider: timeProvider, logger: _logger);
 
-        resolver.GetMapping("name");
-        resolver.GetMapping("missing_1");
-        resolver.GetMapping("missing_2");
-        int afterBackoff = fetchCount;
+        Assert.True(resolver.GetMapping("name")?.Found);
+        Assert.False(resolver.GetMapping("typo")?.Found);
 
-        // Act - the field now exists, so the reload that finds it must reset the backoff
-        timeProvider.Advance(TimeSpan.FromSeconds(10));
         serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
-        var created = resolver.GetMapping("idx.keyword-000001");
+        timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
 
-        timeProvider.Advance(TimeSpan.FromSeconds(5));
-        resolver.GetMapping("missing_3");
+        // Act
+        var mapping = resolver.GetMapping("idx.keyword-000001");
 
         // Assert
-        Assert.NotNull(created);
-        Assert.True(created.Found);
-        Assert.Equal(afterBackoff + 2, fetchCount);
+        Assert.True(mapping?.Found);
+        Assert.Equal(3, fetchCount);
     }
 
     [Fact]
@@ -453,9 +526,9 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public void InvalidateFieldMapping_WithCachedMissForNewlyCreatedField_ResolvesFieldWithoutWaitingForThrottle()
+    public void RefreshMapping_WithNewlyCreatedField_ResolvesFieldWithoutWaitingForThrottle()
     {
-        // Arrange - arm the unmapped field throttle so the cached miss cannot refresh itself
+        // Arrange - arm the unmapped field throttle before the field exists.
         var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
         var serverMapping = CreateTextWithKeywordMapping("name");
         using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer, timeProvider: timeProvider, logger: _logger);
@@ -467,7 +540,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         Assert.False(resolver.GetMapping("idx.keyword-000001")!.Found);
 
         // Act
-        resolver.InvalidateFieldMapping("idx.keyword-000001");
+        resolver.RefreshMapping();
         var mapping = resolver.GetMapping("idx.keyword-000001");
 
         // Assert
@@ -491,7 +564,99 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         for (int i = 0; i < 25; i++)
             Assert.False(resolver.GetMapping($"field_{i}")!.Found);
 
-        // Assert - one cold start attempt plus one miss driven attempt, then throttled
+        // Assert - the failed cold start also arms the miss throttle, so one lookup cannot immediately retry.
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public void GetMapping_WhenAutomaticRefreshReturnsNull_PreservesLastKnownGoodMapping()
+    {
+        // Arrange
+        int fetchCount = 0;
+        TypeMapping? serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return serverMapping;
+        }, _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+
+        Assert.True(resolver.GetMapping("name")?.Found);
+        serverMapping = null;
+
+        // Act
+        Assert.False(resolver.GetMapping("missing")?.Found);
+        var knownMapping = resolver.GetMapping("name");
+
+        // Assert
+        Assert.True(knownMapping?.Found);
+        Assert.Equal(2, fetchCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetMapping_AfterFailedMissRefresh_RetriesAfterInterval(bool throwException)
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        bool failRefresh = false;
+        TypeMapping serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            if (failRefresh)
+            {
+                if (throwException)
+                    throw new InvalidOperationException("Elasticsearch is unavailable");
+
+                return null;
+            }
+
+            return serverMapping;
+        }, _inferrer, timeProvider, _logger);
+
+        Assert.True(resolver.GetMapping("name")?.Found);
+        failRefresh = true;
+        Assert.False(resolver.GetMapping("missing")?.Found);
+
+        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
+        failRefresh = false;
+
+        // Act
+        Assert.False(resolver.GetMapping("idx.keyword-000001")?.Found);
+        timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+        var mapping = resolver.GetMapping("idx.keyword-000001");
+
+        // Assert
+        Assert.True(mapping?.Found);
+        Assert.Equal(3, fetchCount);
+    }
+
+    [Fact]
+    public void GetMapping_WithFailedMissRefresh_AttemptsOneReload()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        bool serverUnavailable = false;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            if (serverUnavailable)
+                throw new InvalidOperationException("Elasticsearch is unavailable");
+
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, timeProvider: timeProvider, logger: _logger);
+
+        Assert.True(resolver.GetMapping("name")?.Found);
+        serverUnavailable = true;
+
+        // Act
+        var mapping = resolver.GetMapping("missing");
+
+        // Assert
+        Assert.False(mapping?.Found);
         Assert.Equal(2, fetchCount);
     }
 
@@ -499,11 +664,17 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     public async Task GetMapping_WithConcurrentUnmappedLookups_FetchesServerMappingOnce()
     {
         // Arrange
+        using var fetchStarted = new ManualResetEventSlim(false);
+        using var releaseFetch = new ManualResetEventSlim(false);
         int fetchCount = 0;
         using var resolver = new ElasticMappingResolver(() =>
         {
-            Interlocked.Increment(ref fetchCount);
-            Thread.Sleep(100);
+            if (Interlocked.Increment(ref fetchCount) > 1)
+            {
+                fetchStarted.Set();
+                releaseFetch.Wait(TimeSpan.FromSeconds(30));
+            }
+
             return CreateTextWithKeywordMapping("name");
         }, _inferrer, logger: _logger);
 
@@ -511,15 +682,144 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         int afterColdStart = fetchCount;
 
         // Act
-        var lookups = Enumerable.Range(0, 16)
-            .Select(_ => Task.Run(() => resolver.GetMapping("idx.keyword-000001")))
+        var lookups = Enumerable.Range(0, 100)
+            .Select(i => Task.Run(() => resolver.GetMapping($"missing{i}")))
             .ToArray();
+        Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestCancellationToken));
+        releaseFetch.Set();
         await Task.WhenAll(lookups);
 
         // Assert
         Assert.Equal(1, afterColdStart);
         Assert.Equal(afterColdStart + 1, fetchCount);
         Assert.All(lookups, t => Assert.False(t.Result!.Found));
+    }
+
+    [Fact]
+    public async Task GetMapping_WhenAnotherCallerPublishesNewerMapping_UsesNewerMapping()
+    {
+        // Arrange
+        using var timeProvider = new BlockingTimeProvider();
+        TypeMapping serverMapping = CreateTextWithKeywordMapping("name");
+        using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer, timeProvider, _logger);
+
+        Assert.False(resolver.GetMapping("idx.keyword-000001")!.Found);
+        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
+        timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+
+        timeProvider.BlockNextTimestampRead();
+        var staleLookup = Task.Run(() => resolver.GetMapping("idx.keyword-000001"));
+        Assert.True(timeProvider.WaitUntilBlocked(TimeSpan.FromSeconds(10)));
+
+        // Act
+        var freshLookup = resolver.GetMapping("idx.keyword-000001");
+        timeProvider.ReleaseTimestampRead();
+        var result = await staleLookup;
+
+        // Assert
+        Assert.True(freshLookup?.Found);
+        Assert.True(result?.Found);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetMapping_WithConcurrentFailedMissRefresh_AttemptsOnce(bool throwException)
+    {
+        // Arrange
+        using var fetchStarted = new ManualResetEventSlim(false);
+        using var releaseFetch = new ManualResetEventSlim(false);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            int callNumber = Interlocked.Increment(ref fetchCount);
+            if (callNumber == 1)
+                return CreateTextWithKeywordMapping("name");
+
+            fetchStarted.Set();
+            releaseFetch.Wait(TimeSpan.FromSeconds(30));
+            if (throwException)
+                throw new InvalidOperationException("Elasticsearch is unavailable");
+
+            return null;
+        }, _inferrer, logger: _logger);
+
+        Assert.True(resolver.GetMapping("name")?.Found);
+
+        // Act
+        var lookups = Enumerable.Range(0, 100)
+            .Select(i => Task.Run(() => resolver.GetMapping($"missing{i}")))
+            .ToArray();
+        Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestCancellationToken));
+        releaseFetch.Set();
+        await Task.WhenAll(lookups);
+
+        // Assert
+        Assert.Equal(2, fetchCount);
+        Assert.All(lookups, task => Assert.False(task.Result?.Found));
+        Assert.True(resolver.GetMapping("name")?.Found);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetMapping_WithConcurrentFailedInitialFetch_AttemptsOnce(bool throwException)
+    {
+        // Arrange
+        using var fetchStarted = new ManualResetEventSlim(false);
+        using var releaseFetch = new ManualResetEventSlim(false);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            fetchStarted.Set();
+            releaseFetch.Wait(TimeSpan.FromSeconds(30));
+            if (throwException)
+                throw new InvalidOperationException("Elasticsearch is unavailable");
+
+            return null;
+        }, _inferrer, logger: _logger);
+
+        // Act
+        var lookups = Enumerable.Range(0, 100)
+            .Select(i => Task.Run(() => resolver.GetMapping($"field{i}")))
+            .ToArray();
+        Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestCancellationToken));
+        releaseFetch.Set();
+        await Task.WhenAll(lookups);
+
+        // Assert
+        Assert.Equal(1, fetchCount);
+        Assert.All(lookups, task => Assert.False(task.Result?.Found));
+    }
+
+    [Fact]
+    public async Task GetMapping_WithConcurrentSuccessfulInitialFetch_AttemptsOnce()
+    {
+        // Arrange
+        using var fetchStarted = new ManualResetEventSlim(false);
+        using var releaseFetch = new ManualResetEventSlim(false);
+        int fetchCount = 0;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            fetchStarted.Set();
+            releaseFetch.Wait(TimeSpan.FromSeconds(30));
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, logger: _logger);
+
+        // Act
+        var lookups = Enumerable.Range(0, 100)
+            .Select(_ => Task.Run(() => resolver.GetMapping("name")))
+            .ToArray();
+        Assert.True(fetchStarted.Wait(TimeSpan.FromSeconds(10), TestCancellationToken));
+        await Task.Delay(200, TestCancellationToken);
+        releaseFetch.Set();
+        await Task.WhenAll(lookups);
+
+        // Assert
+        Assert.Equal(1, fetchCount);
+        Assert.All(lookups, task => Assert.True(task.Result?.Found));
     }
 
     [Fact]
@@ -574,51 +874,14 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public async Task GetMapping_WithServerMappingFetchSlowerThanFiveSeconds_ResolvesFieldForAllConcurrentLookups()
-    {
-        // Arrange - the join timeout must comfortably exceed the mapping fetch latency, otherwise concurrent
-        // lookups give up on the very fetch that would have resolved their field and silently treat it as
-        // unmapped. Six seconds would have exceeded the previously hard coded five second join timeout.
-        int fetchCount = 0;
-        var serverMapping = CreateTextWithKeywordMapping("name");
-        using var resolver = new ElasticMappingResolver(() =>
-        {
-            if (Interlocked.Increment(ref fetchCount) > 1)
-                Thread.Sleep(TimeSpan.FromSeconds(6));
-
-            return serverMapping;
-        }, _inferrer, logger: _logger);
-
-        resolver.GetMapping("name");
-        serverMapping = CreateDynamicCustomFieldMapping("name", "keyword-000001", new KeywordProperty());
-
-        // Act
-        var lookups = Enumerable.Range(0, 8)
-            .Select(_ => Task.Run(() => resolver.GetMapping("idx.keyword-000001")))
-            .ToArray();
-        await Task.WhenAll(lookups);
-
-        // Assert - one fetch served them all and every caller got the real mapping
-        Assert.Equal(2, fetchCount);
-        Assert.All(lookups, t =>
-        {
-            Assert.NotNull(t.Result);
-            Assert.True(t.Result!.Found);
-            Assert.Equal("idx.keyword-000001", t.Result.FullPath);
-        });
-    }
-
-    [Fact]
     public void MappingRefreshWaitTimeout_ByDefault_ExceedsTypicalMappingFetchLatency()
     {
         // Arrange + Act
         using var resolver = new ElasticMappingResolver(() => CreateTextWithKeywordMapping("name"), _inferrer, logger: _logger);
 
-        // Assert - waiting for an in-flight fetch is never more expensive than performing it, so the default
-        // must leave plenty of headroom above a normal get mapping round trip
+        // Assert
         Assert.Equal(TimeSpan.FromSeconds(30), resolver.MappingRefreshWaitTimeout);
         Assert.Equal(TimeSpan.FromSeconds(5), resolver.UnmappedFieldRefreshInterval);
-        Assert.Equal(TimeSpan.FromMinutes(1), resolver.MappingRefreshInterval);
     }
 
     [Theory]
@@ -718,6 +981,31 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
+    public void GetMapping_WithIncompatibleCodeAndServerParentTypes_DoesNotFabricateChildField()
+    {
+        // Arrange - the server mapping is authoritative about whether a field is a container or a leaf.
+        var codeMapping = new TypeMapping
+        {
+            Properties = CreateProperties(("value", new ObjectProperty
+            {
+                Properties = CreateProperties(("child", new KeywordProperty()))
+            }))
+        };
+        var serverMapping = new TypeMapping
+        {
+            Properties = CreateProperties(("value", new KeywordProperty()))
+        };
+        using var resolver = new ElasticMappingResolver(codeMapping, _inferrer, () => serverMapping, logger: _logger);
+
+        // Act
+        var mapping = resolver.GetMapping("value.child");
+
+        // Assert
+        Assert.False(mapping?.Found);
+        Assert.Equal("value.child", mapping?.FullPath);
+    }
+
+    [Fact]
     public void GetNonAnalyzedFieldName_WithCodeDeclaredKeywordSubField_UsesCodeDeclaredSubField()
     {
         // Arrange - sorting on an analyzed field fails unless the non analyzed sub-field is found, and the
@@ -744,76 +1032,67 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public void MaxCachedFields_WhenExceededByUnmappedFields_EvictsMissesAndKeepsResolvedFields()
+    public void GetMapping_WithSharedServerPropertyInstanceAndDistinctCodeSubFields_DoesNotLeakSubFieldsAcrossFields()
     {
-        // Arrange - field names come from user supplied queries, so a caller probing many non-existent
-        // fields must not be able to displace the resolutions real queries depend on.
+        // Arrange - reusing one IProperty instance for several fields is legal, so merged children must be
+        // keyed by field name. Keying them by property instance makes one field's code declared sub-field
+        // resolve under the other field's name.
+        var alphaCode = new KeywordProperty { Fields = CreateProperties(("alpha_only", new KeywordProperty())) };
+        var betaCode = new KeywordProperty { Fields = CreateProperties(("beta_only", new KeywordProperty())) };
+        var codeMapping = new TypeMapping { Properties = CreateProperties(("alpha", alphaCode), ("beta", betaCode)) };
+
+        var shared = new KeywordProperty();
+        var serverMapping = new TypeMapping { Properties = CreateProperties(("alpha", shared), ("beta", shared)) };
+
+        using var resolver = new ElasticMappingResolver(codeMapping, _inferrer, () => serverMapping, logger: _logger);
+
+        // Act
+        var alphaOwn = resolver.GetMapping("alpha.alpha_only");
+        var betaOwn = resolver.GetMapping("beta.beta_only");
+        var alphaLeaked = resolver.GetMapping("alpha.beta_only");
+        var betaLeaked = resolver.GetMapping("beta.alpha_only");
+
+        // Assert
+        Assert.True(alphaOwn?.Found);
+        Assert.True(betaOwn?.Found);
+        Assert.False(alphaLeaked?.Found);
+        Assert.False(betaLeaked?.Found);
+    }
+
+    [Fact]
+    public void GetMapping_WithManyDistinctMisses_KeepsKnownFieldsResolvable()
+    {
+        // Arrange - many caller-controlled misses should share one throttled reload attempt without affecting
+        // successful resolutions.
         var properties = new Properties();
         properties.Add("name", new KeywordProperty());
         properties.Add("status", new KeywordProperty());
         properties.Add("created", new DateProperty());
         properties.Add("count", new LongNumberProperty());
         string[] realFields = ["name", "status", "created", "count"];
+        int fetchCount = 0;
 
-        using var resolver = new ElasticMappingResolver(() => new TypeMapping { Properties = properties }, _inferrer,
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            return new TypeMapping { Properties = properties };
+        }, _inferrer,
             new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
-        resolver.MaxCachedFields = 8;
         resolver.UnmappedFieldRefreshInterval = TimeSpan.FromHours(1);
-
-        // Arm both reload throttles before caching anything worth keeping. The first lookup triggers the
-        // cold start load and the second arms the separate unmapped field throttle, so the flood below
-        // exercises cache eviction rather than snapshot replacement.
-        Assert.False(resolver.GetMapping("warmup1")?.Found);
-        Assert.False(resolver.GetMapping("warmup2")?.Found);
 
         foreach (string realField in realFields)
             Assert.True(resolver.GetMapping(realField)?.Found);
+        int afterColdStart = fetchCount;
 
         // Act
         for (int i = 0; i < 100; i++)
-            resolver.GetMapping($"missing{i}");
+            Assert.False(resolver.GetMapping($"missing{i}")?.Found);
 
-        long countAfterFlood = resolver.CachedFieldCount;
+        // Assert
+        Assert.Equal(afterColdStart + 1, fetchCount);
+
         foreach (string realField in realFields)
             Assert.True(resolver.GetMapping(realField)?.Found);
-
-        // Assert - re-resolving the real fields added nothing, so they were still cached.
-        Assert.Equal(countAfterFlood, resolver.CachedFieldCount);
-        Assert.True(countAfterFlood <= resolver.MaxCachedFields,
-            $"Expected cache to stay bounded but it held {countAfterFlood} fields.");
-    }
-
-    [Fact]
-    public void MaxCachedFields_WhenSetToZero_DisablesCachingWithoutBreakingResolution()
-    {
-        // Arrange
-        using var resolver = new ElasticMappingResolver(() => CreateTextWithKeywordMapping("name"), _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
-        resolver.MaxCachedFields = 0;
-
-        // Act
-        var first = resolver.GetMapping("name");
-        var second = resolver.GetMapping("name");
-
-        // Assert
-        Assert.True(first?.Found);
-        Assert.True(second?.Found);
-        Assert.Equal(0, resolver.CachedFieldCount);
-    }
-
-    [Theory]
-    [InlineData(-1)]
-    [InlineData(-60)]
-    public void MappingRefreshInterval_WithNegativeValue_ThrowsArgumentOutOfRangeException(int seconds)
-    {
-        // Arrange
-        using var resolver = new ElasticMappingResolver(() => null, _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
-
-        // Act
-        var exception = Record.Exception(() => resolver.MappingRefreshInterval = TimeSpan.FromSeconds(seconds));
-
-        // Assert
-        var argumentException = Assert.IsType<ArgumentOutOfRangeException>(exception);
-        Assert.Equal("value", argumentException.ParamName);
     }
 
     [Fact]
@@ -831,27 +1110,17 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public void UnmappedFieldRefreshInterval_WithZero_AlwaysAllowsReload()
+    public void UnmappedFieldRefreshInterval_WithZero_ThrowsArgumentOutOfRangeException()
     {
-        // Arrange - zero means "never throttle", which must be accepted rather than treated as invalid.
-        int callCount = 0;
-        using var resolver = new ElasticMappingResolver(() =>
-        {
-            callCount++;
-            return CreateTextWithKeywordMapping("name");
-        }, _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
-        resolver.UnmappedFieldRefreshInterval = TimeSpan.Zero;
-
-        Assert.True(resolver.GetMapping("name")?.Found);
-        int callsAfterColdStart = callCount;
+        // Arrange
+        using var resolver = new ElasticMappingResolver(() => null, _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
 
         // Act
-        resolver.GetMapping("missing1");
-        resolver.GetMapping("missing2");
+        var exception = Record.Exception(() => resolver.UnmappedFieldRefreshInterval = TimeSpan.Zero);
 
         // Assert
-        Assert.True(callCount > callsAfterColdStart + 1,
-            $"Expected each unmapped lookup to reload but only {callCount - callsAfterColdStart} reloads occurred.");
+        var argumentException = Assert.IsType<ArgumentOutOfRangeException>(exception);
+        Assert.Equal("value", argumentException.ParamName);
     }
 
     [Theory]
@@ -872,17 +1141,59 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public void MappingRefreshWaitTimeout_WithInfiniteTimeSpan_IsAccepted()
+    public void MappingRefreshWaitTimeout_WithInfiniteTimeSpan_ThrowsArgumentOutOfRangeException()
     {
-        // Arrange - waiting forever is safe when the fetch callback enforces its own timeout, and
-        // Timeout.InfiniteTimeSpan is the idiomatic way to express it.
+        // Arrange
         using var resolver = new ElasticMappingResolver(() => CreateTextWithKeywordMapping("name"), _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
 
         // Act
-        resolver.MappingRefreshWaitTimeout = Timeout.InfiniteTimeSpan;
+        var exception = Record.Exception(() => resolver.MappingRefreshWaitTimeout = Timeout.InfiniteTimeSpan);
 
         // Assert
-        Assert.Equal(Timeout.InfiniteTimeSpan, resolver.MappingRefreshWaitTimeout);
+        var argumentException = Assert.IsType<ArgumentOutOfRangeException>(exception);
+        Assert.Equal("value", argumentException.ParamName);
+    }
+
+    [Fact]
+    public void MappingRefreshWaitTimeout_WithValueExceedingSemaphoreLimit_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange - a value a semaphore cannot accept was previously clamped silently on every wait, so the
+        // configured timeout and the effective one disagreed.
+        using var resolver = new ElasticMappingResolver(() => null, _inferrer, new FakeTimeProvider(DateTimeOffset.UtcNow), _logger);
+
+        // Act
+        var exception = Record.Exception(() => resolver.MappingRefreshWaitTimeout = TimeSpan.FromDays(30));
+
+        // Assert
+        var argumentException = Assert.IsType<ArgumentOutOfRangeException>(exception);
+        Assert.Equal("value", argumentException.ParamName);
+    }
+
+    [Fact]
+    public void GetMapping_AfterFailedColdStart_RetriesOnceIntervalElapses()
+    {
+        // Arrange - a cold start that failed must not permanently mark the mapping as loaded, otherwise a
+        // resolver created while the cluster was unreachable never fetches the mapping again.
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        int fetchCount = 0;
+        bool serverUnavailable = true;
+        using var resolver = new ElasticMappingResolver(() =>
+        {
+            Interlocked.Increment(ref fetchCount);
+            if (serverUnavailable)
+                throw new InvalidOperationException("Elasticsearch is unavailable");
+
+            return CreateTextWithKeywordMapping("name");
+        }, _inferrer, timeProvider, _logger);
+
+        Assert.False(resolver.GetMapping("name")?.Found);
+        Assert.Equal(1, fetchCount);
+
+        // Act
+        serverUnavailable = false;
+        timeProvider.Advance(resolver.UnmappedFieldRefreshInterval);
+
+        // Assert
         Assert.True(resolver.GetMapping("name")?.Found);
     }
 
@@ -988,52 +1299,6 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public async Task GetMapping_WithConcurrentLookupsOfSameUnmappedField_BacksOffOncePerReload()
-    {
-        // Arrange - every one of these lookups adopts the result of a single reload, so the backoff must
-        // only advance one step rather than being ratcheted to the ceiling by the burst.
-        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
-        int fetchCount = 0;
-        using var resolver = new ElasticMappingResolver(() =>
-        {
-            Interlocked.Increment(ref fetchCount);
-            return CreateTextWithKeywordMapping("name");
-        }, _inferrer, timeProvider: timeProvider, logger: _logger);
-
-        resolver.GetMapping("name");
-        int afterColdStart = fetchCount;
-
-        // Act
-        await Task.WhenAll(Enumerable.Range(0, 32).Select(_ => Task.Run(() => resolver.GetMapping("idx.keyword-000001"))));
-        int afterBurst = fetchCount;
-
-        timeProvider.Advance(TimeSpan.FromSeconds(10));
-        resolver.GetMapping("idx.keyword-000002");
-
-        // Assert - one reload for the burst, then one more after a single 10s backoff step
-        Assert.Equal(1, afterColdStart);
-        Assert.Equal(2, afterBurst);
-        Assert.Equal(3, fetchCount);
-    }
-
-    [Fact]
-    public void GetMapping_WithMoreDistinctFieldsThanMaxCachedFields_BoundsCachedFieldCount()
-    {
-        // Arrange
-        using var resolver = new ElasticMappingResolver(CreateTextWithKeywordMapping("name"), _inferrer, () => null, logger: _logger)
-        {
-            MaxCachedFields = 16
-        };
-
-        // Act
-        for (int i = 0; i < 500; i++)
-            resolver.GetMapping($"unknown_field_{i}");
-
-        // Assert
-        Assert.True(resolver.CachedFieldCount <= 16, $"Expected at most 16 cached fields but found {resolver.CachedFieldCount}");
-    }
-
-    [Fact]
     public void GetMapping_WithCodeSubPropertyUnderServerNestedProperty_ResolvesCodeSubProperty()
     {
         // Arrange - the server mapping only knows the sub fields that have actually been indexed, so
@@ -1079,6 +1344,20 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         Assert.Equal("beta", beta);
     }
 
+    [Fact]
+    public void GetResolvedField_WithMissingTextSubField_PreservesOriginalPath()
+    {
+        // Arrange
+        var serverMapping = new TypeMapping { Properties = CreateProperties(("body", new TextProperty())) };
+        using var resolver = new ElasticMappingResolver(() => serverMapping, _inferrer, logger: _logger);
+
+        // Act
+        string? resolved = resolver.GetResolvedField("body.keyword");
+
+        // Assert
+        Assert.Equal("body.keyword", resolved);
+    }
+
     private static Properties CreateProperties(params (string Name, IProperty Property)[] properties)
     {
         var props = new Properties();
@@ -1086,6 +1365,19 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             props.Add(name, property);
 
         return props;
+    }
+
+    private sealed class ZeroOriginTimeProvider : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => Interlocked.Read(ref _timestamp);
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(GetTimestamp());
+
+        public void Advance(TimeSpan value) => Interlocked.Add(ref _timestamp, value.Ticks);
     }
 
     /// <summary>
@@ -1938,5 +2230,48 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         string json = SerializeQuery(query);
         Assert.Contains("counter", json);
         Assert.Contains("18446744073709551615", json);
+    }
+
+    private sealed class BlockingTimeProvider : TimeProvider, IDisposable
+    {
+        private readonly ManualResetEventSlim _timestampReadBlocked = new(false);
+        private readonly ManualResetEventSlim _releaseTimestampRead = new(false);
+        private long _timestamp;
+        private int _blockNextTimestampRead;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override DateTimeOffset GetUtcNow() => DateTimeOffset.UnixEpoch.AddTicks(Volatile.Read(ref _timestamp));
+
+        public override long GetTimestamp()
+        {
+            if (Interlocked.Exchange(ref _blockNextTimestampRead, 0) == 1)
+            {
+                _timestampReadBlocked.Set();
+                _releaseTimestampRead.Wait(TimeSpan.FromSeconds(30));
+            }
+
+            return Volatile.Read(ref _timestamp);
+        }
+
+        public void Advance(TimeSpan value) => Interlocked.Add(ref _timestamp, value.Ticks);
+
+        public void BlockNextTimestampRead()
+        {
+            _timestampReadBlocked.Reset();
+            _releaseTimestampRead.Reset();
+            Volatile.Write(ref _blockNextTimestampRead, 1);
+        }
+
+        public bool WaitUntilBlocked(TimeSpan timeout) => _timestampReadBlocked.Wait(timeout);
+
+        public void ReleaseTimestampRead() => _releaseTimestampRead.Set();
+
+        public void Dispose()
+        {
+            _releaseTimestampRead.Set();
+            _timestampReadBlocked.Dispose();
+            _releaseTimestampRead.Dispose();
+        }
     }
 }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticMappingResolverUnitTests.cs
@@ -83,7 +83,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         // Arrange
         var mapping = CreateTextWithKeywordAndSortMapping("title");
         mapping.Properties!.Add("created", new DateProperty());
-        using var resolver = new ElasticMappingResolver(
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(
             cancellationToken => Task.FromResult<TypeMapping?>(mapping), _inferrer, logger: _logger);
 
         // Act + Assert
@@ -110,7 +110,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var releaseLoad = new TaskCompletionSource<TypeMapping?>(TaskCreationOptions.RunContinuationsAsynchronously);
         var parser = new ElasticQueryParser(configuration =>
         {
-            configuration.UseMappings(async cancellationToken =>
+            configuration.UseMappingsWithAsyncLoader(async cancellationToken =>
             {
                 loadStarted.TrySetResult();
                 return await releaseLoad.Task;
@@ -152,7 +152,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         // Arrange
         var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
         int fetchCount = 0;
-        using var resolver = new ElasticMappingResolver(cancellationToken =>
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(cancellationToken =>
         {
             Interlocked.Increment(ref fetchCount);
             return Task.FromResult<TypeMapping?>(CreateTextOnlyMapping("title"));
@@ -425,7 +425,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         int fetchCount = 0;
         TypeMapping serverMapping = CreateTextWithKeywordMapping("name");
-        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
         {
             int callNumber = Interlocked.Increment(ref fetchCount);
             TypeMapping capturedMapping = serverMapping;
@@ -950,7 +950,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         int fetchCount = 0;
-        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
         {
             Interlocked.Increment(ref fetchCount);
             fetchStarted.TrySetResult();
@@ -982,7 +982,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         int fetchCount = 0;
-        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
         {
             if (Interlocked.Increment(ref fetchCount) > 1)
             {
@@ -1017,7 +1017,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         int fetchCount = 0;
-        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
         {
             Interlocked.Increment(ref fetchCount);
             fetchStarted.TrySetResult();
@@ -1048,7 +1048,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         // Arrange
         var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var fetchCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var resolver = new ElasticMappingResolver(async cancellationToken =>
+        var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
         {
             fetchStarted.TrySetResult();
             try
@@ -1083,7 +1083,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
         int fetchCount = 0;
         bool failRefresh = false;
-        using var resolver = new ElasticMappingResolver(cancellationToken =>
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(cancellationToken =>
         {
             Interlocked.Increment(ref fetchCount);
             if (!failRefresh)
@@ -1117,7 +1117,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     {
         // Arrange
         int fetchCount = 0;
-        using var resolver = new ElasticMappingResolver(cancellationToken =>
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(cancellationToken =>
         {
             Interlocked.Increment(ref fetchCount);
             return Task.FromResult<TypeMapping?>(CreateTextWithKeywordMapping("name"));
@@ -1140,7 +1140,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var refreshStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseRefresh = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         int fetchCount = 0;
-        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
         {
             if (Interlocked.Increment(ref fetchCount) > 1)
             {
@@ -1171,7 +1171,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var fetchStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         int fetchCount = 0;
-        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
         {
             Interlocked.Increment(ref fetchCount);
             fetchStarted.TrySetResult();
@@ -1195,6 +1195,42 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
+    public async Task GetMapping_WithAsyncOnlyLoaderAndSynchronizationContext_DoesNotDeadlock()
+    {
+        // Arrange
+        var completion = new TaskCompletionSource<FieldMapping?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thread = new Thread(() =>
+        {
+            SynchronizationContext.SetSynchronizationContext(new NonPumpingSynchronizationContext());
+
+            try
+            {
+                using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
+                {
+                    await Task.Yield();
+                    return CreateTextWithKeywordMapping("name");
+                }, _inferrer, logger: _logger);
+
+                completion.TrySetResult(resolver.GetMapping("name"));
+            }
+            catch (Exception ex)
+            {
+                completion.TrySetException(ex);
+            }
+        })
+        {
+            IsBackground = true
+        };
+
+        // Act
+        thread.Start();
+        var mapping = await completion.Task.WaitAsync(TimeSpan.FromSeconds(2), TestCancellationToken);
+
+        // Assert
+        Assert.True(mapping?.Found);
+    }
+
+    [Fact]
     public async Task GetMappingAsync_WhenJoinTimesOut_LaterCallerStillJoinsSharedFetch()
     {
         // Arrange
@@ -1202,7 +1238,7 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
         var releaseFetch = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         int fetchCount = 0;
         TypeMapping serverMapping = CreateTextWithKeywordMapping("name");
-        using var resolver = new ElasticMappingResolver(async cancellationToken =>
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(async cancellationToken =>
         {
             if (Interlocked.Increment(ref fetchCount) > 1)
             {
@@ -1890,17 +1926,24 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
     }
 
     [Fact]
-    public void GetMapping_WithoutAnyMappingSource_ThrowsInvalidOperationException()
+    public void SynchronousMappingApis_WithNullLoader_RemainUnambiguousAndThrowInvalidOperationException()
     {
         // Arrange - a resolver constructed with neither a code mapping nor a server mapping callback is a
         // configuration error and must fail loudly rather than reporting every field as unmapped.
-        using var resolver = new ElasticMappingResolver((Func<TypeMapping?>)null!, _inferrer, logger: _logger);
+        using var constructedResolver = new ElasticMappingResolver(null!, _inferrer, logger: _logger);
+        using var createdResolver = ElasticMappingResolver.Create(null!, _inferrer, _logger);
+        var configuration = new ElasticQueryParserConfiguration().UseMappings(null!, _inferrer);
+        using var configuredResolver = configuration.MappingResolver!;
 
         // Act
-        var exception = Record.Exception(() => resolver.GetMapping("name"));
+        var constructorException = Record.Exception(() => constructedResolver.GetMapping("name"));
+        var factoryException = Record.Exception(() => createdResolver.GetMapping("name"));
+        var configurationException = Record.Exception(() => configuredResolver.GetMapping("name"));
 
         // Assert
-        Assert.IsType<InvalidOperationException>(exception);
+        Assert.IsType<InvalidOperationException>(constructorException);
+        Assert.IsType<InvalidOperationException>(factoryException);
+        Assert.IsType<InvalidOperationException>(configurationException);
     }
 
     [Theory]
@@ -3070,6 +3113,13 @@ public class ElasticMappingResolverUnitTests : TestWithLoggingBase, IDisposable
             _releaseTimestampRead.Set();
             _timestampReadBlocked.Dispose();
             _releaseTimestampRead.Dispose();
+        }
+    }
+
+    private sealed class NonPumpingSynchronizationContext : SynchronizationContext
+    {
+        public override void Post(SendOrPostCallback d, object? state)
+        {
         }
     }
 

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -1391,6 +1391,23 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         Assert.True(validationResult.IsValid);
         Assert.Single(validationResult.ReferencedFields, "field2");
         Assert.Empty(validationResult.UnresolvedFields);
+
+        aliasMap = new FieldMap { { "field3", "missing_physical" } };
+        context = new ElasticQueryVisitorContext();
+        parser = new ElasticQueryParser(c => c.UseMappings(Client, index).UseFieldMap(aliasMap).SetValidationOptions(new QueryValidationOptions { AllowUnresolvedFields = false }));
+        ex = await Assert.ThrowsAsync<QueryValidationException>(() => parser.BuildQueryAsync("field3:value", context));
+
+        Assert.Contains("field3", ex.Result!.ReferencedFields);
+        Assert.Contains("field3", ex.Result.UnresolvedFields);
+
+        var validationOptions = new QueryValidationOptions { AllowUnresolvedFields = false };
+        validationOptions.RestrictedFields.Add("missing_restricted");
+        context = new ElasticQueryVisitorContext();
+        parser = new ElasticQueryParser(c => c.UseMappings(Client, index).UseFieldMap(new FieldMap()).SetValidationOptions(validationOptions));
+        query = await parser.BuildQueryAsync("field1:value", context);
+
+        Assert.NotNull(query);
+        Assert.Empty(context.GetValidationResult().UnresolvedFields);
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/MappingConsumerCompatibilityTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/MappingConsumerCompatibilityTests.cs
@@ -88,6 +88,25 @@ public class MappingConsumerCompatibilityTests
         Assert.Single(remote.Fields!);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetMappingProperty_WithExpressionChild_PreservesInferredName(bool server)
+    {
+        var name = new PropertyName((System.Linq.Expressions.Expression<Func<string, object>>)(value => value.Length));
+        var child = new KeywordProperty();
+        var parent = new ObjectProperty { Properties = new Properties { { name, child } } };
+        using var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200"));
+        var mapping = new TypeMapping { Properties = new Properties { { "parent", parent } } };
+        using var resolver = new ElasticMappingResolver(server ? new TypeMapping() : mapping, new Inferrer(settings), () => server ? mapping : null);
+
+        var merged = Assert.IsType<ObjectProperty>(resolver.GetMappingProperty("parent"));
+
+        Assert.Same(child, resolver.GetMappingProperty("parent.length"));
+        Assert.Equal("length", Assert.Single(merged.Properties!).Key.Name);
+        Assert.Same(name, Assert.Single(parent.Properties!).Key);
+    }
+
     [Fact]
     public void Parse_WithSynchronousOverride_PreservesCallerThread()
     {

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/MappingConsumerCompatibilityTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/MappingConsumerCompatibilityTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Mapping;
+using Foundatio.Parsers.LuceneQueries;
+using Foundatio.Parsers.LuceneQueries.Nodes;
+using Foundatio.Parsers.LuceneQueries.Visitors;
+using Xunit;
+
+namespace Foundatio.Parsers.ElasticQueries.Tests;
+
+public class MappingConsumerCompatibilityTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GetMappingProperty_WithMergedChildren_PreservesPublicShape(bool text)
+    {
+        using var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200"));
+        IProperty code = text ? new TextProperty { Fields = new Properties { { "local", new KeywordProperty() } } } : new ObjectProperty { Properties = new Properties { { "local", new KeywordProperty() } } };
+        IProperty server = text ? new TextProperty { Fields = new Properties { { "remote", new KeywordProperty() } } } : new ObjectProperty { Properties = new Properties { { "remote", new KeywordProperty() } } };
+        using var resolver = new ElasticMappingResolver(new TypeMapping { Properties = new Properties { { "name", code } } }, new Inferrer(settings), () => new TypeMapping { Properties = new Properties { { "name", server } } });
+        var property = resolver.GetMappingProperty("name");
+        var children = property is TextProperty t ? t.Fields : ((ObjectProperty)property!).Properties;
+        Assert.True(resolver.GetMapping("name.local")?.Found);
+        Assert.Contains(children!, child => child.Key.Name == "local");
+        Assert.Contains(children!, child => child.Key.Name == "remote");
+    }
+
+    public static TheoryData<string> PropertyTypes => new(typeof(IProperty).Assembly.GetExportedTypes()
+        .Where(type => !type.IsAbstract && type != typeof(FieldAliasProperty) && typeof(IProperty).IsAssignableFrom(type) && type.GetConstructor(Type.EmptyTypes) is not null)
+        .Select(type => type.FullName!));
+
+    [Theory]
+    [MemberData(nameof(PropertyTypes))]
+    public void GetMappingProperty_WithCodeChildren_PreservesClientPropertyTypes(string typeName)
+    {
+        var type = typeof(IProperty).Assembly.GetType(typeName)!;
+        var code = (IProperty)Activator.CreateInstance(type)!;
+        var server = (IProperty)Activator.CreateInstance(type)!;
+        string childPropertyName = code is ObjectProperty or NestedProperty ? "Properties" : "Fields";
+        var childProperty = type.GetProperty(childPropertyName)!;
+        childProperty.SetValue(code, new Properties { { "local", new KeywordProperty() } });
+        childProperty.SetValue(server, new Properties { { "remote", new KeywordProperty() } });
+        using var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200"));
+        using var resolver = new ElasticMappingResolver(new TypeMapping { Properties = new Properties { { "name", code } } }, new Inferrer(settings), () => new TypeMapping { Properties = new Properties { { "name", server } } });
+        resolver.SetPropertyMetadataValue(code, "custom", "value");
+
+        var merged = resolver.GetMappingProperty("name", followAlias: false)!;
+        var children = (Properties)childProperty.GetValue(merged)!;
+
+        Assert.Equal(type, merged.GetType());
+        Assert.NotSame(server, merged);
+        Assert.Contains(children, child => child.Key.Name == "local");
+        Assert.Contains(children, child => child.Key.Name == "remote");
+        Assert.Single((Properties)childProperty.GetValue(server)!);
+        Assert.Single((Properties)childProperty.GetValue(code)!);
+        Assert.Same(children.Single(child => child.Key.Name == "local").Value, resolver.GetMappingProperty("name.local"));
+        Assert.Equal("value", resolver.GetPropertyMetadataValue<string>(merged, "custom"));
+    }
+
+    [Fact]
+    public void GetMappingProperty_WithNestedMerges_PreservesSettingsAndSerialization()
+    {
+        var local = new TextProperty { Fields = new Properties { { "local", new KeywordProperty() } } };
+        var remote = new TextProperty { Analyzer = "english", SearchAnalyzer = "standard", Index = false, Norms = false, Fields = new Properties { { "remote", new KeywordProperty { IgnoreAbove = 256 } } } };
+        using var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200"));
+        var code = new TypeMapping { Properties = new Properties { { "parent", new ObjectProperty { Properties = new Properties { { "name", local } } } } } };
+        var server = new TypeMapping { Properties = new Properties { { "parent", new ObjectProperty { Dynamic = DynamicMapping.Strict, Properties = new Properties { { "name", remote } } } } } };
+        using var resolver = new ElasticMappingResolver(code, new Inferrer(settings), () => server);
+        var parent = Assert.IsType<ObjectProperty>(resolver.GetMappingProperty("parent"));
+        var merged = Assert.IsType<TextProperty>(parent.Properties!.Single().Value);
+        Assert.Equal(DynamicMapping.Strict, parent.Dynamic);
+        Assert.Equal("english", merged.Analyzer);
+        Assert.Equal("standard", merged.SearchAnalyzer);
+        Assert.False(merged.Index);
+        Assert.False(merged.Norms);
+        Assert.Equal(2, merged.Fields!.Count());
+        var client = new ElasticsearchClient(settings);
+        using var stream = new System.IO.MemoryStream();
+        client.RequestResponseSerializer.Serialize<IProperty>(parent, stream);
+        string json = System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        Assert.Contains("\"local\"", json);
+        Assert.Contains("\"remote\"", json);
+        Assert.Contains("\"ignore_above\":256", json);
+        Assert.Single(remote.Fields!);
+    }
+
+    [Fact]
+    public void Parse_WithSynchronousOverride_PreservesCallerThread()
+    {
+        var previous = SynchronizationContext.Current;
+        var parser = new ThreadBoundParser();
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+            Assert.NotNull(parser.Parse("value", new QueryVisitorContext()));
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previous);
+        }
+    }
+
+    [Fact]
+    public async Task ValidateQueryAsync_WithMissingAlias_CallsRuntimeResolverOnce()
+    {
+        int calls = 0;
+        using var resolver = new ElasticMappingResolver(() => new TypeMapping { Properties = new Properties() });
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver).UseFieldMap(new FieldMap { { "alias", "missing" } }).UseRuntimeFieldResolver(_ => { calls++; return Task.FromResult<ElasticRuntimeField?>(null); }));
+        var result = await parser.ValidateQueryAsync("alias:value", new QueryValidationOptions { AllowUnresolvedFields = false });
+        Assert.False(result.IsValid);
+        Assert.Equal(1, calls);
+    }
+
+    private sealed class ThreadBoundParser : LuceneQueryParser
+    {
+        private readonly int _owner = Environment.CurrentManagedThreadId;
+        public override Task<IQueryNode?> ParseAsync(string query, IQueryVisitorContext? context = null)
+        {
+            if (Environment.CurrentManagedThreadId != _owner)
+                throw new InvalidOperationException("Synchronous override moved off owner thread");
+            return Task.FromResult<IQueryNode?>(new TermNode { Term = query });
+        }
+    }
+}

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/MappingValidationTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/MappingValidationTests.cs
@@ -12,6 +12,35 @@ namespace Foundatio.Parsers.ElasticQueries.Tests;
 public class MappingValidationTests
 {
     [Theory]
+    [InlineData(20, false)]
+    [InlineData(20, true)]
+    [InlineData(21, false)]
+    [InlineData(21, true)]
+    [InlineData(29, false)]
+    [InlineData(29, true)]
+    public async Task ValidateAsync_WithCustomFieldResolverPriority_ValidatesResolvedFields(int priority, bool useFieldMap)
+    {
+        using var resolver = new ElasticMappingResolver(CreateMapping);
+        var parser = new ElasticQueryParser(c =>
+        {
+            c.UseMappings(resolver).SetValidationOptions(new QueryValidationOptions { AllowUnresolvedFields = false });
+            if (useFieldMap)
+                c.UseFieldMap(new FieldMap { { "alias", "known" } }, priority);
+            else
+                c.UseFieldResolver((field, _) => Task.FromResult<string?>(field == "alias" ? "known" : null), priority);
+        });
+
+        Assert.True((await parser.ValidateQueryAsync("alias:value")).IsValid);
+        Assert.True((await parser.ValidateSortAsync("alias")).IsValid);
+        Assert.True((await parser.ValidateAggregationsAsync("terms:alias")).IsValid);
+        Assert.NotNull(await parser.BuildQueryAsync("alias:value"));
+
+        var missing = await parser.ValidateQueryAsync("missing:value");
+        Assert.False(missing.IsValid);
+        Assert.Contains("missing", missing.UnresolvedFields);
+    }
+
+    [Theory]
     [InlineData("query")]
     [InlineData("sort")]
     [InlineData("aggregation")]

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/MappingValidationTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/MappingValidationTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch.Mapping;
+using Foundatio.Parsers.ElasticQueries.Visitors;
+using Foundatio.Parsers.LuceneQueries;
+using Foundatio.Parsers.LuceneQueries.Visitors;
+using Xunit;
+
+namespace Foundatio.Parsers.ElasticQueries.Tests;
+
+public class MappingValidationTests
+{
+    [Theory]
+    [InlineData("query")]
+    [InlineData("sort")]
+    [InlineData("aggregation")]
+    public async Task ValidateAsync_WithReusedContextAndMissingAlias_ReportsOriginalField(string queryType)
+    {
+        using var resolver = new ElasticMappingResolver(CreateMapping);
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver)
+            .UseFieldMap(new FieldMap { { "alias", "missing" } })
+            .SetValidationOptions(new QueryValidationOptions { AllowUnresolvedFields = false }));
+        var context = new ElasticQueryVisitorContext();
+
+        async Task<QueryValidationResult> ValidateAsync(string field) => queryType switch
+        {
+            "sort" => await parser.ValidateSortAsync(field, context: context),
+            "aggregation" => await parser.ValidateAggregationsAsync($"terms:{field}", context: context),
+            _ => await parser.ValidateQueryAsync($"{field}:value", context: context)
+        };
+
+        Assert.True((await ValidateAsync("known")).IsValid);
+        var result = await ValidateAsync("alias");
+
+        Assert.False(result.IsValid);
+        Assert.Contains("alias", result.UnresolvedFields);
+        Assert.DoesNotContain("missing", result.UnresolvedFields);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ValidateQueryAsync_WithMissingDefaultField_RejectsOnlyUsedFields(bool mixed, bool included)
+    {
+        int loads = 0;
+        using var resolver = new ElasticMappingResolver(() => { loads++; return CreateMapping(); });
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver)
+            .SetDefaultFields(mixed ? ["known", "missing"] : ["missing"])
+            .UseIncludes(new Dictionary<string, string> { { "fragment", "value" } }));
+        var options = new QueryValidationOptions { AllowUnresolvedFields = false };
+
+        var result = await parser.ValidateQueryAsync(included ? "@include:fragment" : "value", options);
+
+        Assert.False(result.IsValid);
+        Assert.Single(result.UnresolvedFields, "missing");
+        Assert.InRange(loads, 1, mixed ? 2 : 1);
+    }
+
+    [Fact]
+    public async Task BuildQueryAsync_WithMissingDefaultField_ThrowsValidationException()
+    {
+        using var resolver = new ElasticMappingResolver(CreateMapping);
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver).SetDefaultFields(["missing"])
+            .SetValidationOptions(new QueryValidationOptions { AllowUnresolvedFields = false }));
+
+        var error = await Assert.ThrowsAsync<QueryValidationException>(() => parser.BuildQueryAsync("value"));
+
+        Assert.Contains("missing", error.Result!.UnresolvedFields);
+    }
+
+    [Theory]
+    [InlineData("known:value")]
+    [InlineData("known:(value)")]
+    [InlineData("known:[1 TO 2]")]
+    [InlineData("_exists_:known")]
+    [InlineData("_missing_:known")]
+    public async Task ValidateQueryAsync_WithUnusedMissingDefaultsAndRestrictions_RemainsValid(string query)
+    {
+        using var resolver = new ElasticMappingResolver(CreateMapping);
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver).UseFieldMap(new FieldMap())
+            .SetDefaultFields(["unused-default"]));
+        var options = new QueryValidationOptions { AllowUnresolvedFields = false };
+        options.RestrictedFields.Add("unused-restriction");
+
+        var result = await parser.ValidateQueryAsync(query, options);
+
+        Assert.True(result.IsValid, result.Message);
+        Assert.Empty(result.UnresolvedFields);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ValidateQueryAsync_WithRuntimeDefaultField_PreservesRuntimeResolution(bool dynamic)
+    {
+        using var resolver = new ElasticMappingResolver(CreateMapping);
+        var parser = new ElasticQueryParser(c =>
+        {
+            c.UseMappings(resolver).SetDefaultFields(["runtime"]);
+            if (dynamic)
+                c.UseRuntimeFieldResolver(field => Task.FromResult<ElasticRuntimeField?>(field == "runtime" ? new ElasticRuntimeField { Name = "runtime" } : null));
+        });
+        var context = new ElasticQueryVisitorContext();
+        if (!dynamic)
+            context.RuntimeFields.Add(new ElasticRuntimeField { Name = "runtime" });
+
+        var result = await parser.ValidateQueryAsync("value", new QueryValidationOptions { AllowUnresolvedFields = false }, context);
+
+        Assert.True(result.IsValid, result.Message);
+        Assert.Empty(result.UnresolvedFields);
+        Assert.Single(context.RuntimeFields);
+    }
+
+    [Fact]
+    public async Task ValidateQueryAsync_WithMappedAliasAndRuntimeField_RemainsValid()
+    {
+        var mapping = CreateMapping();
+        mapping.Properties!.Add("server-alias", new FieldAliasProperty { Path = "known" });
+        using var resolver = new ElasticMappingResolver(() => mapping);
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver).UseFieldMap(new FieldMap { { "alias", "known" } }));
+        var context = new ElasticQueryVisitorContext();
+        context.RuntimeFields.Add(new ElasticRuntimeField { Name = "runtime" });
+
+        var result = await parser.ValidateQueryAsync("alias:value OR server-alias:value OR runtime:value",
+            new QueryValidationOptions { AllowUnresolvedFields = false }, context);
+
+        Assert.True(result.IsValid, result.Message);
+        Assert.Empty(result.UnresolvedFields);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ValidateQueryAsync_WithFailingRuntimeResolver_PreservesValidationError(bool defaultField)
+    {
+        using var resolver = new ElasticMappingResolver(CreateMapping);
+        int calls = 0;
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver).SetDefaultFields(["missing"]).UseRuntimeFieldResolver(_ =>
+        {
+            calls++;
+            throw new InvalidOperationException("runtime lookup failed");
+        }));
+
+        var result = await parser.ValidateQueryAsync(defaultField ? "value" : "missing:value", new QueryValidationOptions { AllowUnresolvedFields = false });
+
+        Assert.False(result.IsValid);
+        Assert.Contains("runtime lookup failed", result.Message);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task ValidateQueryAsync_WithUnresolvedRuntimeField_DoesNotRepeatCallback()
+    {
+        using var resolver = new ElasticMappingResolver(CreateMapping);
+        int calls = 0;
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver).UseRuntimeFieldResolver(_ =>
+        {
+            calls++;
+            return Task.FromResult<ElasticRuntimeField?>(null);
+        }));
+
+        var result = await parser.ValidateQueryAsync("missing:value", new QueryValidationOptions { AllowUnresolvedFields = false });
+
+        Assert.False(result.IsValid);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task ValidateQueryAsync_WithBlockedDefaultFieldLoader_ReturnsBeforeLoadCompletes()
+    {
+        var release = new TaskCompletionSource<TypeMapping?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ => release.Task);
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver).SetDefaultFields(["missing"]));
+
+        var validation = parser.ValidateQueryAsync("value", new QueryValidationOptions { AllowUnresolvedFields = false });
+        Assert.False(validation.IsCompleted);
+        release.SetResult(CreateMapping());
+        var result = await validation.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsValid);
+        Assert.Single(result.UnresolvedFields, "missing");
+    }
+
+    [Fact]
+    public async Task ValidateQueryAsync_WithoutMappings_PreservesCustomResolverContract()
+    {
+        var parser = new ElasticQueryParser(c => c.UseFieldMap(new FieldMap { { "alias", "custom" } }));
+
+        var result = await parser.ValidateQueryAsync("alias:value", new QueryValidationOptions { AllowUnresolvedFields = false });
+
+        Assert.True(result.IsValid, result.Message);
+    }
+
+    [Fact]
+    public async Task ValidateAggregationsAsync_WithMetadataField_DoesNotRequireMapping()
+    {
+        using var resolver = new ElasticMappingResolver(CreateMapping);
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver));
+
+        var result = await parser.ValidateAggregationsAsync("@name:custom terms:known", new QueryValidationOptions { AllowUnresolvedFields = false });
+
+        Assert.Empty(result.UnresolvedFields);
+    }
+
+    private static TypeMapping CreateMapping() => new() { Properties = new Properties { { "known", new KeywordProperty() } } };
+}

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/MappingValidationTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/MappingValidationTests.cs
@@ -205,5 +205,34 @@ public class MappingValidationTests
         Assert.Empty(result.UnresolvedFields);
     }
 
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task ValidateQueryAsync_WithRepeatedRuntimeLookup_SharesOutcomeAndReleasesScope(bool defaults, bool throws)
+    {
+        int calls = 0;
+        using var resolver = new ElasticMappingResolver(CreateMapping);
+        var parser = new ElasticQueryParser(c => c.UseMappings(resolver).SetDefaultFields(["missing"])
+            .UseIncludes(new Dictionary<string, string> { { "fragment", defaults ? "value other" : "alias:value other:second" } })
+            .UseFieldMap(new FieldMap { { "alias", "missing" }, { "other", "missing" } })
+            .UseRuntimeFieldResolver(async _ =>
+            {
+                calls++;
+                await Task.Yield();
+                if (throws)
+                    throw new InvalidOperationException("runtime lookup failed");
+                return null;
+            }));
+        var context = new ElasticQueryVisitorContext();
+        var options = new QueryValidationOptions { AllowUnresolvedFields = false };
+
+        Assert.False((await parser.ValidateQueryAsync("@include:fragment", options, context)).IsValid);
+        Assert.Equal(1, calls);
+        Assert.False((await parser.ValidateQueryAsync("alias:value", options, context)).IsValid);
+        Assert.Equal(2, calls);
+    }
+
     private static TypeMapping CreateMapping() => new() { Properties = new Properties { { "known", new KeywordProperty() } } };
 }

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/TypedFieldMappingTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/TypedFieldMappingTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Mapping;
+using Xunit;
+
+namespace Foundatio.Parsers.ElasticQueries.Tests;
+
+public class TypedFieldMappingTests
+{
+    [Theory]
+    [InlineData("sort", false)]
+    [InlineData("sort", true)]
+    [InlineData("aggregation", false)]
+    [InlineData("aggregation", true)]
+    [InlineData("non-analyzed", false)]
+    [InlineData("non-analyzed", true)]
+    public async Task GetFieldName_WithColdMissingTypedField_FetchesOnce(string helper, bool asynchronous)
+    {
+        using var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200"));
+        int loads = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ =>
+        {
+            Interlocked.Increment(ref loads);
+            return Task.FromResult<TypeMapping?>(new TypeMapping { Properties = new Properties() });
+        }, new Inferrer(settings));
+
+        string result = asynchronous
+            ? await GetFieldNameAsync(resolver, new Field("missing"), helper, TestContext.Current.CancellationToken)
+            : GetFieldName(resolver, new Field("missing"), helper);
+
+        Assert.Equal("missing", result);
+        Assert.Equal(1, loads);
+
+        int stringLoads = 0;
+        using var stringResolver = ElasticMappingResolver.CreateWithAsyncLoader(_ =>
+        {
+            stringLoads++;
+            return Task.FromResult<TypeMapping?>(new TypeMapping { Properties = new Properties() });
+        });
+        string? stringResult = asynchronous
+            ? await GetFieldNameAsync(stringResolver, "missing", helper, TestContext.Current.CancellationToken)
+            : GetFieldName(stringResolver, "missing", helper);
+        Assert.Equal(result, stringResult);
+        Assert.Equal(loads, stringLoads);
+    }
+
+    [Theory]
+    [InlineData("title", "sort", "title.sort", "title.sort")]
+    [InlineData("TITLE", "aggregation", "title.keyword", "title.keyword")]
+    [InlineData("alias", "non-analyzed", "title.keyword", "title.keyword")]
+    [InlineData("status-alias", "sort", "status", "status-alias")]
+    [InlineData("STATUS", "aggregation", "status", "STATUS")]
+    [InlineData("title.missing", "non-analyzed", "title.missing", "title.missing")]
+    public async Task GetFieldName_WithTypedField_PreservesCanonicalNamesAndSubfields(string field, string helper, string expected, string stringExpected)
+    {
+        using var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200"));
+        using var resolver = new ElasticMappingResolver(CreateMapping, new Inferrer(settings));
+
+        Assert.Equal(expected, GetFieldName(resolver, new Field(field), helper));
+        Assert.Equal(expected, await GetFieldNameAsync(resolver, new Field(field), helper, TestContext.Current.CancellationToken));
+        Assert.Equal(stringExpected, GetFieldName(resolver, field, helper));
+        Assert.Equal(stringExpected, await GetFieldNameAsync(resolver, field, helper, TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData("sort")]
+    [InlineData("aggregation")]
+    [InlineData("non-analyzed")]
+    public async Task GetFieldNameAsync_WithCancelledCaller_DoesNotStartLoad(string helper)
+    {
+        using var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200"));
+        int loads = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ => { loads++; return Task.FromResult<TypeMapping?>(CreateMapping()); }, new Inferrer(settings));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => GetFieldNameAsync(resolver, new Field("missing"), helper, cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => GetFieldNameAsync(resolver, "missing", helper, cancellation.Token));
+
+        Assert.Equal(0, loads);
+    }
+
+    [Fact]
+    public async Task GetFieldNameAsync_WithExpressionField_UsesConfiguredInferrer()
+    {
+        using var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200"));
+        settings.DefaultFieldNameInferrer(name => name.ToUpperInvariant());
+        int loads = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ =>
+        {
+            loads++;
+            return Task.FromResult<TypeMapping?>(new TypeMapping
+            {
+                Properties = new Properties { { "TITLE", new TextProperty { Fields = new Properties { { "keyword", new KeywordProperty() } } } } }
+            });
+        }, new Inferrer(settings));
+
+        string field = await resolver.GetSortFieldNameAsync(Infer.Field<Document>(d => d.Title), TestContext.Current.CancellationToken);
+
+        Assert.Equal("TITLE.keyword", field);
+        Assert.Equal(1, loads);
+    }
+
+    [Theory]
+    [InlineData("sort")]
+    [InlineData("aggregation")]
+    [InlineData("non-analyzed")]
+    public async Task GetFieldNameAsync_WithConcurrentMissingFields_JoinsOneLoad(string helper)
+    {
+        using var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200"));
+        var release = new TaskCompletionSource<TypeMapping?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        int loads = 0;
+        using var resolver = ElasticMappingResolver.CreateWithAsyncLoader(_ => { Interlocked.Increment(ref loads); return release.Task; }, new Inferrer(settings));
+
+        var first = GetFieldNameAsync(resolver, new Field("missing"), helper, TestContext.Current.CancellationToken);
+        var second = GetFieldNameAsync(resolver, "other", helper, TestContext.Current.CancellationToken);
+        Assert.False(first.IsCompleted);
+        Assert.False(second.IsCompleted);
+        release.SetResult(CreateMapping());
+        await Task.WhenAll((Task)first, second).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.Equal("missing", await first);
+        Assert.Equal("other", await second);
+        Assert.Equal(1, loads);
+    }
+
+    private static string GetFieldName(ElasticMappingResolver resolver, Field field, string helper) => helper switch
+    {
+        "sort" => resolver.GetSortFieldName(field),
+        "aggregation" => resolver.GetAggregationsFieldName(field),
+        _ => resolver.GetNonAnalyzedFieldName(field)
+    };
+
+    private static async Task<string> GetFieldNameAsync(ElasticMappingResolver resolver, Field field, string helper, CancellationToken cancellationToken = default) => helper switch
+    {
+        "sort" => await resolver.GetSortFieldNameAsync(field, cancellationToken),
+        "aggregation" => await resolver.GetAggregationsFieldNameAsync(field, cancellationToken),
+        _ => await resolver.GetNonAnalyzedFieldNameAsync(field, cancellationToken: cancellationToken)
+    };
+
+    private static string? GetFieldName(ElasticMappingResolver resolver, string field, string helper) => helper switch
+    {
+        "sort" => resolver.GetSortFieldName(field),
+        "aggregation" => resolver.GetAggregationsFieldName(field),
+        _ => resolver.GetNonAnalyzedFieldName(field)
+    };
+
+    private static async Task<string?> GetFieldNameAsync(ElasticMappingResolver resolver, string field, string helper, CancellationToken cancellationToken) => helper switch
+    {
+        "sort" => await resolver.GetSortFieldNameAsync(field, cancellationToken),
+        "aggregation" => await resolver.GetAggregationsFieldNameAsync(field, cancellationToken),
+        _ => await resolver.GetNonAnalyzedFieldNameAsync(field, cancellationToken: cancellationToken)
+    };
+
+    private static TypeMapping CreateMapping() => new()
+    {
+        Properties = new Properties
+        {
+            { "title", new TextProperty { Fields = new Properties { { "keyword", new KeywordProperty() }, { "sort", new KeywordProperty() } } } },
+            { "status", new KeywordProperty() },
+            { "alias", new FieldAliasProperty { Path = "title" } },
+            { "status-alias", new FieldAliasProperty { Path = "status" } }
+        }
+    };
+
+    private sealed class Document
+    {
+        public string? Title { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes #250

Dynamically created fields could resolve as unmapped after cold start, and concurrent queries could continue with stale mappings while another caller refreshed them. This could produce flat queries for nested fields or select the wrong sort field.

The resolver now shares asynchronous mapping loads, publishes immutable snapshots, and retries missing fields with a five-second cooldown. Known fields remain cached; `RefreshMapping()` explicitly invalidates them. Failed loads preserve the last good mapping, and superseded loads cannot overwrite a newer snapshot. Existing synchronous APIs and the public `FieldMapping` constructor remain compatible.

Query, sort, aggregation, and validation operations reuse their mapping results, including misses. Mapping validation follows custom-priority field resolvers so valid aliases are not rejected. Runtime-field result dictionaries are allocated only when needed. The optional `ServerMappingRevisionResolver` preserves the merged tree and cached fields when the mapping owner supplies an unchanged complete revision. It is disabled by default: the revision must include index identity and dynamic mapping changes; a schema deployment version alone is insufficient.

Reuse one resolver per index and process. Load sharing is local to that resolver, and the cooldown is not a freshness guarantee. Revision reuse saves local rebuilding; it does not remove mapping HTTP requests or JSON parsing.

The daily/monthly Foundatio.Repositories loader fix is in [companion PR #322](https://github.com/FoundatioFx/Foundatio.Repositories/pull/322), which pins this PR's preview package for combined validation.

Validation: solution build passed with no warnings; 291 focused mapping tests passed; changed-file formatting passed. A controlled .NET 10 Release allocation probe measured approximately 1.1 MB → 344 bytes for an unchanged 5,000-field refresh with a trusted revision, excluding HTTP/deserialization, and 80 fewer bytes per ordinary query from lazy runtime caching. Hosted CI passed all 813 tests at `1f01e52`; the final automated review completed with no outstanding findings.
