### PR TITLE
Fix SQL negation and required clauses

### DIFF
--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -33,15 +33,26 @@ public static class SqlNodeExtensions
         if (hasRequiredOperands)
         {
             operands = operands
-                .Where(n => HasRequiredClause(n) || n.IsExcluded())
+                .Where(n => HasRequiredClause(n) || HasProhibitedClause(n))
                 .ToList();
             op = GroupOperator.And;
         }
         else if (op == GroupOperator.Or)
         {
-            prohibitedOperands = operands.Where(n => n.IsExcluded()).ToList();
+            prohibitedOperands = operands.Where(HasProhibitedClause).ToList();
             if (prohibitedOperands.Count > 0)
-                optionalOperands = operands.Where(n => !n.IsExcluded()).ToList();
+            {
+                if (prohibitedOperands.Any(n => !n.IsExcluded()))
+                {
+                    operands = prohibitedOperands;
+                    prohibitedOperands = null;
+                    op = GroupOperator.And;
+                }
+                else
+                {
+                    optionalOperands = operands.Where(n => !HasProhibitedClause(n)).ToList();
+                }
+            }
         }
 
         if (node.IsNegated.HasValue && node.IsNegated.Value)
@@ -477,6 +488,16 @@ public static class SqlNodeExtensions
         return node is GroupNode { HasParens: false } groupNode
             && ((groupNode.Left is not null && HasRequiredClause(groupNode.Left))
                 || (groupNode.Right is not null && HasRequiredClause(groupNode.Right)));
+    }
+
+    private static bool HasProhibitedClause(IQueryNode node)
+    {
+        if (node.IsExcluded())
+            return true;
+
+        return node is GroupNode { HasParens: false } groupNode
+            && ((groupNode.Left is not null && HasProhibitedClause(groupNode.Left))
+                || (groupNode.Right is not null && HasProhibitedClause(groupNode.Right)));
     }
 
     private static List<IQueryNode> GetOperands(GroupNode node, GroupOperator op, ISqlQueryVisitorContext context)

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -196,7 +196,7 @@ public static class SqlNodeExtensions
 
         // support overriding the generated query
         if (node.TryGetQuery(out string? query))
-            return query;
+            return node.IsExcluded() ? $"!({query})" : query;
 
         var builder = new StringBuilder();
         bool isExcluded = node.IsExcluded();

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -27,6 +27,8 @@ public static class SqlNodeExtensions
         var operands = GetOperands(node, op, context);
         bool hasRequiredOperands = op == GroupOperator.Or
             && operands.Any(HasRequiredClause);
+        List<IQueryNode>? optionalOperands = null;
+        List<IQueryNode>? prohibitedOperands = null;
 
         if (hasRequiredOperands)
         {
@@ -34,6 +36,12 @@ public static class SqlNodeExtensions
                 .Where(n => HasRequiredClause(n) || n.IsExcluded())
                 .ToList();
             op = GroupOperator.And;
+        }
+        else if (op == GroupOperator.Or)
+        {
+            prohibitedOperands = operands.Where(n => n.IsExcluded()).ToList();
+            if (prohibitedOperands.Count > 0)
+                optionalOperands = operands.Where(n => !n.IsExcluded()).ToList();
         }
 
         if (node.IsNegated.HasValue && node.IsNegated.Value)
@@ -48,15 +56,25 @@ public static class SqlNodeExtensions
         if (node.HasParens)
             builder.Append("(");
 
-        for (int i = 0; i < operands.Count; i++)
+        if (prohibitedOperands is { Count: > 0 } && optionalOperands is not null)
         {
-            if (i > 0)
-                builder.Append(op == GroupOperator.Or ? " OR " : " AND ");
+            if (optionalOperands.Count > 0)
+            {
+                if (optionalOperands.Count > 1)
+                    builder.Append("(");
 
-            builder.Append(operands[i] is GroupNode groupNode
-                ? groupNode.ToDynamicLinqString(context)
-                : operands[i].ToDynamicLinqString(context));
+                AppendOperands(optionalOperands, GroupOperator.Or);
+
+                if (optionalOperands.Count > 1)
+                    builder.Append(")");
+
+                builder.Append(" AND ");
+            }
+
+            AppendOperands(prohibitedOperands, GroupOperator.And);
         }
+        else
+            AppendOperands(operands, op);
 
         if (node.HasParens)
             builder.Append(")");
@@ -68,6 +86,19 @@ public static class SqlNodeExtensions
             builder.Append("^" + node.Boost);
 
         return builder.ToString();
+
+        void AppendOperands(IReadOnlyList<IQueryNode> nodes, GroupOperator joinOperator)
+        {
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                if (i > 0)
+                    builder.Append(joinOperator == GroupOperator.Or ? " OR " : " AND ");
+
+                builder.Append(nodes[i] is GroupNode groupNode
+                    ? groupNode.ToDynamicLinqString(context)
+                    : nodes[i].ToDynamicLinqString(context));
+            }
+        }
     }
 
     public static string ToDynamicLinqString(this ExistsNode node, ISqlQueryVisitorContext context)
@@ -83,14 +114,22 @@ public static class SqlNodeExtensions
         var (fieldPrefix, fieldSuffix) = field.GetFieldPrefixAndSuffix();
 
         var builder = new StringBuilder();
+        bool isExcluded = node.IsExcluded();
+        bool negateExpression = isExcluded && !String.IsNullOrEmpty(fieldSuffix);
+
+        if (negateExpression)
+            builder.Append("!(");
 
         builder.Append(fieldPrefix);
         builder.Append(field.Name);
-        if (!node.IsExcluded())
+        if (!isExcluded || negateExpression)
             builder.Append(" != null");
         else
             builder.Append(" == null");
         builder.Append(fieldSuffix);
+
+        if (negateExpression)
+            builder.Append(")");
 
         return builder.ToString();
     }

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -27,8 +27,6 @@ public static class SqlNodeExtensions
         var operands = GetOperands(node, op, context);
         bool hasRequiredOperands = op == GroupOperator.Or
             && operands.Any(HasRequiredClause);
-        List<IQueryNode>? optionalOperands = null;
-        List<IQueryNode>? prohibitedOperands = null;
 
         if (hasRequiredOperands)
         {
@@ -36,23 +34,6 @@ public static class SqlNodeExtensions
                 .Where(n => HasRequiredClause(n) || HasProhibitedClause(n))
                 .ToList();
             op = GroupOperator.And;
-        }
-        else if (op == GroupOperator.Or)
-        {
-            prohibitedOperands = operands.Where(HasProhibitedClause).ToList();
-            if (prohibitedOperands.Count > 0)
-            {
-                if (prohibitedOperands.Any(n => !n.IsExcluded()))
-                {
-                    operands = prohibitedOperands;
-                    prohibitedOperands = null;
-                    op = GroupOperator.And;
-                }
-                else
-                {
-                    optionalOperands = operands.Where(n => !HasProhibitedClause(n)).ToList();
-                }
-            }
         }
 
         if (node.IsNegated.HasValue && node.IsNegated.Value)
@@ -67,25 +48,7 @@ public static class SqlNodeExtensions
         if (node.HasParens)
             builder.Append("(");
 
-        if (prohibitedOperands is { Count: > 0 } && optionalOperands is not null)
-        {
-            if (optionalOperands.Count > 0)
-            {
-                if (optionalOperands.Count > 1)
-                    builder.Append("(");
-
-                AppendOperands(optionalOperands, GroupOperator.Or);
-
-                if (optionalOperands.Count > 1)
-                    builder.Append(")");
-
-                builder.Append(" AND ");
-            }
-
-            AppendOperands(prohibitedOperands, GroupOperator.And);
-        }
-        else
-            AppendOperands(operands, op);
+        AppendOperands(operands, op);
 
         if (node.HasParens)
             builder.Append(")");
@@ -110,8 +73,7 @@ public static class SqlNodeExtensions
                     bool requiresParens = !groupNode.HasParens
                         && joinOperator == GroupOperator.And
                         && groupNode.GetOperator(context) == GroupOperator.Or
-                        && !HasRequiredClause(groupNode)
-                        && !HasProhibitedClause(groupNode);
+                        && !HasRequiredClause(groupNode);
 
                     if (requiresParens)
                         builder.Append("(");

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -116,9 +116,6 @@ public static class SqlNodeExtensions
 
     public static string? ToDynamicLinqString(this TermNode node, ISqlQueryVisitorContext context)
     {
-        if (!String.IsNullOrEmpty(node.Prefix))
-            context.AddValidationError("Prefix is not supported for term range queries.");
-
         if (node.Term is null)
             return null;
 
@@ -127,6 +124,7 @@ public static class SqlNodeExtensions
             return query;
 
         var builder = new StringBuilder();
+        bool isExcluded = node.IsExcluded();
 
         if (String.IsNullOrEmpty(node.Field))
         {
@@ -160,7 +158,7 @@ public static class SqlNodeExtensions
 
             fieldTerms.Where(f => f.Value.Tokens is { Count: > 0 }).ForEach((kvp, x) =>
             {
-                if (x.IsFirst && node.IsNegated.HasValue && node.IsNegated.Value)
+                if (x.IsFirst && isExcluded)
                     builder.Append("!");
 
                 builder.Append(x.IsFirst ? "(" : " OR ");
@@ -264,8 +262,8 @@ public static class SqlNodeExtensions
         else if (node.Term.EndsWith("*"))
             searchOperator = SqlSearchOperator.StartsWith;
 
-        if (node.IsNegated.HasValue && node.IsNegated.Value)
-            builder.Append("!");
+        if (isExcluded)
+            builder.Append("!(");
 
         if (searchOperator == SqlSearchOperator.Equals)
         {
@@ -325,6 +323,9 @@ public static class SqlNodeExtensions
             builder.Append(fieldSuffix);
         }
 
+        if (isExcluded)
+            builder.Append(")");
+
         return builder.ToString();
     }
 
@@ -349,11 +350,13 @@ public static class SqlNodeExtensions
         var (scopePrefix, argumentPrefix) = SplitFieldPrefix(field, fieldPrefix);
 
         var builder = new StringBuilder();
+        bool isExcluded = node.IsExcluded();
+        bool shouldWrap = isExcluded || (node.Min != null && node.Max != null);
 
-        if (node.IsNegated.HasValue && node.IsNegated.Value)
+        if (isExcluded)
             builder.Append("!");
 
-        if (node.Min != null && node.Max != null)
+        if (shouldWrap)
             builder.Append("(");
 
         if (node.Min != null)
@@ -379,7 +382,7 @@ public static class SqlNodeExtensions
             builder.Append(fieldSuffix);
         }
 
-        if (node.Min != null && node.Max != null)
+        if (shouldWrap)
             builder.Append(")");
 
         return builder.ToString();

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -105,9 +105,26 @@ public static class SqlNodeExtensions
                 if (i > 0)
                     builder.Append(joinOperator == GroupOperator.Or ? " OR " : " AND ");
 
-                builder.Append(nodes[i] is GroupNode groupNode
-                    ? groupNode.ToDynamicLinqString(context)
-                    : nodes[i].ToDynamicLinqString(context));
+                if (nodes[i] is GroupNode groupNode)
+                {
+                    bool requiresParens = !groupNode.HasParens
+                        && joinOperator == GroupOperator.And
+                        && groupNode.GetOperator(context) == GroupOperator.Or
+                        && !HasRequiredClause(groupNode)
+                        && !HasProhibitedClause(groupNode);
+
+                    if (requiresParens)
+                        builder.Append("(");
+
+                    builder.Append(groupNode.ToDynamicLinqString(context));
+
+                    if (requiresParens)
+                        builder.Append(")");
+                }
+                else
+                {
+                    builder.Append(nodes[i].ToDynamicLinqString(context));
+                }
             }
         }
     }

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -167,24 +167,30 @@ public static class SqlNodeExtensions
         if (String.IsNullOrEmpty(node.Field))
             context.AddValidationError("Field is required for missing node queries.");
 
-        if (!String.IsNullOrEmpty(node.Prefix) && !node.IsRequired())
-            context.AddValidationError("Prefix is not supported for missing node queries.");
-
         // support overriding the generated query
         if (node.TryGetQuery(out string? query))
-            return query;
+            return node.IsExcluded() ? $"!({query})" : query;
 
         var field = GetFieldInfo(context.Fields, node.Field);
         var (fieldPrefix, fieldSuffix) = field.GetFieldPrefixAndSuffix();
 
         var builder = new StringBuilder();
+        bool isExcluded = node.IsExcluded();
+        bool negateExpression = !isExcluded && !String.IsNullOrEmpty(fieldSuffix);
+
+        if (negateExpression)
+            builder.Append("!(");
+
         builder.Append(fieldPrefix);
         builder.Append(field.Name);
-        if (!node.IsNegated.HasValue || !node.IsNegated.Value)
-            builder.Append(" == null");
-        else
+        if (isExcluded || negateExpression)
             builder.Append(" != null");
+        else
+            builder.Append(" == null");
         builder.Append(fieldSuffix);
+
+        if (negateExpression)
+            builder.Append(")");
 
         return builder.ToString();
     }

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -24,11 +24,23 @@ public static class SqlNodeExtensions
 
         var builder = new StringBuilder();
         var op = node.Operator != GroupOperator.Default ? node.Operator : defaultOperator;
+        var operands = GetOperands(node, op, context);
+        bool hasRequiredOperands = op == GroupOperator.Or
+            && operands.Any(n => n is IFieldQueryNode fieldNode && fieldNode.IsRequired());
+
+        if (hasRequiredOperands)
+        {
+            operands = operands
+                .Where(n => n is IFieldQueryNode fieldNode && (fieldNode.IsRequired() || fieldNode.IsExcluded()))
+                .ToList();
+            op = GroupOperator.And;
+        }
 
         if (node.IsNegated.HasValue && node.IsNegated.Value)
             builder.Append("NOT ");
 
-        builder.Append(node.Prefix);
+        if (!node.IsRequired())
+            builder.Append(node.Prefix);
 
         if (!String.IsNullOrEmpty(node.Field))
             builder.Append(node.Field).Append(':');
@@ -36,19 +48,15 @@ public static class SqlNodeExtensions
         if (node.HasParens)
             builder.Append("(");
 
-        if (node.Left != null)
-            builder.Append(node.Left is GroupNode groupNode ? groupNode.ToDynamicLinqString(context) : node.Left.ToDynamicLinqString(context));
-
-        if (node.Left != null && node.Right != null)
+        for (int i = 0; i < operands.Count; i++)
         {
-            if (op == GroupOperator.Or || (op == GroupOperator.Default && defaultOperator == GroupOperator.Or))
-                builder.Append(" OR ");
-            else if (node.Right != null)
-                builder.Append(" AND ");
-        }
+            if (i > 0)
+                builder.Append(op == GroupOperator.Or ? " OR " : " AND ");
 
-        if (node.Right != null)
-            builder.Append(node.Right is GroupNode groupNode ? groupNode.ToDynamicLinqString(context) : node.Right.ToDynamicLinqString(context));
+            builder.Append(operands[i] is GroupNode groupNode
+                ? groupNode.ToDynamicLinqString(context)
+                : operands[i].ToDynamicLinqString(context));
+        }
 
         if (node.HasParens)
             builder.Append(")");
@@ -92,8 +100,8 @@ public static class SqlNodeExtensions
         if (String.IsNullOrEmpty(node.Field))
             context.AddValidationError("Field is required for missing node queries.");
 
-        if (!String.IsNullOrEmpty(node.Prefix))
-            context.AddValidationError("Prefix is not supported for term range queries.");
+        if (!String.IsNullOrEmpty(node.Prefix) && !node.IsRequired())
+            context.AddValidationError("Prefix is not supported for missing node queries.");
 
         // support overriding the generated query
         if (node.TryGetQuery(out string? query))
@@ -420,6 +428,37 @@ public static class SqlNodeExtensions
             fieldPrefix = fieldPrefix.Substring(0, fieldPrefix.Length - navigationPrefix.Length);
 
         return (fieldPrefix, navigationPrefix);
+    }
+
+    private static List<IQueryNode> GetOperands(GroupNode node, GroupOperator op, ISqlQueryVisitorContext context)
+    {
+        var operands = new List<IQueryNode>();
+        AddOperand(node.Left);
+        AddOperand(node.Right);
+        return operands;
+
+        void AddOperand(IQueryNode? operand)
+        {
+            if (operand is null)
+                return;
+
+            if (operand is GroupNode groupNode
+                && !groupNode.HasParens
+                && String.IsNullOrEmpty(groupNode.Field)
+                && String.IsNullOrEmpty(groupNode.Prefix)
+                && groupNode.IsNegated is not true
+                && String.IsNullOrEmpty(groupNode.Boost)
+                && String.IsNullOrEmpty(groupNode.Proximity)
+                && groupNode.GetQuery() is null
+                && groupNode.GetOperator(context) == op)
+            {
+                AddOperand(groupNode.Left);
+                AddOperand(groupNode.Right);
+                return;
+            }
+
+            operands.Add(operand);
+        }
     }
 
     private static void AppendField(StringBuilder builder, EntityFieldInfo field, string term, ISqlQueryVisitorContext context)

--- a/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
+++ b/src/Foundatio.Parsers.SqlQueries/Extensions/SqlNodeExtensions.cs
@@ -26,12 +26,12 @@ public static class SqlNodeExtensions
         var op = node.Operator != GroupOperator.Default ? node.Operator : defaultOperator;
         var operands = GetOperands(node, op, context);
         bool hasRequiredOperands = op == GroupOperator.Or
-            && operands.Any(n => n is IFieldQueryNode fieldNode && fieldNode.IsRequired());
+            && operands.Any(HasRequiredClause);
 
         if (hasRequiredOperands)
         {
             operands = operands
-                .Where(n => n is IFieldQueryNode fieldNode && (fieldNode.IsRequired() || fieldNode.IsExcluded()))
+                .Where(n => HasRequiredClause(n) || n.IsExcluded())
                 .ToList();
             op = GroupOperator.And;
         }
@@ -86,7 +86,7 @@ public static class SqlNodeExtensions
 
         builder.Append(fieldPrefix);
         builder.Append(field.Name);
-        if (!node.IsNegated.HasValue || !node.IsNegated.Value)
+        if (!node.IsExcluded())
             builder.Append(" != null");
         else
             builder.Append(" == null");
@@ -428,6 +428,16 @@ public static class SqlNodeExtensions
             fieldPrefix = fieldPrefix.Substring(0, fieldPrefix.Length - navigationPrefix.Length);
 
         return (fieldPrefix, navigationPrefix);
+    }
+
+    private static bool HasRequiredClause(IQueryNode node)
+    {
+        if (node is IFieldQueryNode fieldNode && fieldNode.IsRequired())
+            return true;
+
+        return node is GroupNode { HasParens: false } groupNode
+            && ((groupNode.Left is not null && HasRequiredClause(groupNode.Left))
+                || (groupNode.Right is not null && HasRequiredClause(groupNode.Right)));
     }
 
     private static List<IQueryNode> GetOperands(GroupNode node, GroupOperator op, ISqlQueryVisitorContext context)

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -59,6 +59,46 @@ public class SqlQueryParserTests : TestWithLoggingBase
         return ParseAndValidateQuery(query, expected, true);
     }
 
+    [Theory]
+    [InlineData("NOT title:Open")]
+    [InlineData("!title:Open")]
+    [InlineData("-title:Open")]
+    public async Task ToDynamicLinqAsync_WithNegatedFieldComparison_ParenthesizesComparison(string query)
+    {
+        var parser = new SqlQueryParser();
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                new EntityFieldInfo { Name = "Title", FullName = "title" }
+            ]
+        };
+
+        string result = await parser.ToDynamicLinqAsync(query, context);
+
+        Assert.Equal("""!(Title = "Open")""", result);
+    }
+
+    [Theory]
+    [InlineData("NOT salary:>100")]
+    [InlineData("!salary:>100")]
+    [InlineData("-salary:>100")]
+    public async Task ToDynamicLinqAsync_WithNegatedOneSidedRange_ParenthesizesComparison(string query)
+    {
+        var parser = new SqlQueryParser();
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                new EntityFieldInfo { Name = "Salary", FullName = "salary", IsNumber = true }
+            ]
+        };
+
+        string result = await parser.ToDynamicLinqAsync(query, context);
+
+        Assert.Equal("!(Salary > 100)", result);
+    }
+
     [Fact]
     public async Task CanSearchDefaultFields()
     {

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -138,6 +138,40 @@ public class SqlQueryParserTests : TestWithLoggingBase
     }
 
     [Theory]
+    [InlineData("_missing_:department", "Department == null")]
+    [InlineData("NOT _missing_:department", "Department != null")]
+    [InlineData("!_missing_:department", "Department != null")]
+    [InlineData("-_missing_:department", "Department != null")]
+    [InlineData("_missing_:Companies.Name", "!(Companies.Any(Name != null))")]
+    [InlineData("NOT _missing_:Companies.Name", "Companies.Any(Name != null)")]
+    [InlineData("!_missing_:Companies.Name", "Companies.Any(Name != null)")]
+    [InlineData("-_missing_:Companies.Name", "Companies.Any(Name != null)")]
+    public async Task ToDynamicLinqAsync_WithMissingClause_AppliesExclusionToWholeClause(string query, string expected)
+    {
+        var parser = new SqlQueryParser();
+        var companiesField = new EntityFieldInfo
+        {
+            Name = "Companies",
+            FullName = "Companies",
+            IsCollection = true,
+            IsNavigation = true
+        };
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                new EntityFieldInfo { Name = "Department", FullName = "department" },
+                companiesField,
+                new EntityFieldInfo { Name = "Name", FullName = "Companies.Name", Parent = companiesField }
+            ]
+        };
+
+        string result = await parser.ToDynamicLinqAsync(query, context);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
     [InlineData("title:Open OR -department:Closed", "Title = \"Open\" AND !(Department = \"Closed\")")]
     [InlineData("title:Open OR status:Pending OR -department:Closed", "(Title = \"Open\" OR Status = \"Pending\") AND !(Department = \"Closed\")")]
     [InlineData("-status:Inactive OR -department:Closed", "!(Status = \"Inactive\") AND !(Department = \"Closed\")")]

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -80,6 +80,88 @@ public class SqlQueryParserTests : TestWithLoggingBase
     }
 
     [Theory]
+    [InlineData("+status:Active", "Status = \"Active\"")]
+    [InlineData("title:Open AND +status:Active", "Title = \"Open\" AND Status = \"Active\"")]
+    [InlineData("title:Open OR +status:Active", "Status = \"Active\"")]
+    [InlineData("title:Open OR status:Pending OR +department:Support", "Department = \"Support\"")]
+    [InlineData("+status:Active OR +department:Support", "Status = \"Active\" AND Department = \"Support\"")]
+    [InlineData("title:Open OR +status:Active OR +department:Support", "Status = \"Active\" AND Department = \"Support\"")]
+    [InlineData("title:Open OR +status:Active OR -department:Closed", "Status = \"Active\" AND !(Department = \"Closed\")")]
+    [InlineData("+status:Active AND -department:Closed", "Status = \"Active\" AND !(Department = \"Closed\")")]
+    [InlineData("title:Open OR +salary:>100", "Salary > 100")]
+    [InlineData("title:Open OR +_exists_:department", "Department != null")]
+    [InlineData("title:Open OR +_missing_:department", "Department == null")]
+    [InlineData("title:Open OR +(status:Active OR department:Support)", "(Status = \"Active\" OR Department = \"Support\")")]
+    [InlineData("title:Open AND (status:Pending OR +department:Support)", "Title = \"Open\" AND (Department = \"Support\")")]
+    public async Task ToDynamicLinqAsync_WithRequiredClause_RequiresClause(string query, string expected)
+    {
+        var parser = new SqlQueryParser();
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                new EntityFieldInfo { Name = "Title", FullName = "title" },
+                new EntityFieldInfo { Name = "Status", FullName = "status" },
+                new EntityFieldInfo { Name = "Department", FullName = "department" },
+                new EntityFieldInfo { Name = "Salary", FullName = "salary", IsNumber = true }
+            ]
+        };
+
+        string result = await parser.ToDynamicLinqAsync(query, context);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task ToDynamicLinqAsync_WithRequiredDefaultFieldClause_RequiresClause()
+    {
+        var parser = new SqlQueryParser();
+        parser.Configuration.SetDefaultFields(["Title"], SqlSearchOperator.Equals);
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                new EntityFieldInfo { Name = "Title", FullName = "Title" },
+                new EntityFieldInfo { Name = "Status", FullName = "status" }
+            ]
+        };
+
+        string result = await parser.ToDynamicLinqAsync("status:Pending OR +Open", context);
+
+        Assert.Equal("""(Title in ("Open"))""", result);
+    }
+
+    [Fact]
+    public async Task ToDynamicLinqAsync_WithRequiredClause_FiltersByRequiredClause()
+    {
+        var parser = new SqlQueryParser();
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                new EntityFieldInfo { Name = "Title", FullName = "title" },
+                new EntityFieldInfo { Name = "Salary", FullName = "salary", IsNumber = true }
+            ]
+        };
+
+        string query = await parser.ToDynamicLinqAsync("title:Open OR +salary:>100", context);
+        AssertRequiredSalaryFilter(parser, query);
+    }
+
+    private static void AssertRequiredSalaryFilter(SqlQueryParser parser, string query)
+    {
+        var results = new[]
+        {
+            new Employee { Title = "Open", Salary = 50 },
+            new Employee { Title = "Closed", Salary = 150 },
+            new Employee { Title = "Open", Salary = 200 }
+        }.AsQueryable().Where(parser.ParsingConfig, query).ToList();
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, employee => Assert.True(employee.Salary > 100));
+    }
+
+    [Theory]
     [InlineData("NOT salary:>100")]
     [InlineData("!salary:>100")]
     [InlineData("-salary:>100")]

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -80,23 +80,67 @@ public class SqlQueryParserTests : TestWithLoggingBase
     }
 
     [Theory]
-    [InlineData("NOT _exists_:department")]
-    [InlineData("!_exists_:department")]
-    [InlineData("-_exists_:department")]
-    public async Task ToDynamicLinqAsync_WithNegatedExistsClause_NegatesClause(string query)
+    [InlineData("NOT _exists_:department", "Department == null")]
+    [InlineData("!_exists_:department", "Department == null")]
+    [InlineData("-_exists_:department", "Department == null")]
+    [InlineData("NOT _exists_:Companies.Name", "!(Companies.Any(Name != null))")]
+    [InlineData("!_exists_:Companies.Name", "!(Companies.Any(Name != null))")]
+    [InlineData("-_exists_:Companies.Name", "!(Companies.Any(Name != null))")]
+    public async Task ToDynamicLinqAsync_WithNegatedExistsClause_NegatesClause(string query, string expected)
     {
         var parser = new SqlQueryParser();
+        var companiesField = new EntityFieldInfo
+        {
+            Name = "Companies",
+            FullName = "Companies",
+            IsCollection = true,
+            IsNavigation = true
+        };
         var context = new SqlQueryVisitorContext
         {
             Fields =
             [
-                new EntityFieldInfo { Name = "Department", FullName = "department" }
+                new EntityFieldInfo { Name = "Department", FullName = "department" },
+                companiesField,
+                new EntityFieldInfo { Name = "Name", FullName = "Companies.Name", Parent = companiesField }
             ]
         };
 
         string result = await parser.ToDynamicLinqAsync(query, context);
 
-        Assert.Equal("Department == null", result);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("title:Open OR -department:Closed", "Title = \"Open\" AND !(Department = \"Closed\")")]
+    [InlineData("title:Open OR status:Pending OR -department:Closed", "(Title = \"Open\" OR Status = \"Pending\") AND !(Department = \"Closed\")")]
+    [InlineData("-status:Inactive OR -department:Closed", "!(Status = \"Inactive\") AND !(Department = \"Closed\")")]
+    [InlineData("title:Open OR -_exists_:Companies.Name", "Title = \"Open\" AND !(Companies.Any(Name != null))")]
+    public async Task ToDynamicLinqAsync_WithProhibitedOrClause_RequiresOptionalAndProhibitedClauses(string query, string expected)
+    {
+        var parser = new SqlQueryParser();
+        var companiesField = new EntityFieldInfo
+        {
+            Name = "Companies",
+            FullName = "Companies",
+            IsCollection = true,
+            IsNavigation = true
+        };
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                new EntityFieldInfo { Name = "Title", FullName = "title" },
+                new EntityFieldInfo { Name = "Status", FullName = "status" },
+                new EntityFieldInfo { Name = "Department", FullName = "department" },
+                companiesField,
+                new EntityFieldInfo { Name = "Name", FullName = "Companies.Name", Parent = companiesField }
+            ]
+        };
+
+        string result = await parser.ToDynamicLinqAsync(query, context);
+
+        Assert.Equal(expected, result);
     }
 
     [Theory]
@@ -183,6 +227,73 @@ public class SqlQueryParserTests : TestWithLoggingBase
 
         Assert.Equal(2, results.Count);
         Assert.All(results, employee => Assert.True(employee.Salary > 100));
+    }
+
+    [Fact]
+    public async Task ToDynamicLinqAsync_WithProhibitedOrClause_FiltersByOptionalAndProhibitedClauses()
+    {
+        var parser = new SqlQueryParser();
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                new EntityFieldInfo { Name = "Title", FullName = "title" },
+                new EntityFieldInfo { Name = "Department", FullName = "department" }
+            ]
+        };
+
+        string query = await parser.ToDynamicLinqAsync("title:Open OR -department:Closed", context);
+        AssertProhibitedClauseFilter(parser, query);
+    }
+
+    private static void AssertProhibitedClauseFilter(SqlQueryParser parser, string query)
+    {
+        var results = new[]
+        {
+            new { Title = "Open", Department = "Closed" },
+            new { Title = "Open", Department = "Support" },
+            new { Title = "Pending", Department = "Support" }
+        }.AsQueryable().Where(parser.ParsingConfig, query).ToList();
+
+        var result = Assert.Single(results);
+        Assert.Equal("Open", result.Title);
+        Assert.Equal("Support", result.Department);
+    }
+
+    [Fact]
+    public async Task ToDynamicLinqAsync_WithNegatedCollectionExists_FiltersWholeCollection()
+    {
+        var parser = new SqlQueryParser();
+        var companiesField = new EntityFieldInfo
+        {
+            Name = "Companies",
+            FullName = "Companies",
+            IsCollection = true,
+            IsNavigation = true
+        };
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                companiesField,
+                new EntityFieldInfo { Name = "Name", FullName = "Companies.Name", Parent = companiesField }
+            ]
+        };
+
+        string query = await parser.ToDynamicLinqAsync("-_exists_:Companies.Name", context);
+        AssertNegatedCollectionExistsFilter(parser, query);
+    }
+
+    private static void AssertNegatedCollectionExistsFilter(SqlQueryParser parser, string query)
+    {
+        var results = new[]
+        {
+            new { Id = 1, Companies = Array.Empty<Company>() },
+            new { Id = 2, Companies = new[] { new Company { Name = null! } } },
+            new { Id = 3, Companies = new[] { new Company { Name = null! }, new Company { Name = "Acme" } } }
+        }.AsQueryable().Where(parser.ParsingConfig, query).Select(record => record.Id).ToList();
+
+        Assert.Equal([1, 2], results);
     }
 
     [Theory]

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -80,13 +80,37 @@ public class SqlQueryParserTests : TestWithLoggingBase
     }
 
     [Theory]
+    [InlineData("NOT _exists_:department")]
+    [InlineData("!_exists_:department")]
+    [InlineData("-_exists_:department")]
+    public async Task ToDynamicLinqAsync_WithNegatedExistsClause_NegatesClause(string query)
+    {
+        var parser = new SqlQueryParser();
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                new EntityFieldInfo { Name = "Department", FullName = "department" }
+            ]
+        };
+
+        string result = await parser.ToDynamicLinqAsync(query, context);
+
+        Assert.Equal("Department == null", result);
+    }
+
+    [Theory]
     [InlineData("+status:Active", "Status = \"Active\"")]
     [InlineData("title:Open AND +status:Active", "Title = \"Open\" AND Status = \"Active\"")]
     [InlineData("title:Open OR +status:Active", "Status = \"Active\"")]
+    [InlineData("title:Open OR +status:Active AND department:Support", "Status = \"Active\" AND Department = \"Support\"")]
+    [InlineData("title:Open AND +status:Active OR department:Support", "Title = \"Open\" AND Status = \"Active\"")]
+    [InlineData("title:Open OR (+status:Active AND department:Support)", "Title = \"Open\" OR (Status = \"Active\" AND Department = \"Support\")")]
     [InlineData("title:Open OR status:Pending OR +department:Support", "Department = \"Support\"")]
     [InlineData("+status:Active OR +department:Support", "Status = \"Active\" AND Department = \"Support\"")]
     [InlineData("title:Open OR +status:Active OR +department:Support", "Status = \"Active\" AND Department = \"Support\"")]
     [InlineData("title:Open OR +status:Active OR -department:Closed", "Status = \"Active\" AND !(Department = \"Closed\")")]
+    [InlineData("title:Open OR +status:Active OR -_exists_:department", "Status = \"Active\" AND Department == null")]
     [InlineData("+status:Active AND -department:Closed", "Status = \"Active\" AND !(Department = \"Closed\")")]
     [InlineData("title:Open OR +salary:>100", "Salary > 100")]
     [InlineData("title:Open OR +_exists_:department", "Department != null")]

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -172,15 +172,17 @@ public class SqlQueryParserTests : TestWithLoggingBase
     }
 
     [Theory]
-    [InlineData("title:Open OR -department:Closed", "Title = \"Open\" AND !(Department = \"Closed\")")]
-    [InlineData("title:Open OR status:Pending OR -department:Closed", "(Title = \"Open\" OR Status = \"Pending\") AND !(Department = \"Closed\")")]
-    [InlineData("-status:Inactive OR -department:Closed", "!(Status = \"Inactive\") AND !(Department = \"Closed\")")]
-    [InlineData("title:Open OR -_exists_:Companies.Name", "Title = \"Open\" AND !(Companies.Any(Name != null))")]
-    [InlineData("title:Open OR -department:Closed AND status:Pending", "!(Department = \"Closed\") AND Status = \"Pending\"")]
-    [InlineData("title:Open OR status:Pending AND -department:Closed", "Status = \"Pending\" AND !(Department = \"Closed\")")]
-    [InlineData("title:A OR -status:B AND department:C OR team:D", "!(Status = \"B\") AND (Department = \"C\" OR Team = \"D\")")]
+    [InlineData("title:Open OR NOT department:Closed", "Title = \"Open\" OR !(Department = \"Closed\")")]
+    [InlineData("title:Open OR !department:Closed", "Title = \"Open\" OR !(Department = \"Closed\")")]
+    [InlineData("title:Open OR -department:Closed", "Title = \"Open\" OR !(Department = \"Closed\")")]
+    [InlineData("title:Open OR status:Pending OR -department:Closed", "Title = \"Open\" OR Status = \"Pending\" OR !(Department = \"Closed\")")]
+    [InlineData("-status:Inactive OR -department:Closed", "!(Status = \"Inactive\") OR !(Department = \"Closed\")")]
+    [InlineData("title:Open OR -_exists_:Companies.Name", "Title = \"Open\" OR !(Companies.Any(Name != null))")]
+    [InlineData("title:Open OR -department:Closed AND status:Pending", "Title = \"Open\" OR !(Department = \"Closed\") AND Status = \"Pending\"")]
+    [InlineData("title:Open OR status:Pending AND -department:Closed", "Title = \"Open\" OR Status = \"Pending\" AND !(Department = \"Closed\")")]
+    [InlineData("title:A OR -status:B AND department:C OR team:D", "Title = \"A\" OR !(Status = \"B\") AND (Department = \"C\" OR Team = \"D\")")]
     [InlineData("title:Open OR (-department:Closed AND status:Pending)", "Title = \"Open\" OR (!(Department = \"Closed\") AND Status = \"Pending\")")]
-    public async Task ToDynamicLinqAsync_WithProhibitedOrClause_RequiresOptionalAndProhibitedClauses(string query, string expected)
+    public async Task ToDynamicLinqAsync_WithProhibitedOrClause_PreservesOrSemantics(string query, string expected)
     {
         var parser = new SqlQueryParser();
         var companiesField = new EntityFieldInfo
@@ -297,7 +299,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
     }
 
     [Fact]
-    public async Task ToDynamicLinqAsync_WithProhibitedOrClause_FiltersByOptionalAndProhibitedClauses()
+    public async Task ToDynamicLinqAsync_WithProhibitedOrClause_FiltersByEitherClause()
     {
         var parser = new SqlQueryParser();
         var context = new SqlQueryVisitorContext
@@ -310,10 +312,10 @@ public class SqlQueryParserTests : TestWithLoggingBase
         };
 
         string query = await parser.ToDynamicLinqAsync("title:Open OR -department:Closed", context);
-        AssertProhibitedClauseFilter(parser, query);
+        AssertProhibitedOrFilter(parser, query);
     }
 
-    private static void AssertProhibitedClauseFilter(SqlQueryParser parser, string query)
+    private static void AssertProhibitedOrFilter(SqlQueryParser parser, string query)
     {
         var results = new[]
         {
@@ -322,9 +324,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
             new { Title = "Pending", Department = "Support" }
         }.AsQueryable().Where(parser.ParsingConfig, query).ToList();
 
-        var result = Assert.Single(results);
-        Assert.Equal("Open", result.Title);
-        Assert.Equal("Support", result.Department);
+        Assert.Equal(3, results.Count);
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -116,6 +116,9 @@ public class SqlQueryParserTests : TestWithLoggingBase
     [InlineData("title:Open OR status:Pending OR -department:Closed", "(Title = \"Open\" OR Status = \"Pending\") AND !(Department = \"Closed\")")]
     [InlineData("-status:Inactive OR -department:Closed", "!(Status = \"Inactive\") AND !(Department = \"Closed\")")]
     [InlineData("title:Open OR -_exists_:Companies.Name", "Title = \"Open\" AND !(Companies.Any(Name != null))")]
+    [InlineData("title:Open OR -department:Closed AND status:Pending", "!(Department = \"Closed\") AND Status = \"Pending\"")]
+    [InlineData("title:Open OR status:Pending AND -department:Closed", "Status = \"Pending\" AND !(Department = \"Closed\")")]
+    [InlineData("title:Open OR (-department:Closed AND status:Pending)", "Title = \"Open\" OR (!(Department = \"Closed\") AND Status = \"Pending\")")]
     public async Task ToDynamicLinqAsync_WithProhibitedOrClause_RequiresOptionalAndProhibitedClauses(string query, string expected)
     {
         var parser = new SqlQueryParser();

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -118,6 +118,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
     [InlineData("title:Open OR -_exists_:Companies.Name", "Title = \"Open\" AND !(Companies.Any(Name != null))")]
     [InlineData("title:Open OR -department:Closed AND status:Pending", "!(Department = \"Closed\") AND Status = \"Pending\"")]
     [InlineData("title:Open OR status:Pending AND -department:Closed", "Status = \"Pending\" AND !(Department = \"Closed\")")]
+    [InlineData("title:A OR -status:B AND department:C OR team:D", "!(Status = \"B\") AND (Department = \"C\" OR Team = \"D\")")]
     [InlineData("title:Open OR (-department:Closed AND status:Pending)", "Title = \"Open\" OR (!(Department = \"Closed\") AND Status = \"Pending\")")]
     public async Task ToDynamicLinqAsync_WithProhibitedOrClause_RequiresOptionalAndProhibitedClauses(string query, string expected)
     {
@@ -136,6 +137,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
                 new EntityFieldInfo { Name = "Title", FullName = "title" },
                 new EntityFieldInfo { Name = "Status", FullName = "status" },
                 new EntityFieldInfo { Name = "Department", FullName = "department" },
+                new EntityFieldInfo { Name = "Team", FullName = "team" },
                 companiesField,
                 new EntityFieldInfo { Name = "Name", FullName = "Companies.Name", Parent = companiesField }
             ]
@@ -151,6 +153,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
     [InlineData("title:Open AND +status:Active", "Title = \"Open\" AND Status = \"Active\"")]
     [InlineData("title:Open OR +status:Active", "Status = \"Active\"")]
     [InlineData("title:Open OR +status:Active AND department:Support", "Status = \"Active\" AND Department = \"Support\"")]
+    [InlineData("title:A OR +status:B AND department:C OR team:D", "Status = \"B\" AND (Department = \"C\" OR Team = \"D\")")]
     [InlineData("title:Open AND +status:Active OR department:Support", "Title = \"Open\" AND Status = \"Active\"")]
     [InlineData("title:Open OR (+status:Active AND department:Support)", "Title = \"Open\" OR (Status = \"Active\" AND Department = \"Support\")")]
     [InlineData("title:Open OR status:Pending OR +department:Support", "Department = \"Support\"")]
@@ -174,6 +177,7 @@ public class SqlQueryParserTests : TestWithLoggingBase
                 new EntityFieldInfo { Name = "Title", FullName = "title" },
                 new EntityFieldInfo { Name = "Status", FullName = "status" },
                 new EntityFieldInfo { Name = "Department", FullName = "department" },
+                new EntityFieldInfo { Name = "Team", FullName = "team" },
                 new EntityFieldInfo { Name = "Salary", FullName = "salary", IsNumber = true }
             ]
         };

--- a/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.SqlQueries.Tests/SqlQueryParserTests.cs
@@ -80,6 +80,32 @@ public class SqlQueryParserTests : TestWithLoggingBase
     }
 
     [Theory]
+    [InlineData("NOT datadefinitions.key:age")]
+    [InlineData("!datadefinitions.key:age")]
+    [InlineData("-datadefinitions.key:age")]
+    public async Task ToDynamicLinqAsync_WithNegatedVisitorTermQuery_NegatesOverride(string query)
+    {
+        var parser = new SqlQueryParser();
+        parser.Configuration.AddQueryVisitor(new DynamicFieldVisitor());
+        var context = new SqlQueryVisitorContext
+        {
+            Fields =
+            [
+                new EntityFieldInfo
+                {
+                    Name = "CustomField",
+                    FullName = "datadefinitions.key",
+                    Data = { { "DataDefinitionId", 1 } }
+                }
+            ]
+        };
+
+        string result = await parser.ToDynamicLinqAsync(query, context);
+
+        Assert.Equal("""!(DataValues.Any(DataDefinitionId = 1 AND StringValue = "age"))""", result);
+    }
+
+    [Theory]
     [InlineData("NOT _exists_:department", "Department == null")]
     [InlineData("!_exists_:department", "Department == null")]
     [InlineData("-_exists_:department", "Department == null")]


### PR DESCRIPTION
Fixes #254

## Summary

- generate negation around the complete Dynamic LINQ field predicate
- recognize `NOT`, `!`, and `-` consistently through the existing exclusion semantics, including exists/missing clauses and visitor-provided term predicates
- make collection-backed `_missing_` the exact inverse of `_exists_`
- implement Lucene `+` required-clause semantics for SQL generation
- find required and prohibited clauses across mixed unparenthesized operators while preserving parenthesized boundaries
- keep prohibited operands mandatory when paired with required clauses, while preserving `OR NOT` / `OR !` / `OR -` branch semantics in parity with the Elastic backend
- preserve nested boolean grouping when retained mixed-operator operands are emitted as Dynamic LINQ
- add regression coverage for negated scalar/range/exists/missing/custom comparisons; required terms, ranges, exists/missing queries, default fields, groups, and mixed/chained clauses; prohibited OR branches; collection null semantics; mixed-operator precedence; and executable filtering

## Root cause

SQL generation checked only `IsNegated`, so the `!` and `-` prefix forms stored in `Prefix` were ignored. For `NOT`, the generator prepended a bare `!` directly to the field operand, causing Dynamic LINQ to parse expressions such as `!Title = "Open"` as `(!Title) = "Open"`. Visitor-provided term predicates also returned before exclusion handling, leaving custom dynamic-field predicates positive. Missing clauses separately rejected `!` and `-` and checked only `IsNegated`.

The SQL generator also emitted `+` literally instead of interpreting it as a required Lucene clause. Required and prohibited clause discovery initially considered only direct or same-operator OR operands, missing descendants inside unparenthesized mixed-operator groups. Required clauses and their sibling exclusions now remain mandatory across transparent AST groups, while explicit parenthesized groups preserve their own Boolean boundary. In OR groups without a required clause, negated operands remain OR branches, matching the repository's Elastic query behavior. When a retained mixed operand contains a nested OR beneath AND, the generator adds the parentheses required to preserve that boundary in Dynamic LINQ.

Collection null checks must negate the complete positive `Any(... != null)` predicate. Flipping only the leaf comparison incorrectly changes empty and mixed null/non-null collection behavior. Exists and missing now use complementary whole-expression semantics.

## Impact

Negated filters now produce valid Dynamic LINQ such as `!(Title = "Open")` and `!(Salary > 100)`, including complete visitor-provided predicates such as `!(DataValues.Any(...))`. Required queries such as `title:Open OR +salary:>100` now generate `Salary > 100`, with sibling prohibited clauses retained as mandatory exclusions. Queries such as `title:Open OR -department:Closed` preserve their two OR branches consistently across SQL and Elastic. Scalar and collection-backed exists/missing queries honor all exclusion spellings with correct inverse predicates.

## Validation

- `dotnet build Foundatio.Parsers.slnx -p:ReferenceFoundatioSource=false` — succeeded with 0 warnings
- affected SQL parser tests — 62 passed
- full Lucene query parser suite — 270 passed
- formatter verification for the two changed files — passed
- GitHub Actions — both build jobs and CLA passed on the latest revision
- full local integration suites require SQL Server and Elasticsearch services; GitHub Actions exercises those suites