### PR TITLE
Fix NOT and prefix operators being dropped on ranges and field groups, clarify negation vs prefix

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -38,7 +38,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/docs/guide/nested-queries.md
+++ b/docs/guide/nested-queries.md
@@ -237,7 +237,7 @@ graph TD
 
 Key observations about this AST:
 - **GroupNode A** (`Field=@category`, `HasParens=true`, `Operator=Or`) is the outer scoped group. The PEG grammar's `paren_exp` rule sets `HasParens=true` on the `node` result, and then the `field_exp` rule sets `Field` and `Prefix` from the fieldname on that same node. The OR operator also lives on this node since the `node` grammar rule constructs a GroupNode with `Left`, `Operator`, and `Right`.
-- **GroupNode B** (`Field=@category`, `Prefix=-`, `HasParens=true`) is the inner negated field group. It was similarly produced by `paren_exp` setting `HasParens=true`, followed by `field_exp` setting `Field=@category` and `Prefix=-`.
+- **GroupNode B** (`Field=@category`, `Prefix=-`, `HasParens=true`) is the inner negated field group. It was similarly produced by `paren_exp` setting `HasParens=true`, followed by `field_exp` setting `Field=@category` and `Prefix=-`. Note that the `-` operator lands in `Prefix`, not `IsNegated`, so use `IsExcluded()` to detect the negation -- see [Negation and Prefix Operators](./visitors#negation-and-prefix-operators).
 - **TermNode `value1`** has `Field = null`. When visitors call `GetDefaultFields`, it walks up to GroupNode B (which has parens and a non-empty Field) and resolves to `"@category"`.
 - **TermNode `value2`** has `Field = null`. When visitors call `GetDefaultFields`, it walks up to GroupNode A (which has parens and a non-empty Field) and resolves to `"@category"`.
 

--- a/docs/guide/query-syntax.md
+++ b/docs/guide/query-syntax.md
@@ -199,7 +199,7 @@ result = parser.Parse("-deleted:true");
 result = parser.Parse("+status:active -deleted:true type:user");
 ```
 
-`-`, `!`, and `NOT` all negate a clause, but the parser stores them on different node properties: `NOT` sets `IsNegated` while `-` and `!` set `Prefix`. Use the `IsExcluded()` extension method rather than checking either property directly. See [Negation and Prefix Operators](./visitors#negation-and-prefix-operators).
+`-`, `!`, and `NOT` all negate a clause, but the parser stores them on different node properties: `NOT` sets `IsNegated` while `-` and `!` set `Prefix`. In query contexts, use the `IsExcluded()` extension method rather than checking either property directly. See [Negation and Prefix Operators](./visitors#negation-and-prefix-operators).
 
 ## Grouping
 

--- a/docs/guide/query-syntax.md
+++ b/docs/guide/query-syntax.md
@@ -201,6 +201,8 @@ result = parser.Parse("+status:active -deleted:true type:user");
 
 `-`, `!`, and `NOT` all negate a clause, but the parser stores them on different node properties: `NOT` sets `IsNegated` while `-` and `!` set `Prefix`. In query contexts, use the `IsExcluded()` extension method rather than checking either property directly. See [Negation and Prefix Operators](./visitors#negation-and-prefix-operators).
 
+These operators may be written either before the field name or immediately after the colon, and both forms are equivalent: `-field:value` and `field:-value` parse the same, as do `-field:(value)` and `field:-(value)`. The one exception is ranges, where only the leading position is accepted -- `-field:[1 TO 2]` and `NOT field:[1 TO 2]` work, while `field:-[1 TO 2]` and `field:NOT [1 TO 2]` throw a `FormatException`.
+
 ## Grouping
 
 Use parentheses to group clauses and control precedence:

--- a/docs/guide/query-syntax.md
+++ b/docs/guide/query-syntax.md
@@ -186,6 +186,7 @@ Use prefix operators for required/excluded terms:
 |--------|-------------|
 | `+` | Term must be present (required) |
 | `-` | Term must not be present (excluded) |
+| `!` | Term must not be present (excluded) |
 
 ```csharp
 // Required term
@@ -197,6 +198,8 @@ result = parser.Parse("-deleted:true");
 // Combined
 result = parser.Parse("+status:active -deleted:true type:user");
 ```
+
+`-`, `!`, and `NOT` all negate a clause, but the parser stores them on different node properties: `NOT` sets `IsNegated` while `-` and `!` set `Prefix`. Use the `IsExcluded()` extension method rather than checking either property directly. See [Negation and Prefix Operators](./visitors#negation-and-prefix-operators).
 
 ## Grouping
 

--- a/docs/guide/visitors.md
+++ b/docs/guide/visitors.md
@@ -344,19 +344,19 @@ Negation is stored in two different places depending on the syntax used:
 |-------|-------------|----------|
 | `NOT field:value` | `true` | `null` |
 | `NOT [1 TO 2]` | `true` | `null` |
-| `-field:value` | not `true` | `"-"` |
-| `!field:value` | not `true` | `"!"` |
-| `+field:value` | not `true` | `"+"` |
+| `-field:value` | `null` | `"-"` |
+| `!field:value` | `null` | `"!"` |
+| `+field:value` | `null` | `"+"` |
 
-`IsNegated` is a `bool?` that is only ever set to `true` by the `NOT` keyword. When `NOT` is absent it is left as `null` or `false` depending on which grammar rule matched, so always compare against `true` rather than treating it as a plain boolean.
+`IsNegated` is a `bool?` that the parser sets to `true` only for the `NOT` keyword, leaving it `null` otherwise. Visitors that rewrite the tree (`InvertNegation`, `CleanupQueryVisitor`) may also set it, including to `false`, so compare against `true` rather than treating the value as a plain boolean.
 
 The split is intentional: keeping the operator that was actually written means `GenerateQueryVisitor` and `ToString()` round-trip the original query instead of rewriting `-value` into `NOT value`. As a result, `IsNegated` alone is never a complete negation check.
 
-Use the extension methods instead of inspecting the properties directly:
+In query contexts, use the extension methods instead of inspecting the properties directly:
 
 - `IsExcluded()` - node-local negation, covering `NOT`, `-`, and `!`
 - `IsRequired()` - the `+` prefix
-- `IsNodeOrGroupNegated()` - `IsExcluded()` plus negation on the nearest enclosing parenthesized group, and `false` when the node is required
+- `IsNodeOrGroupNegated()` - `IsExcluded()` plus negation on the nearest enclosing parenthesized group
 
 ```csharp
 // Wrong: misses the ! prefix and any negation on the enclosing group
@@ -369,6 +369,11 @@ bool isNegated = node.IsExcluded();
 // e.g. the value term in -field:(value)
 bool isNegated = node.IsNodeOrGroupNegated();
 ```
+
+Two caveats worth knowing:
+
+- `IsNodeOrGroupNegated()` checks only the nearest parenthesized group, not the whole ancestor chain, and returns `false` when the node carries a `+` prefix even if `NOT` is also present.
+- In sort and aggregation contexts a `-` prefix means **descending**, not negation (see `DefaultSortNodeExtensions` and `CombineAggregationsVisitor`). Do not use `IsExcluded()` to interpret sort direction.
 
 ### Node Data Dictionary
 

--- a/docs/guide/visitors.md
+++ b/docs/guide/visitors.md
@@ -313,7 +313,7 @@ Visitors can handle different node types:
 // Common to all field nodes
 string field = node.Field;
 string unescapedField = node.UnescapedField;
-bool? isNegated = node.IsNegated; // true only for the NOT keyword
+bool? isNegated = node.IsNegated; // the NOT keyword; also set by tree-rewriting visitors
 string prefix = node.Prefix; // +, -, !, or null
 
 // TermNode specific
@@ -347,16 +347,37 @@ Negation is stored in two different places depending on the syntax used:
 | `-field:value` | `null` | `"-"` |
 | `!field:value` | `null` | `"!"` |
 | `+field:value` | `null` | `"+"` |
+| `field:value` | `null` | `null` |
+| `field:[1 TO 2]` | `false` | `null` |
+| `_exists_:field` | `false` | `null` |
 
-`IsNegated` is a `bool?` that the parser sets to `true` only for the `NOT` keyword, leaving it `null` otherwise. Visitors that rewrite the tree (`InvertNegation`, `CleanupQueryVisitor`) may also set it, including to `false`, so compare against `true` rather than treating the value as a plain boolean.
+#### Why `IsNegated` is a `bool?` and not a `bool`
 
-The split is intentional: keeping the operator that was actually written means `GenerateQueryVisitor` and `ToString()` round-trip the original query instead of rewriting `-value` into `NOT value`. As a result, `IsNegated` alone is never a complete negation check.
+The name reads like a boolean, and the nullability does not buy any semantics: `null` and `false` behave **identically** everywhere in the library. Feeding every combination of parent and child negation states through `CleanupQueryVisitor`'s group-collapse and double-negative logic produces the same output for `null` as for `false`; only `true` changes the result. The tri-state is a historical artifact, not a meaningful distinction.
+
+What differs between the two values is only incidental:
+
+- `DebugQueryVisitor` omits the `IsNegated` line entirely when the value is `null`.
+- `CopyTo` copies the value only when it is set, which reaches the same end state either way.
+- `.Value` throws on `null`, which is a hazard rather than a feature.
+
+Which of `null` or `false` a non-negated node receives varies by grammar rule, as the table above shows, and carries no meaning. So the practical rules are:
+
+- Compare against `true` (`node.IsNegated is true`); never treat it as a plain boolean and never rely on `false` versus `null`.
+- Never call `.Value` without checking `HasValue`.
+- Better still, call `IsExcluded()`, which handles all of this along with the `-` and `!` prefixes.
+
+Narrowing the property to a non-nullable `bool` would be a reasonable cleanup, but it is a breaking change to the public `IFieldQueryNode` interface and to every node type and custom visitor implementing it, so it belongs in a major version rather than here.
+
+Visitors that rewrite the tree (`InvertNegation`, `CleanupQueryVisitor`) also set this value, including to `false`.
+
+The split between the two properties is intentional: keeping the operator that was actually written means `GenerateQueryVisitor` and `ToString()` round-trip the original query instead of rewriting `-value` into `NOT value`. As a result, `IsNegated` alone is never a complete negation check.
 
 In query contexts, use the extension methods instead of inspecting the properties directly:
 
 - `IsExcluded()` - node-local negation, covering `NOT`, `-`, and `!`
 - `IsRequired()` - the `+` prefix
-- `IsNodeOrGroupNegated()` - `IsExcluded()` plus negation on the nearest enclosing parenthesized group
+- `IsNodeOrGroupNegated()` - `IsExcluded()` plus negation on the nearest enclosing parenthesized group. When called on a `GroupNode` that already has parens, `GetGroupNode()` returns that same node, so only the group's own negation is considered and an excluded parent group is not inspected.
 
 ```csharp
 // Wrong: misses the ! prefix and any negation on the enclosing group
@@ -372,7 +393,7 @@ bool isNegated = node.IsNodeOrGroupNegated();
 
 Two caveats worth knowing:
 
-- `IsNodeOrGroupNegated()` checks only the nearest parenthesized group, not the whole ancestor chain, and returns `false` when the node carries a `+` prefix even if `NOT` is also present.
+- `IsNodeOrGroupNegated()` walks only up to the nearest parenthesized group, not the whole ancestor chain, so the inner group in `NOT (a:(b))` reports `false`. It also returns `false` when the node carries a `+` prefix even if `NOT` is also present.
 - Outside of query contexts these operators are interpreted as ordering, not negation, and the set of operators that is honored differs:
   - **Sort**: `DefaultSortNodeExtensions` calls `IsNodeOrGroupNegated()`, so `-field`, `!field`, and `NOT field` all sort descending. Because that helper ignores negation when `+` is present, `NOT +field` sorts **ascending**.
   - **Aggregations**: `CombineAggregationsVisitor` reads `Prefix` directly and only honors `-` (descending) and `+` (ascending) on a sub-aggregation. `!` and the `NOT` keyword produce no `order` at all.

--- a/docs/guide/visitors.md
+++ b/docs/guide/visitors.md
@@ -353,17 +353,16 @@ Negation is stored in two different places depending on the syntax used:
 
 #### Why `IsNegated` is a `bool?` and not a `bool`
 
-The name reads like a boolean, and the nullability does not buy any semantics: `null` and `false` behave **identically** everywhere in the library. Feeding every combination of parent and child negation states through `CleanupQueryVisitor`'s group-collapse and double-negative logic produces the same output for `null` as for `false`; only `true` changes the result. The tri-state is a historical artifact, not a meaningful distinction.
+The name reads like a boolean, so the nullability invites the question of whether `null` means something `false` does not. For **query rendering** it does not: flipping any non-negated node between `null` and `false` across a corpus of nested, grouped and negated queries produces byte-identical output from both `CleanupQueryVisitor` and `GenerateQueryVisitor`, including through the group-collapse and double-negative folding. Only `true` changes the result. Every consumer in the repo tests `HasValue && Value` or `is true`, so none of them distinguishes the two.
 
-What differs between the two values is only incidental:
+Two places do observe the difference, so `null` and `false` are not strictly interchangeable:
 
-- `DebugQueryVisitor` omits the `IsNegated` line entirely when the value is `null`.
-- `CopyTo` copies the value only when it is set, which reaches the same end state either way.
-- `.Value` throws on `null`, which is a hazard rather than a feature.
+- `DebugQueryVisitor` prints an `IsNegated` line only when the value is set, so `false` adds a line that `null` omits.
+- `CopyTo` copies the value only when it is set, so copying a `null` source over a `true` target leaves `true`, while copying a `false` source overwrites it with `false`.
 
-Which of `null` or `false` a non-negated node receives varies by grammar rule, as the table above shows, and carries no meaning. So the practical rules are:
+Neither is a semantic distinction worth relying on, and which value a non-negated node receives varies by grammar rule (see the table above) with no meaning attached. The practical rules are:
 
-- Compare against `true` (`node.IsNegated is true`); never treat it as a plain boolean and never rely on `false` versus `null`.
+- Compare against `true` (`node.IsNegated is true`); never treat it as a plain boolean and never branch on `false` versus `null`.
 - Never call `.Value` without checking `HasValue`.
 - Better still, call `IsExcluded()`, which handles all of this along with the `-` and `!` prefixes.
 

--- a/docs/guide/visitors.md
+++ b/docs/guide/visitors.md
@@ -370,7 +370,9 @@ Narrowing the property to a non-nullable `bool` would be a reasonable cleanup, b
 
 Visitors that rewrite the tree (`InvertNegation`, `CleanupQueryVisitor`) also set this value, including to `false`.
 
-The split between the two properties is intentional: keeping the operator that was actually written means `GenerateQueryVisitor` and `ToString()` round-trip the original query instead of rewriting `-value` into `NOT value`. As a result, `IsNegated` alone is never a complete negation check.
+The split between the two properties is intentional: keeping the operator that was actually written means `GenerateQueryVisitor` and `ToString()` re-emit `-value` as `-value` rather than rewriting it to `NOT value`. As a result, `IsNegated` alone is never a complete negation check.
+
+Round-tripping preserves the operator, not always its position. A prefix or `NOT` written inside a scoped field group is re-emitted in the canonical leading position, so `field:-(value)` renders as `-field:(value)` and `field:NOT (value)` as `NOT field:(value)`. These are semantically equivalent.
 
 In query contexts, use the extension methods instead of inspecting the properties directly:
 

--- a/docs/guide/visitors.md
+++ b/docs/guide/visitors.md
@@ -373,7 +373,11 @@ bool isNegated = node.IsNodeOrGroupNegated();
 Two caveats worth knowing:
 
 - `IsNodeOrGroupNegated()` checks only the nearest parenthesized group, not the whole ancestor chain, and returns `false` when the node carries a `+` prefix even if `NOT` is also present.
-- In sort and aggregation contexts a `-` prefix means **descending**, not negation (see `DefaultSortNodeExtensions` and `CombineAggregationsVisitor`). Do not use `IsExcluded()` to interpret sort direction.
+- Outside of query contexts these operators are interpreted as ordering, not negation, and the set of operators that is honored differs:
+  - **Sort**: `DefaultSortNodeExtensions` calls `IsNodeOrGroupNegated()`, so `-field`, `!field`, and `NOT field` all sort descending. Because that helper ignores negation when `+` is present, `NOT +field` sorts **ascending**.
+  - **Aggregations**: `CombineAggregationsVisitor` reads `Prefix` directly and only honors `-` (descending) and `+` (ascending) on a sub-aggregation. `!` and the `NOT` keyword produce no `order` at all.
+
+  Do not use `IsExcluded()` to interpret sort or aggregation direction.
 
 ### Node Data Dictionary
 

--- a/docs/guide/visitors.md
+++ b/docs/guide/visitors.md
@@ -313,8 +313,8 @@ Visitors can handle different node types:
 // Common to all field nodes
 string field = node.Field;
 string unescapedField = node.UnescapedField;
-bool isNegated = node.IsNegated;
-string prefix = node.Prefix; // +, -, or null
+bool? isNegated = node.IsNegated; // true only for the NOT keyword
+string prefix = node.Prefix; // +, -, !, or null
 
 // TermNode specific
 string term = termNode.Term;
@@ -334,6 +334,39 @@ IQueryNode left = groupNode.Left;
 IQueryNode right = groupNode.Right;
 GroupOperator op = groupNode.Operator; // And, Or, Default
 bool hasParens = groupNode.HasParens;
+```
+
+### Negation and Prefix Operators
+
+Negation is stored in two different places depending on the syntax used:
+
+| Query | `IsNegated` | `Prefix` |
+|-------|-------------|----------|
+| `NOT field:value` | `true` | `null` |
+| `-field:value` | not `true` | `"-"` |
+| `!field:value` | not `true` | `"!"` |
+| `+field:value` | not `true` | `"+"` |
+
+`IsNegated` is a `bool?` that is only ever set to `true` by the `NOT` keyword. When `NOT` is absent it is left as `null` or `false` depending on which grammar rule matched, so always compare against `true` rather than treating it as a plain boolean.
+
+The split is intentional: keeping the operator that was actually written means `GenerateQueryVisitor` and `ToString()` round-trip the original query instead of rewriting `-value` into `NOT value`. As a result, `IsNegated` alone is never a complete negation check.
+
+Use the extension methods instead of inspecting the properties directly:
+
+- `IsExcluded()` - node-local negation, covering `NOT`, `-`, and `!`
+- `IsRequired()` - the `+` prefix
+- `IsNodeOrGroupNegated()` - `IsExcluded()` plus negation on the nearest enclosing parenthesized group, and `false` when the node is required
+
+```csharp
+// Wrong: misses the ! prefix and any negation on the enclosing group
+bool isNegated = node.IsNegated.GetValueOrDefault() || node.Prefix == "-";
+
+// Right
+bool isNegated = node.IsExcluded();
+
+// Right, when negation on the enclosing group should also apply
+// e.g. the value term in -field:(value)
+bool isNegated = node.IsNodeOrGroupNegated();
 ```
 
 ### Node Data Dictionary

--- a/docs/guide/visitors.md
+++ b/docs/guide/visitors.md
@@ -343,6 +343,7 @@ Negation is stored in two different places depending on the syntax used:
 | Query | `IsNegated` | `Prefix` |
 |-------|-------------|----------|
 | `NOT field:value` | `true` | `null` |
+| `NOT [1 TO 2]` | `true` | `null` |
 | `-field:value` | not `true` | `"-"` |
 | `!field:value` | not `true` | `"!"` |
 | `+field:value` | not `true` | `"+"` |

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -54,7 +54,7 @@ public static class QueryNodeExtensions
         if (node == null)
             return false;
 
-        return !String.IsNullOrEmpty(node.Prefix) && String.Equals(node.Prefix, "+", StringComparison.Ordinal);
+        return !String.IsNullOrEmpty(node.Prefix) && node.Prefix is "+";
     }
 
     /// <summary>
@@ -107,7 +107,7 @@ public static class QueryNodeExtensions
             {
                 fieldNode.IsNegated = null;
             }
-            else if (!String.IsNullOrEmpty(fieldNode.Prefix) && (String.Equals(fieldNode.Prefix, "-", StringComparison.Ordinal) || String.Equals(fieldNode.Prefix, "!", StringComparison.Ordinal)))
+            else if (!String.IsNullOrEmpty(fieldNode.Prefix) && fieldNode.Prefix is "-" or "!")
             {
                 fieldNode.Prefix = null;
             }

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -30,6 +30,11 @@ public static class QueryNodeExtensions
             parent.Right = null;
     }
 
+    /// <summary>
+    /// Determines whether the node is negated by the <c>NOT</c> keyword or by a <c>-</c> or <c>!</c> prefix operator.
+    /// The parser stores the <c>NOT</c> keyword in <see cref="IFieldQueryNode.IsNegated"/> and the <c>-</c> and <c>!</c>
+    /// operators in <see cref="IFieldQueryNode.Prefix"/>, so neither property alone is a complete negation check.
+    /// </summary>
     public static bool IsExcluded(this IQueryNode node)
     {
         if (node == null)
@@ -41,6 +46,9 @@ public static class QueryNodeExtensions
         return false;
     }
 
+    /// <summary>
+    /// Determines whether the node is marked as required by the <c>+</c> prefix operator.
+    /// </summary>
     public static bool IsRequired(this IFieldQueryNode node)
     {
         if (node == null)
@@ -49,6 +57,10 @@ public static class QueryNodeExtensions
         return !String.IsNullOrEmpty(node.Prefix) && node.Prefix == "+";
     }
 
+    /// <summary>
+    /// Determines whether the node is negated. Equivalent to <see cref="IsExcluded(IQueryNode)"/>.
+    /// </summary>
+    [Obsolete("Use IsExcluded() instead; this method is easily confused with the IsNegated property, which is only set by the NOT keyword.")]
     public static bool IsNegated(this IFieldQueryNode node)
     {
         return node.IsExcluded();
@@ -118,6 +130,10 @@ public static class QueryNodeExtensions
         });
     }
 
+    /// <summary>
+    /// Determines whether the node is negated, either directly or by the nearest enclosing parenthesized group.
+    /// Returns <c>false</c> when the node is marked as required by the <c>+</c> prefix operator.
+    /// </summary>
     public static bool IsNodeOrGroupNegated(this IFieldQueryNode node)
     {
         if (node.IsRequired())

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -54,7 +54,7 @@ public static class QueryNodeExtensions
         if (node == null)
             return false;
 
-        return !String.IsNullOrEmpty(node.Prefix) && node.Prefix == "+";
+        return !String.IsNullOrEmpty(node.Prefix) && String.Equals(node.Prefix, "+", StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -107,7 +107,7 @@ public static class QueryNodeExtensions
             {
                 fieldNode.IsNegated = null;
             }
-            else if (!String.IsNullOrEmpty(fieldNode.Prefix) && (fieldNode.Prefix == "-" || fieldNode.Prefix == "!"))
+            else if (!String.IsNullOrEmpty(fieldNode.Prefix) && (String.Equals(fieldNode.Prefix, "-", StringComparison.Ordinal) || String.Equals(fieldNode.Prefix, "!", StringComparison.Ordinal)))
             {
                 fieldNode.Prefix = null;
             }

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -60,7 +60,7 @@ public static class QueryNodeExtensions
     /// <summary>
     /// Determines whether the node is negated. Equivalent to <see cref="IsExcluded(IQueryNode)"/>.
     /// </summary>
-    [Obsolete("Use IsExcluded() instead; this method is easily confused with the IsNegated property, which is only set by the NOT keyword.")]
+    [Obsolete("Use IsExcluded() instead; this method is easily confused with the IsNegated property, which only reflects the NOT keyword and not the - and ! prefix operators.")]
     public static bool IsNegated(this IFieldQueryNode node)
     {
         return node.IsExcluded();
@@ -134,6 +134,11 @@ public static class QueryNodeExtensions
     /// Determines whether the node is negated, either directly or by the nearest enclosing parenthesized group.
     /// Returns <c>false</c> when the node is marked as required by the <c>+</c> prefix operator.
     /// </summary>
+    /// <remarks>
+    /// Only the nearest parenthesized group is inspected, not the full ancestor chain. When called on a
+    /// <see cref="GroupNode"/> that already has parens, that same node is the nearest group, so an excluded
+    /// parent group does not affect the result.
+    /// </remarks>
     public static bool IsNodeOrGroupNegated(this IFieldQueryNode node)
     {
         if (node.IsRequired())

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
@@ -97,7 +97,8 @@ field_exp<IQueryNode>
           range.Field = name[0].Field;
           range.Prefix = name[0].Prefix;
 
-          // An unqualified range leaves IsNegated unset, which is the value it has always had.
+          // A qualified range records an explicit false. An unqualified one is left unset,
+          // which is the value it has always had.
           range.IsNegated = false;
         }
 

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
@@ -94,13 +94,16 @@ field_exp<IQueryNode>
   / not:not_exp? name:fieldname? range:range_operator_exp
     {{
         if (name.Count == 1) {
-          range.IsNegated = not.Any();
           range.Field = name[0].Field;
           range.Prefix = name[0].Prefix;
         }
-        else if (not.Any()) {
+
+        // A NOT keyword always negates. Without one, only a qualified range records an explicit
+        // false; an unqualified range leaves IsNegated unset, which is the value it has always had.
+        if (not.Any())
           range.IsNegated = true;
-        }
+        else if (name.Count == 1)
+          range.IsNegated = false;
 
         return range;
     }}
@@ -112,8 +115,8 @@ field_exp<IQueryNode>
     }}
   / not:not_exp? name:fieldname node:paren_exp
     {{
-        // paren_exp already set IsNegated for a NOT inside the parens, so only overwrite it
-        // when this rule has its own NOT; otherwise default an unset value to false.
+        // paren_exp already recorded a NOT that appeared inside the parens, as in field:NOT (value),
+        // so only overwrite it when this rule matched its own NOT.
         if (not.Any())
           node.IsNegated = true;
         else if (node.IsNegated == null)

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
@@ -96,14 +96,13 @@ field_exp<IQueryNode>
         if (name.Count == 1) {
           range.Field = name[0].Field;
           range.Prefix = name[0].Prefix;
+
+          // An unqualified range leaves IsNegated unset, which is the value it has always had.
+          range.IsNegated = false;
         }
 
-        // A NOT keyword always negates. Without one, only a qualified range records an explicit
-        // false; an unqualified range leaves IsNegated unset, which is the value it has always had.
         if (not.Any())
           range.IsNegated = true;
-        else if (name.Count == 1)
-          range.IsNegated = false;
 
         return range;
     }}
@@ -115,19 +114,11 @@ field_exp<IQueryNode>
     }}
   / not:not_exp? name:fieldname node:paren_exp
     {{
-        // paren_exp already recorded a NOT that appeared inside the parens, as in field:NOT (value),
-        // so only overwrite it when this rule matched its own NOT.
-        if (not.Any())
-          node.IsNegated = true;
-        else if (node.IsNegated == null)
-          node.IsNegated = false;
-
+        // paren_exp may have already recorded a NOT or a prefix that was written after the colon,
+        // as in field:NOT (value) or field:-(value), so combine with it rather than overwrite it.
+        node.IsNegated = not.Any() || node.IsNegated == true;
         node.Field = name.Field;
-
-        // Likewise, paren_exp may have recorded a prefix written after the colon, as in field:-(value).
-        // Only let the fieldname's prefix win when it actually has one.
-        if (name.Prefix != null || node.Prefix == null)
-          node.Prefix = name.Prefix;
+        node.Prefix = name.Prefix ?? node.Prefix;
 
         return node;
     }}

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
@@ -85,15 +85,16 @@ paren_exp<GroupNode>
 field_exp<IQueryNode>
   = not:not_exp? op:prefix_operator_exp? '_exists_' _* ':' _* fieldname:name_term
   {{
-        return new ExistsNode { IsNegated = not.Any(), Prefix = op.SingleOrDefault(), Field = fieldname };
+        return new ExistsNode { IsNegated = not.Any() ? true : null, Prefix = op.SingleOrDefault(), Field = fieldname };
   }}
   / not:not_exp? op:prefix_operator_exp? '_missing_' _* ':' _* fieldname:name_term
   {{
-        return new MissingNode { IsNegated = not.Any(), Prefix = op.SingleOrDefault(), Field = fieldname };
+        return new MissingNode { IsNegated = not.Any() ? true : null, Prefix = op.SingleOrDefault(), Field = fieldname };
   }}
   / not:not_exp? name:fieldname? range:range_operator_exp
     {{
-        range.IsNegated = not.Any();
+        if (not.Any())
+          range.IsNegated = true;
 
         if (name.Count == 1) {
           range.Field = name[0].Field;
@@ -104,13 +105,17 @@ field_exp<IQueryNode>
     }}
   / not:not_exp? op:prefix_operator_exp? range:range_operator_exp
     {{
-        range.IsNegated = not.Any();
+        if (not.Any())
+          range.IsNegated = true;
+
         range.Prefix = op.SingleOrDefault();
         return range;
     }}
   / not:not_exp? name:fieldname node:paren_exp
     {{
-        node.IsNegated = not.Any();
+        if (not.Any())
+          node.IsNegated = true;
+
         node.Field = name.Field;
         node.Prefix = name.Prefix;
         return node;

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
@@ -85,36 +85,39 @@ paren_exp<GroupNode>
 field_exp<IQueryNode>
   = not:not_exp? op:prefix_operator_exp? '_exists_' _* ':' _* fieldname:name_term
   {{
-        return new ExistsNode { IsNegated = not.Any() ? true : null, Prefix = op.SingleOrDefault(), Field = fieldname };
+        return new ExistsNode { IsNegated = not.Any(), Prefix = op.SingleOrDefault(), Field = fieldname };
   }}
   / not:not_exp? op:prefix_operator_exp? '_missing_' _* ':' _* fieldname:name_term
   {{
-        return new MissingNode { IsNegated = not.Any() ? true : null, Prefix = op.SingleOrDefault(), Field = fieldname };
+        return new MissingNode { IsNegated = not.Any(), Prefix = op.SingleOrDefault(), Field = fieldname };
   }}
   / not:not_exp? name:fieldname? range:range_operator_exp
     {{
-        if (not.Any())
-          range.IsNegated = true;
-
         if (name.Count == 1) {
+          range.IsNegated = not.Any();
           range.Field = name[0].Field;
           range.Prefix = name[0].Prefix;
+        }
+        else if (not.Any()) {
+          range.IsNegated = true;
         }
 
         return range;
     }}
   / not:not_exp? op:prefix_operator_exp? range:range_operator_exp
     {{
-        if (not.Any())
-          range.IsNegated = true;
-
+        range.IsNegated = not.Any();
         range.Prefix = op.SingleOrDefault();
         return range;
     }}
   / not:not_exp? name:fieldname node:paren_exp
     {{
+        // paren_exp already set IsNegated for a NOT inside the parens, so only overwrite it
+        // when this rule has its own NOT; otherwise default an unset value to false.
         if (not.Any())
           node.IsNegated = true;
+        else if (node.IsNegated == null)
+          node.IsNegated = false;
 
         node.Field = name.Field;
         node.Prefix = name.Prefix;

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
@@ -123,7 +123,12 @@ field_exp<IQueryNode>
           node.IsNegated = false;
 
         node.Field = name.Field;
-        node.Prefix = name.Prefix;
+
+        // Likewise, paren_exp may have recorded a prefix written after the colon, as in field:-(value).
+        // Only let the fieldname's prefix win when it actually has one.
+        if (name.Prefix != null || node.Prefix == null)
+          node.Prefix = name.Prefix;
+
         return node;
     }}
   / not:not_exp? name:fieldname? term:term

--- a/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
+++ b/src/Foundatio.Parsers.LuceneQueries/LuceneQueryParser.peg
@@ -93,8 +93,9 @@ field_exp<IQueryNode>
   }}
   / not:not_exp? name:fieldname? range:range_operator_exp
     {{
+        range.IsNegated = not.Any();
+
         if (name.Count == 1) {
-          range.IsNegated = not.Any();
           range.Field = name[0].Field;
           range.Prefix = name[0].Prefix;
         }

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
@@ -56,8 +56,8 @@ public interface IFieldQueryNode : IQueryNode
     /// may also set this value.
     /// </summary>
     /// <remarks>
-    /// The nullability carries no meaning: <c>null</c> and <c>false</c> behave identically throughout the library,
-    /// and which one a non-negated node receives varies by grammar rule. Only <c>true</c> is significant. Always
+    /// Only <c>true</c> is significant. <c>null</c> and <c>false</c> render identically and every consumer tests for
+    /// <c>true</c>, so which one a non-negated node receives (it varies by grammar rule) carries no meaning. Always
     /// compare against <c>true</c> rather than treating this as a plain boolean, and never call <c>.Value</c>
     /// without checking <c>HasValue</c> first.
     /// </remarks>

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
@@ -50,12 +50,17 @@ public interface IQueryNode
 public interface IFieldQueryNode : IQueryNode
 {
     /// <summary>
-    /// Whether this node is negated (NOT operator applied).
+    /// Whether this node is negated by the <c>NOT</c> keyword. The <c>-</c> and <c>!</c> operators are stored in
+    /// <see cref="Prefix"/> instead, so this property alone is not a complete negation check. Prefer the
+    /// <c>IsExcluded()</c> extension method, which covers all three forms. Visitors that rewrite the query tree
+    /// may also set this value.
     /// </summary>
     bool? IsNegated { get; set; }
 
     /// <summary>
-    /// The prefix modifier (+, -, etc.) applied to this node.
+    /// The verbatim prefix operator (<c>+</c>, <c>-</c>, or <c>!</c>) as written in the query, preserved so the
+    /// original syntax round-trips. Prefer the <c>IsExcluded()</c> and <c>IsRequired()</c> extension methods over
+    /// interpreting this value directly.
     /// </summary>
     string? Prefix { get; set; }
 

--- a/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Nodes/IQueryNode.cs
@@ -55,6 +55,12 @@ public interface IFieldQueryNode : IQueryNode
     /// <c>IsExcluded()</c> extension method, which covers all three forms. Visitors that rewrite the query tree
     /// may also set this value.
     /// </summary>
+    /// <remarks>
+    /// The nullability carries no meaning: <c>null</c> and <c>false</c> behave identically throughout the library,
+    /// and which one a non-negated node receives varies by grammar rule. Only <c>true</c> is significant. Always
+    /// compare against <c>true</c> rather than treating this as a plain boolean, and never call <c>.Value</c>
+    /// without checking <c>HasValue</c> first.
+    /// </remarks>
     bool? IsNegated { get; set; }
 
     /// <summary>

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/AggregationParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/AggregationParserTests.cs
@@ -550,6 +550,71 @@ public class AggregationParserTests : ElasticsearchTestBase
         Assert.Equal(expectedResponse.Total, actualResponse.Total);
     }
 
+    [Theory]
+    [InlineData("-cardinality:field4", SortOrder.Desc)]
+    [InlineData("+cardinality:field4", SortOrder.Asc)]
+    public async Task BuildAggregationsAsync_WithPrefixedSubAggregation_AppliesTermsOrder(string subAggregation, SortOrder expectedOrder)
+    {
+        // Arrange
+        string index = await CreateRandomIndexAsync<MyType>();
+        await Client.IndexManyAsync([new MyType { Field1 = "value1" }], index, TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, cancellationToken: TestCancellationToken);
+        var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
+
+        // Act
+        var aggregations = await processor.BuildAggregationsAsync($"terms:(field1 {subAggregation})");
+        var actualResponse = await Client.SearchAsync<MyType>(d => d.Indices(index).Aggregations(aggregations), TestCancellationToken);
+
+        // Assert
+        string actualRequest = actualResponse.GetRequest();
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = await Client.SearchAsync<MyType>(d => d.Indices(index).Aggregations(a => a
+            .Add("terms_field1", a1 => a1
+                .Terms(t => t.Field("field1.keyword").Order(new List<KeyValuePair<Field, SortOrder>> { new("cardinality_field4", expectedOrder) }))
+                    .Aggregations(a2 => a2.Add("cardinality_field4", a3 => a3.Cardinality(c => c.Field(f => f.Field4))))
+                .Meta(m => m.Add("@field_type", "keyword")))), TestCancellationToken);
+        string expectedRequest = expectedResponse.GetRequest();
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+        Assert.True(actualResponse.IsValidResponse);
+    }
+
+    [Theory]
+    [InlineData("cardinality:field4")]
+    // Aggregation ordering reads Prefix directly and only honors "-" and "+". The "!" prefix and
+    // the NOT keyword are negation operators, not ordering operators, so they produce no order.
+    [InlineData("!cardinality:field4")]
+    [InlineData("NOT cardinality:field4")]
+    public async Task BuildAggregationsAsync_WithNonOrderingSubAggregation_OmitsTermsOrder(string subAggregation)
+    {
+        // Arrange
+        string index = await CreateRandomIndexAsync<MyType>();
+        await Client.IndexManyAsync([new MyType { Field1 = "value1" }], index, TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, cancellationToken: TestCancellationToken);
+        var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
+
+        // Act
+        var aggregations = await processor.BuildAggregationsAsync($"terms:(field1 {subAggregation})");
+        var actualResponse = await Client.SearchAsync<MyType>(d => d.Indices(index).Aggregations(aggregations), TestCancellationToken);
+
+        // Assert
+        string actualRequest = actualResponse.GetRequest();
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = await Client.SearchAsync<MyType>(d => d.Indices(index).Aggregations(a => a
+            .Add("terms_field1", a1 => a1
+                .Terms(t => t.Field("field1.keyword"))
+                    .Aggregations(a2 => a2.Add("cardinality_field4", a3 => a3.Cardinality(c => c.Field(f => f.Field4))))
+                .Meta(m => m.Add("@field_type", "keyword")))), TestCancellationToken);
+        string expectedRequest = expectedResponse.GetRequest();
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+        Assert.True(actualResponse.IsValidResponse);
+    }
+
     [Fact]
     public async Task ProcessDateHistogramAggregations()
     {

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -1578,6 +1578,82 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
         Assert.Equal(expectedResponse.Total, actualResponse.Total);
     }
 
+    [Theory]
+    [InlineData("field1", SortOrder.Asc)]
+    [InlineData("+field1", SortOrder.Asc)]
+    [InlineData("-field1", SortOrder.Desc)]
+    [InlineData("!field1", SortOrder.Desc)]
+    [InlineData("NOT field1", SortOrder.Desc)]
+    [InlineData("NOT -field1", SortOrder.Desc)]
+    // A "+" prefix wins over a "NOT" keyword because IsNodeOrGroupNegated() returns false when
+    // IsRequired() is true. In a sort context that means "NOT +field1" sorts ascending. This is
+    // pre-existing behavior and is pinned here so it cannot change silently.
+    [InlineData("NOT +field1", SortOrder.Asc)]
+    public async Task BuildSortAsync_WithNegationAndPrefixOperators_MapsToSortOrder(string sort, SortOrder expectedOrder)
+    {
+        // Arrange
+        string index = await CreateRandomIndexAsync<MyType>(m => m.Dynamic(DynamicMapping.True));
+        var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
+
+        // Act
+        var actualSort = await processor.BuildSortAsync(sort);
+        var actualResponse = await Client.SearchAsync<MyType>(d => d.Indices(index).Sort(actualSort), TestCancellationToken);
+
+        // Assert
+        Assert.True(actualResponse.IsValidResponse);
+        string actualRequest = actualResponse.GetRequest(true);
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = await Client.SearchAsync<MyType>(d => d.Indices(index)
+            .Sort(s => s.Field(f => f.Field1, so => so.Order(expectedOrder).UnmappedType(FieldType.Keyword))), TestCancellationToken);
+        string expectedRequest = expectedResponse.GetRequest(true);
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+    }
+
+    [Theory]
+    [InlineData("NOT field1:value1")]
+    [InlineData("-field1:value1")]
+    [InlineData("!field1:value1")]
+    // Unlike the sort context above, the query path uses IsExcluded(), which ignores the "+"
+    // prefix, so the NOT keyword is still honored and this produces a must_not clause.
+    [InlineData("NOT +field1:value1")]
+    [InlineData("NOT -field1:value1")]
+    // Regression: both of these used to silently drop the NOT and match the wrong documents.
+    [InlineData("field1:NOT (value1)")]
+    [InlineData("NOT field1:(value1)")]
+    public async Task BuildQueryAsync_WithNegatedTerm_ProducesMustNotClause(string query)
+    {
+        // Arrange
+        string index = await CreateRandomIndexAsync<MyType>();
+        await Client.IndexManyAsync([
+            new MyType { Field1 = "value1" },
+            new MyType { Field1 = "value2" }
+        ], index, TestCancellationToken);
+        await Client.Indices.RefreshAsync(index, cancellationToken: TestCancellationToken);
+        var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseMappings(Client, index));
+
+        // Act
+        var result = await processor.BuildQueryAsync(query);
+        var actualResponse = await Client.SearchAsync<MyType>(d => d.Indices(index).Query(result), TestCancellationToken);
+
+        // Assert
+        Assert.True(actualResponse.IsValidResponse);
+        string actualRequest = actualResponse.GetRequest(true);
+        _logger.LogInformation("Actual: {Request}", actualRequest);
+
+        var expectedResponse = await Client.SearchAsync<MyType>(d => d.Indices(index)
+            .Query(q => q.Bool(b => b.Filter(f => f.Bool(b2 => b2
+                .MustNot(mn => mn.Match(m => m.Field(tf => tf.Field1).Query("value1"))))))), TestCancellationToken);
+        string expectedRequest = expectedResponse.GetRequest(true);
+        _logger.LogInformation("Expected: {Request}", expectedRequest);
+
+        Assert.Equal(expectedRequest, actualRequest);
+        Assert.Equal(expectedResponse.Total, actualResponse.Total);
+        Assert.Equal(1, actualResponse.Total);
+    }
+
     [Fact]
     public async Task GeoRangeQueryProcessor()
     {

--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticQueryParserTests.cs
@@ -1623,6 +1623,10 @@ public class ElasticQueryParserTests : ElasticsearchTestBase
     // Regression: both of these used to silently drop the NOT and match the wrong documents.
     [InlineData("field1:NOT (value1)")]
     [InlineData("NOT field1:(value1)")]
+    // Regression: a prefix written after the colon was overwritten by the field name's null prefix,
+    // so these matched documents they were meant to exclude.
+    [InlineData("field1:-(value1)")]
+    [InlineData("field1:!(value1)")]
     public async Task BuildQueryAsync_WithNegatedTerm_ProducesMustNotClause(string query)
     {
         // Arrange

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -567,13 +567,70 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.NotNull(groupNode);
         Assert.True(groupNode.HasParens);
         Assert.Equal("-", groupNode.Prefix);
-        Assert.Null(groupNode.IsNegated);
+        Assert.False(groupNode.IsNegated);
         Assert.True(groupNode.IsExcluded());
 
         var termNode = groupNode.Left as TermNode;
         Assert.NotNull(termNode);
         Assert.False(termNode.IsExcluded());
         Assert.True(termNode.IsNodeOrGroupNegated());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CleanupQuery_WithNullOrFalseIsNegated_ProducesSameOutput(bool? outerIsNegated)
+    {
+        // Arrange
+        // IsNegated is a bool? but null and false carry no distinct meaning: only true is significant.
+        // This pins that equivalence through CleanupQueryVisitor's group-collapse and double-negative
+        // logic so a future change can't quietly make the two values behave differently.
+        var parser = new LuceneQueryParser();
+
+        string RunWithInner(bool? innerIsNegated)
+        {
+            var result = parser.Parse("NOT ((value))");
+            var outerGroup = (GroupNode)result.Left!;
+            outerGroup.IsNegated = outerIsNegated;
+            if (outerGroup.Left is GroupNode innerGroup)
+                innerGroup.IsNegated = innerIsNegated;
+
+            return CleanupQueryVisitor.Run(result) ?? String.Empty;
+        }
+
+        // Act
+        string withNull = RunWithInner(null);
+        string withFalse = RunWithInner(false);
+
+        // Assert
+        Assert.Equal(withNull, withFalse);
+    }
+
+    [Fact]
+    public void Parse_WithNestedGroupInsideExcludedGroup_IsNodeOrGroupNegatedIgnoresParent()
+    {
+        // Arrange
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var result = parser.Parse("-(field:(value))");
+
+        // Assert
+        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
+
+        var outerGroup = result.Left as GroupNode;
+        Assert.NotNull(outerGroup);
+        Assert.Equal("-", outerGroup.Prefix);
+        Assert.True(outerGroup.IsExcluded());
+
+        // The inner group already has parens, so GetGroupNode() returns the inner group itself and the
+        // excluded outer group is never inspected. Pinned because sort behavior depends on this helper.
+        var innerGroup = outerGroup.Left as GroupNode;
+        Assert.NotNull(innerGroup);
+        Assert.True(innerGroup.HasParens);
+        Assert.False(innerGroup.IsExcluded());
+        Assert.False(innerGroup.IsNodeOrGroupNegated());
     }
 
     [Theory]
@@ -585,13 +642,16 @@ public class QueryParserTests : TestWithLoggingBase
     [InlineData("NOT _missing_:field", true, null, true, false)]
     [InlineData("-field:value", null, "-", true, false)]
     [InlineData("!field:value", null, "!", true, false)]
-    [InlineData("-[1 TO 2]", null, "-", true, false)]
-    [InlineData("!field:[1 TO 2]", null, "!", true, false)]
+    [InlineData("-[1 TO 2]", false, "-", true, false)]
+    [InlineData("!field:[1 TO 2]", false, "!", true, false)]
     [InlineData("+field:value", null, "+", false, true)]
     [InlineData("field:value", null, null, false, false)]
+    // Whether a non-negated node reports null or false is inconsistent by rule and is asserted
+    // here as-is to lock the existing public AST. Always compare IsNegated against true.
     [InlineData("[1 TO 2]", null, null, false, false)]
-    [InlineData("field:[1 TO 2]", null, null, false, false)]
-    [InlineData("_exists_:field", null, null, false, false)]
+    [InlineData("field:[1 TO 2]", false, null, false, false)]
+    [InlineData("_exists_:field", false, null, false, false)]
+    [InlineData("_missing_:field", false, null, false, false)]
     public void Parse_WithNegation_StoresNotKeywordInIsNegatedAndOperatorsInPrefix(string query, bool? expectedIsNegated, string? expectedPrefix, bool expectedExcluded, bool expectedRequired)
     {
         // Arrange

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -267,6 +267,8 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.IsType<GroupNode>(result.Left);
         Assert.True((result.Left as GroupNode)!.HasParens);
         Assert.True((result.Left as GroupNode)!.IsNegated);
+        Assert.Null((result.Left as GroupNode)!.Prefix);
+        Assert.True((result.Left as GroupNode)!.IsExcluded());
     }
 
     [Fact]
@@ -299,6 +301,72 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.Equal("Apache Lucene", right.Term);
         Assert.Equal("-", right.Prefix);
         Assert.True(right.IsExcluded());
+
+        result = sut.Parse("+field:value");
+        ast = DebugQueryVisitor.Run(result);
+
+        left = result.Left as TermNode;
+        Assert.NotNull(left);
+        Assert.Equal("+", left.Prefix);
+        Assert.Null(left.IsNegated);
+        Assert.True(left.IsRequired());
+        Assert.False(left.IsExcluded());
+        Assert.False(left.IsNodeOrGroupNegated());
+    }
+
+    [Theory]
+    [InlineData("-field:value")]
+    [InlineData("!field:value")]
+    public void PrefixOperatorsAreStoredInPrefixAndNotIsNegated(string query)
+    {
+        var sut = new LuceneQueryParser();
+
+        var result = sut.Parse(query);
+        string ast = DebugQueryVisitor.Run(result);
+
+        var term = result.Left as TermNode;
+        Assert.NotNull(term);
+        Assert.Null(term.IsNegated);
+        Assert.Equal(query[0].ToString(), term.Prefix);
+        Assert.True(term.IsExcluded());
+        Assert.True(term.IsNodeOrGroupNegated());
+    }
+
+    [Fact]
+    public void NotKeywordIsStoredInIsNegatedAndNotPrefix()
+    {
+        var sut = new LuceneQueryParser();
+
+        var result = sut.Parse("NOT field:value");
+        string ast = DebugQueryVisitor.Run(result);
+
+        var term = result.Left as TermNode;
+        Assert.NotNull(term);
+        Assert.True(term.IsNegated);
+        Assert.Null(term.Prefix);
+        Assert.True(term.IsExcluded());
+        Assert.True(term.IsNodeOrGroupNegated());
+    }
+
+    [Fact]
+    public void CanDetectNegationFromEnclosingGroup()
+    {
+        var sut = new LuceneQueryParser();
+
+        var result = sut.Parse("-field:(value)");
+        string ast = DebugQueryVisitor.Run(result);
+
+        var group = result.Left as GroupNode;
+        Assert.NotNull(group);
+        Assert.True(group.HasParens);
+        Assert.Equal("-", group.Prefix);
+        Assert.NotEqual(true, group.IsNegated);
+        Assert.True(group.IsExcluded());
+
+        var term = group.Left as TermNode;
+        Assert.NotNull(term);
+        Assert.False(term.IsExcluded());
+        Assert.True(term.IsNodeOrGroupNegated());
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -567,13 +567,49 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.NotNull(groupNode);
         Assert.True(groupNode.HasParens);
         Assert.Equal("-", groupNode.Prefix);
-        Assert.NotEqual(true, groupNode.IsNegated);
+        Assert.Null(groupNode.IsNegated);
         Assert.True(groupNode.IsExcluded());
 
         var termNode = groupNode.Left as TermNode;
         Assert.NotNull(termNode);
         Assert.False(termNode.IsExcluded());
         Assert.True(termNode.IsNodeOrGroupNegated());
+    }
+
+    [Theory]
+    [InlineData("NOT field:value", true, null, true, false)]
+    [InlineData("NOT [1 TO 2]", true, null, true, false)]
+    [InlineData("NOT >1", true, null, true, false)]
+    [InlineData("NOT field:[1 TO 2]", true, null, true, false)]
+    [InlineData("NOT _exists_:field", true, null, true, false)]
+    [InlineData("NOT _missing_:field", true, null, true, false)]
+    [InlineData("-field:value", null, "-", true, false)]
+    [InlineData("!field:value", null, "!", true, false)]
+    [InlineData("-[1 TO 2]", null, "-", true, false)]
+    [InlineData("!field:[1 TO 2]", null, "!", true, false)]
+    [InlineData("+field:value", null, "+", false, true)]
+    [InlineData("field:value", null, null, false, false)]
+    [InlineData("[1 TO 2]", null, null, false, false)]
+    [InlineData("field:[1 TO 2]", null, null, false, false)]
+    [InlineData("_exists_:field", null, null, false, false)]
+    public void Parse_WithNegation_StoresNotKeywordInIsNegatedAndOperatorsInPrefix(string query, bool? expectedIsNegated, string? expectedPrefix, bool expectedExcluded, bool expectedRequired)
+    {
+        // Arrange
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var result = parser.Parse(query);
+
+        // Assert
+        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
+
+        var node = result.Left as IFieldQueryNode;
+        Assert.NotNull(node);
+        Assert.Equal(expectedIsNegated, node.IsNegated);
+        Assert.Equal(expectedPrefix, node.Prefix);
+        Assert.Equal(expectedExcluded, node.IsExcluded());
+        Assert.Equal(expectedRequired, node.IsRequired());
+        Assert.Equal(query, GenerateQueryVisitor.Run(result));
     }
 
     [Theory]
@@ -594,28 +630,32 @@ public class QueryParserTests : TestWithLoggingBase
         var rangeNode = result.Left as TermRangeNode;
         Assert.NotNull(rangeNode);
         Assert.True(rangeNode.IsNegated);
+        Assert.Null(rangeNode.Prefix);
         Assert.True(rangeNode.IsExcluded());
         Assert.Equal(query, GenerateQueryVisitor.Run(result));
+        Assert.Equal(query, CleanupQueryVisitor.Run(result));
     }
 
-    [Fact]
-    public void Parse_WithNotKeyword_SetsIsNegatedAndNotPrefix()
+    [Theory]
+    [InlineData("field:NOT (value)", "NOT field:(value)")]
+    [InlineData("field:NOT (a b)", "NOT field:(a b)")]
+    public void Parse_WithNotKeywordBeforeFieldGroup_PreservesNegation(string query, string expectedQuery)
     {
         // Arrange
         var parser = new LuceneQueryParser();
 
         // Act
-        var result = parser.Parse("NOT field:value");
+        var result = parser.Parse(query);
 
         // Assert
         _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
 
-        var termNode = result.Left as TermNode;
-        Assert.NotNull(termNode);
-        Assert.True(termNode.IsNegated);
-        Assert.Null(termNode.Prefix);
-        Assert.True(termNode.IsExcluded());
-        Assert.True(termNode.IsNodeOrGroupNegated());
+        var groupNode = result.Left as GroupNode;
+        Assert.NotNull(groupNode);
+        Assert.Equal("field", groupNode.Field);
+        Assert.True(groupNode.IsNegated);
+        Assert.True(groupNode.IsExcluded());
+        Assert.Equal(expectedQuery, GenerateQueryVisitor.Run(result));
     }
 
     [Fact]
@@ -631,28 +671,6 @@ public class QueryParserTests : TestWithLoggingBase
         var termNode = result.Left as TermNode;
         Assert.NotNull(termNode);
         Assert.Null(termNode.Proximity);
-    }
-
-    [Theory]
-    [InlineData("-field:value", "-")]
-    [InlineData("!field:value", "!")]
-    public void Parse_WithPrefixOperator_SetsPrefixAndNotIsNegated(string query, string expectedPrefix)
-    {
-        // Arrange
-        var parser = new LuceneQueryParser();
-
-        // Act
-        var result = parser.Parse(query);
-
-        // Assert
-        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
-
-        var termNode = result.Left as TermNode;
-        Assert.NotNull(termNode);
-        Assert.Null(termNode.IsNegated);
-        Assert.Equal(expectedPrefix, termNode.Prefix);
-        Assert.True(termNode.IsExcluded());
-        Assert.True(termNode.IsNodeOrGroupNegated());
     }
 
     [Theory]
@@ -683,13 +701,13 @@ public class QueryParserTests : TestWithLoggingBase
     }
 
     [Fact]
-    public void Parse_WithRequiredPrefixOperator_IsRequiredAndNotExcluded()
+    public void Parse_WithRequiredPrefixAndNotKeyword_IsNodeOrGroupNegatedIgnoresNegation()
     {
         // Arrange
         var parser = new LuceneQueryParser();
 
         // Act
-        var result = parser.Parse("+field:value");
+        var result = parser.Parse("NOT +field:value");
 
         // Assert
         _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
@@ -697,9 +715,11 @@ public class QueryParserTests : TestWithLoggingBase
         var termNode = result.Left as TermNode;
         Assert.NotNull(termNode);
         Assert.Equal("+", termNode.Prefix);
-        Assert.Null(termNode.IsNegated);
+        Assert.True(termNode.IsNegated);
         Assert.True(termNode.IsRequired());
-        Assert.False(termNode.IsExcluded());
+        Assert.True(termNode.IsExcluded());
+
+        // IsNodeOrGroupNegated returns false when the node is required, even though NOT is present
         Assert.False(termNode.IsNodeOrGroupNegated());
     }
 }

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -744,6 +744,69 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.Equal(expectedQuery, GenerateQueryVisitor.Run(result));
     }
 
+    [Theory]
+    [InlineData("field1:value1")]
+    [InlineData("NOT field1:value1")]
+    [InlineData("field1:NOT value1")]
+    [InlineData("-field1:value1")]
+    [InlineData("field1:-value1")]
+    [InlineData("!field1:value1")]
+    [InlineData("field1:!value1")]
+    [InlineData("+field1:value1")]
+    [InlineData("field1:+value1")]
+    [InlineData("field1:(value1)")]
+    [InlineData("NOT field1:(value1)")]
+    [InlineData("field1:NOT (value1)")]
+    [InlineData("-field1:(value1)")]
+    [InlineData("field1:-(value1)")]
+    [InlineData("!field1:(value1)")]
+    [InlineData("field1:!(value1)")]
+    [InlineData("+field1:(value1)")]
+    [InlineData("field1:+(value1)")]
+    [InlineData("field1:(-value1)")]
+    [InlineData("field1:(NOT value1)")]
+    [InlineData("(field1:value1)")]
+    [InlineData("NOT (field1:value1)")]
+    [InlineData("-(field1:value1)")]
+    [InlineData("!(field1:value1)")]
+    [InlineData("NOT (NOT field1:value1)")]
+    [InlineData("-(-field1:value1)")]
+    [InlineData("field4:[1 TO 2]")]
+    [InlineData("NOT field4:[1 TO 2]")]
+    [InlineData("-field4:[1 TO 2]")]
+    [InlineData("!field4:[1 TO 2]")]
+    [InlineData("[1 TO 2]")]
+    [InlineData("NOT [1 TO 2]")]
+    [InlineData("-[1 TO 2]")]
+    [InlineData("field4:<3")]
+    [InlineData("NOT field4:<3")]
+    [InlineData("-field4:<3")]
+    [InlineData("_exists_:field2")]
+    [InlineData("NOT _exists_:field2")]
+    [InlineData("-_exists_:field2")]
+    [InlineData("!_exists_:field2")]
+    [InlineData("_missing_:field2")]
+    [InlineData("NOT _missing_:field2")]
+    [InlineData("-_missing_:field2")]
+    [InlineData("field1:value1 AND NOT field2:value2")]
+    [InlineData("NOT field1:value1 OR -field2:value2")]
+    [InlineData("field1:value1 AND (NOT field2:value2 OR -field3:value3)")]
+    public void Parse_WithNegationOrPrefix_GeneratedQueryReparsesToItself(string query)
+    {
+        // Arrange
+        // Negation may be re-emitted in the canonical leading position, so the first generated query is
+        // not always the input. It must be a fixed point though: re-parsing it has to produce the same text,
+        // otherwise a prefix or NOT is being dropped or duplicated somewhere in the round trip.
+        var parser = new LuceneQueryParser();
+
+        // Act
+        string generated = GenerateQueryVisitor.Run(parser.Parse(query));
+        string regenerated = GenerateQueryVisitor.Run(parser.Parse(generated));
+
+        // Assert
+        Assert.Equal(generated, regenerated);
+    }
+
     [Fact]
     public void Parse_WithoutProximityModifier_ProximityIsNull()
     {

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -548,7 +548,7 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.NotNull(termNode);
         Assert.Equal("Wellness", termNode.Term);
         Assert.True(termNode.IsQuotedTerm);
-        Assert.Equal("", termNode.Proximity);
+        Assert.Equal(String.Empty, termNode.Proximity);
     }
 
     [Fact]

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -718,6 +718,32 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.Equal(expectedQuery, GenerateQueryVisitor.Run(result));
     }
 
+    [Theory]
+    [InlineData("field:-(value)", "-field:(value)", "-", true, false)]
+    [InlineData("field:!(value)", "!field:(value)", "!", true, false)]
+    [InlineData("field:+(value)", "+field:(value)", "+", false, true)]
+    public void Parse_WithPrefixInsideFieldGroup_PreservesPrefix(string query, string expectedQuery, string expectedPrefix, bool expectedExcluded, bool expectedRequired)
+    {
+        // Arrange
+        // A prefix written after the colon is captured by paren_exp, and field_exp used to overwrite it
+        // with the field name's null prefix, silently dropping the operator.
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var result = parser.Parse(query);
+
+        // Assert
+        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
+
+        var groupNode = result.Left as GroupNode;
+        Assert.NotNull(groupNode);
+        Assert.Equal("field", groupNode.Field);
+        Assert.Equal(expectedPrefix, groupNode.Prefix);
+        Assert.Equal(expectedExcluded, groupNode.IsExcluded());
+        Assert.Equal(expectedRequired, groupNode.IsRequired());
+        Assert.Equal(expectedQuery, GenerateQueryVisitor.Run(result));
+    }
+
     [Fact]
     public void Parse_WithoutProximityModifier_ProximityIsNull()
     {

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -301,72 +301,6 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.Equal("Apache Lucene", right.Term);
         Assert.Equal("-", right.Prefix);
         Assert.True(right.IsExcluded());
-
-        result = sut.Parse("+field:value");
-        ast = DebugQueryVisitor.Run(result);
-
-        left = result.Left as TermNode;
-        Assert.NotNull(left);
-        Assert.Equal("+", left.Prefix);
-        Assert.Null(left.IsNegated);
-        Assert.True(left.IsRequired());
-        Assert.False(left.IsExcluded());
-        Assert.False(left.IsNodeOrGroupNegated());
-    }
-
-    [Theory]
-    [InlineData("-field:value")]
-    [InlineData("!field:value")]
-    public void PrefixOperatorsAreStoredInPrefixAndNotIsNegated(string query)
-    {
-        var sut = new LuceneQueryParser();
-
-        var result = sut.Parse(query);
-        string ast = DebugQueryVisitor.Run(result);
-
-        var term = result.Left as TermNode;
-        Assert.NotNull(term);
-        Assert.Null(term.IsNegated);
-        Assert.Equal(query[0].ToString(), term.Prefix);
-        Assert.True(term.IsExcluded());
-        Assert.True(term.IsNodeOrGroupNegated());
-    }
-
-    [Fact]
-    public void NotKeywordIsStoredInIsNegatedAndNotPrefix()
-    {
-        var sut = new LuceneQueryParser();
-
-        var result = sut.Parse("NOT field:value");
-        string ast = DebugQueryVisitor.Run(result);
-
-        var term = result.Left as TermNode;
-        Assert.NotNull(term);
-        Assert.True(term.IsNegated);
-        Assert.Null(term.Prefix);
-        Assert.True(term.IsExcluded());
-        Assert.True(term.IsNodeOrGroupNegated());
-    }
-
-    [Fact]
-    public void CanDetectNegationFromEnclosingGroup()
-    {
-        var sut = new LuceneQueryParser();
-
-        var result = sut.Parse("-field:(value)");
-        string ast = DebugQueryVisitor.Run(result);
-
-        var group = result.Left as GroupNode;
-        Assert.NotNull(group);
-        Assert.True(group.HasParens);
-        Assert.Equal("-", group.Prefix);
-        Assert.NotEqual(true, group.IsNegated);
-        Assert.True(group.IsExcluded());
-
-        var term = group.Left as TermNode;
-        Assert.NotNull(term);
-        Assert.False(term.IsExcluded());
-        Assert.True(term.IsNodeOrGroupNegated());
     }
 
     [Fact]
@@ -591,35 +525,16 @@ public class QueryParserTests : TestWithLoggingBase
         _logger.LogInformation("{Result}", await DebugQueryVisitor.RunAsync(result));
     }
 
-    [Theory]
-    [InlineData("term~", null, false, "")]
-    [InlineData("term~1", null, false, "1")]
-    [InlineData("roam~0.8", null, false, "0.8")]
-    [InlineData("\"phrase query\"~2", null, true, "2")]
-    [InlineData("field:term~", "field", false, "")]
-    [InlineData("field:\"phrase\"~3", "field", true, "3")]
-    public void Parse_WithProximityModifier_SetsProximityOnTermNode(string query, string? expectedField, bool expectedQuoted, string expectedProximity)
-    {
-        var parser = new LuceneQueryParser();
-        var result = parser.Parse(query);
-
-        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
-        string generatedQuery = GenerateQueryVisitor.Run(result);
-        Assert.Equal(query, generatedQuery);
-
-        var termNode = result.Left as TermNode;
-        Assert.NotNull(termNode);
-        Assert.Equal(expectedField, termNode.Field);
-        Assert.Equal(expectedQuoted, termNode.IsQuotedTerm);
-        Assert.Equal(expectedProximity, termNode.Proximity);
-    }
-
     [Fact]
     public void Parse_WithFuzzyTermInGroup_SetsProximityOnInnerTermNode()
     {
+        // Arrange
         var parser = new LuceneQueryParser();
+
+        // Act
         var result = parser.Parse("searchKeywords:(\"Wellness\"~)");
 
+        // Assert
         _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
         string generatedQuery = GenerateQueryVisitor.Run(result);
         Assert.Equal("searchKeywords:(\"Wellness\"~)", generatedQuery);
@@ -637,14 +552,155 @@ public class QueryParserTests : TestWithLoggingBase
     }
 
     [Fact]
-    public void Parse_WithoutProximityModifier_ProximityIsNull()
+    public void Parse_WithNegatedFieldGroup_InnerTermIsNodeOrGroupNegated()
     {
+        // Arrange
         var parser = new LuceneQueryParser();
-        var result = parser.Parse("field:value");
+
+        // Act
+        var result = parser.Parse("-field:(value)");
+
+        // Assert
+        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
+
+        var groupNode = result.Left as GroupNode;
+        Assert.NotNull(groupNode);
+        Assert.True(groupNode.HasParens);
+        Assert.Equal("-", groupNode.Prefix);
+        Assert.NotEqual(true, groupNode.IsNegated);
+        Assert.True(groupNode.IsExcluded());
+
+        var termNode = groupNode.Left as TermNode;
+        Assert.NotNull(termNode);
+        Assert.False(termNode.IsExcluded());
+        Assert.True(termNode.IsNodeOrGroupNegated());
+    }
+
+    [Theory]
+    [InlineData("NOT [1 TO 2]")]
+    [InlineData("NOT >1")]
+    [InlineData("NOT field:[1 TO 2]")]
+    public void Parse_WithNegatedRange_SetsIsNegatedAndRoundTrips(string query)
+    {
+        // Arrange
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var result = parser.Parse(query);
+
+        // Assert
+        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
+
+        var rangeNode = result.Left as TermRangeNode;
+        Assert.NotNull(rangeNode);
+        Assert.True(rangeNode.IsNegated);
+        Assert.True(rangeNode.IsExcluded());
+        Assert.Equal(query, GenerateQueryVisitor.Run(result));
+    }
+
+    [Fact]
+    public void Parse_WithNotKeyword_SetsIsNegatedAndNotPrefix()
+    {
+        // Arrange
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var result = parser.Parse("NOT field:value");
+
+        // Assert
+        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
 
         var termNode = result.Left as TermNode;
         Assert.NotNull(termNode);
+        Assert.True(termNode.IsNegated);
+        Assert.Null(termNode.Prefix);
+        Assert.True(termNode.IsExcluded());
+        Assert.True(termNode.IsNodeOrGroupNegated());
+    }
+
+    [Fact]
+    public void Parse_WithoutProximityModifier_ProximityIsNull()
+    {
+        // Arrange
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var result = parser.Parse("field:value");
+
+        // Assert
+        var termNode = result.Left as TermNode;
+        Assert.NotNull(termNode);
         Assert.Null(termNode.Proximity);
+    }
+
+    [Theory]
+    [InlineData("-field:value", "-")]
+    [InlineData("!field:value", "!")]
+    public void Parse_WithPrefixOperator_SetsPrefixAndNotIsNegated(string query, string expectedPrefix)
+    {
+        // Arrange
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var result = parser.Parse(query);
+
+        // Assert
+        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
+
+        var termNode = result.Left as TermNode;
+        Assert.NotNull(termNode);
+        Assert.Null(termNode.IsNegated);
+        Assert.Equal(expectedPrefix, termNode.Prefix);
+        Assert.True(termNode.IsExcluded());
+        Assert.True(termNode.IsNodeOrGroupNegated());
+    }
+
+    [Theory]
+    [InlineData("term~", null, false, "")]
+    [InlineData("term~1", null, false, "1")]
+    [InlineData("roam~0.8", null, false, "0.8")]
+    [InlineData("\"phrase query\"~2", null, true, "2")]
+    [InlineData("field:term~", "field", false, "")]
+    [InlineData("field:\"phrase\"~3", "field", true, "3")]
+    public void Parse_WithProximityModifier_SetsProximityOnTermNode(string query, string? expectedField, bool expectedQuoted, string expectedProximity)
+    {
+        // Arrange
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var result = parser.Parse(query);
+
+        // Assert
+        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
+        string generatedQuery = GenerateQueryVisitor.Run(result);
+        Assert.Equal(query, generatedQuery);
+
+        var termNode = result.Left as TermNode;
+        Assert.NotNull(termNode);
+        Assert.Equal(expectedField, termNode.Field);
+        Assert.Equal(expectedQuoted, termNode.IsQuotedTerm);
+        Assert.Equal(expectedProximity, termNode.Proximity);
+    }
+
+    [Fact]
+    public void Parse_WithRequiredPrefixOperator_IsRequiredAndNotExcluded()
+    {
+        // Arrange
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var result = parser.Parse("+field:value");
+
+        // Assert
+        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(result));
+
+        var termNode = result.Left as TermNode;
+        Assert.NotNull(termNode);
+        Assert.Equal("+", termNode.Prefix);
+        Assert.Null(termNode.IsNegated);
+        Assert.True(termNode.IsRequired());
+        Assert.False(termNode.IsExcluded());
+        Assert.False(termNode.IsNodeOrGroupNegated());
     }
 }
 


### PR DESCRIPTION
## Background

Consumers writing custom visitors keep hand-rolling negation checks like:

```csharp
bool isNegated = node.IsNegated.GetValueOrDefault() || node.Prefix == "-";
```

That check is incomplete: it misses the `!` prefix operator and it misses negation applied to an enclosing parenthesized group. The reason people write it is that `IsNegated` looks like it should be the whole story, and the XML docs on the property reinforced that.

## Why the parser behaves this way

`LuceneQueryParser.peg` sets `IsNegated = true` only for the literal `NOT` keyword. The `+`, `-`, and `!` operators are captured in `Prefix` instead, so `GenerateQueryVisitor` and `ToString()` can round-trip a query faithfully instead of rewriting `-value` into `NOT value`. Collapsing them into a single flag would be a breaking change to query generation, so the parser keeps them separate.

The supported way to ask "is this negated" already exists:

| Helper | Covers |
|--------|--------|
| `IsExcluded()` | `NOT`, `-`, `!` on the node itself |
| `IsRequired()` | `+` |
| `IsNodeOrGroupNegated()` | `IsExcluded()` plus negation on the nearest enclosing parenthesized group |

## :warning: Breaking change

The `IsNegated(this IFieldQueryNode)` extension method is now marked `[Obsolete]`. It only ever forwarded to `IsExcluded()`, and its name collides with the `IsNegated` property it does *not* simply read — which is the root of the confusion this PR addresses.

Consumers that call `.IsNegated()` **and** set `TreatWarningsAsErrors` will fail to build until they switch to `.IsExcluded()`. The fix is a one-line rename at each call site. There are zero call sites in this repository.

## Bugs found and fixed

All three were pre-existing on `main`, and all three were found by checking whether the documentation actually matched the parser. Verified empirically by parsing and re-generating each query on both branches, and by asserting the resulting Elasticsearch request JSON against a live 8.19 instance.

### 1. `NOT` dropped on unqualified ranges

`NOT [1 TO 2]` and `NOT >1` produced a `TermRangeNode` that was not excluded, and query generation dropped the `NOT` entirely. Qualified ranges (`NOT field:[1 TO 2]`) were unaffected. Caught by review feedback on the first revision of this PR.

Scope, since an earlier version of this description overstated it: an unqualified range has no field to apply to, so it compiles to `match_all` in Elasticsearch with or without a configured default field. This bug therefore affects **generated query text and AST consumers** (`ToString()`, `GenerateQueryVisitor`, `CleanupQueryVisitor`, validation, and any visitor reading `IsExcluded()`), not Elasticsearch result sets. Bug 2 below is the one that changes what Elasticsearch actually matches.

### 2. `NOT` dropped on field-scoped groups

`field:NOT (value)` generated `field:(value)`. Same bug family, adjacent grammar rule. Unlike bug 1 this **does** change Elasticsearch results: the emitted query loses its `must_not` and matches the opposite set of documents.

### 3. Prefix operators dropped inside scoped field groups

`field:-(value)`, `field:!(value)` and `field:+(value)` all lost the operator, generating `field:(value)`. The operator is captured by `paren_exp`, but `field_exp` then overwrote `node.Prefix` with the field name's null prefix. Flagged in review after the first two fixes landed.

This is the most severe of the three: like bug 2 it changes results, so `field:-(value)` matched exactly the documents it asked to exclude.

```
field:-(value)  ->  field:(value)     IsExcluded() == false
```

Fixed by mirroring the `IsNegated` handling in the same rule -- let the field name's prefix win only when it actually has one:

```csharp
node.Prefix = name.Prefix ?? node.Prefix;
```

### Root cause and fix

The grammar had two conventions for recording the `NOT` keyword:

| Convention | Result |
|---|---|
| `if (not.Any()) x.IsNegated = true;` | leaves `null` when absent |
| `x.IsNegated = not.Any();` | writes `false` when absent |

The second form is an unconditional overwrite, so in `field:NOT (...)` it clobbered the `IsNegated = true` that the nested `paren_exp` rule had just set.

An earlier revision of this branch "fixed" this by converting **all seven** negation sites to the non-clobbering form. Review correctly flagged that as overreach: it changed the public AST for `_exists_`, `_missing_`, ranges and field groups from `IsNegated == false` to `null`, an unrelated compatibility break that would also make `.Value` throw for callers who previously got `false`. That is reverted.

Only `paren_exp` actually needs the non-clobbering form, because it is the one rule whose sub-rule may already have set `IsNegated`. The range alternatives delegate to `range_operator_exp`, which never touches the property, so there is nothing to clobber there. The grammar diff is now limited to the three bugs.

Bug 3 is the same shape one line further down: `paren_exp` records state that `field_exp` then clobbers. Both are now handled the same way, which is why the fix reads consistently.

Because both bugs in this rule are "combine with what the sub-rule already recorded" rather than "overwrite it", the whole rule body reduces to three straight-line assignments with no nested conditionals:

```csharp
node.IsNegated = not.Any() || node.IsNegated == true;
node.Field = name.Field;
node.Prefix = name.Prefix ?? node.Prefix;
```

An earlier revision of this branch expressed the same logic as two `if`/`else if` chains spanning 12 lines. The collapsed form was verified behavior-identical against the previous revision across the entire probe corpus before being committed, so this is a legibility change with no semantic content.

| Query | `main` | This branch |
|---|---|---|
| `NOT [1 TO 2]` | `[1 TO 2]` :x: | `NOT [1 TO 2]` :white_check_mark: |
| `NOT >1` | `>1` :x: | `NOT >1` :white_check_mark: |
| `field:NOT (value)` | `field:(value)` :x: | `NOT field:(value)` :white_check_mark: |
| `field:NOT (a b)` | `field:(a b)` :x: | `NOT field:(a b)` :white_check_mark: |

Note the fixed output normalizes to a leading `NOT` rather than reproducing the input position. It is semantically equivalent and no longer loses the operator. `TermRangeNode.ToString()` already emitted `NOT ` correctly, so only the grammar needed changing.

## Changes

- `src/.../LuceneQueryParser.peg` -- preserves the `NOT` keyword for unqualified ranges, and stops `field:NOT (...)` from clobbering the negation set by the nested `paren_exp` rule. Non-negated nodes keep the exact `null`/`false` values they have on `main`.
- `src/.../Nodes/IQueryNode.cs` -- rewrote the XML docs on `IFieldQueryNode.IsNegated` and `.Prefix`. These are the tooltips a consumer sees when they type `node.IsNegated`, and they previously said "negated (NOT operator applied)" and "prefix modifier (+, -, etc.)" with no hint that the two interact or that `!` exists.
- `src/.../QueryNodeExtensions.cs` -- XML docs on `IsExcluded`, `IsRequired`, and `IsNodeOrGroupNegated` stating exactly which syntax each covers, and `[Obsolete]` on the `IsNegated()` extension (see breaking change above).
- `docs/guide/visitors.md` -- new **Negation and Prefix Operators** section: storage matrix, round-trip rationale, helper guidance, wrong-vs-right snippet, and caveats. Fixed the node properties snippet, which typed `IsNegated` as `bool` (it is `bool?`) and omitted `!`.
- `docs/guide/query-syntax.md` -- added the `!` prefix operator to the operators table.
- `docs/guide/nested-queries.md` -- cross-linked the existing `Prefix=-` AST example.

Two documentation claims from the first revision were wrong and are now corrected:

- "`IsNegated` is only ever set to `true` by the `NOT` keyword" -- false. `InvertNegation` and `CleanupQueryVisitor` both set it programmatically, including to `false`. That text lives in the visitors guide, i.e. exactly where trees get rewritten.
- "Use `IsExcluded()` rather than checking either property" was stated unconditionally. Outside query contexts these operators mean ordering, not negation, so the guidance is now scoped to query contexts.
- The follow-up claim that "a `-` prefix means descending in sort and aggregation contexts" was itself too coarse. The two contexts honor **different operator sets**, now verified against Elasticsearch 8.19 and documented precisely: sort calls `IsNodeOrGroupNegated()` so `-`, `!` and `NOT` all sort descending, whereas aggregation ordering reads `Prefix` directly and only honors `-` and `+`; `!` and `NOT` emit no `order` clause at all.

## Tests

The per-query negation tests are consolidated into one matrix theory that mirrors the documented table, so the docs and the tests can't drift apart:

- `Parse_WithNegation_StoresNotKeywordInIsNegatedAndOperatorsInPrefix` -- 18 cases asserting the `(IsNegated, Prefix, IsExcluded(), IsRequired())` tuple plus a full round trip. Includes `!`/`-` on ranges, `_exists_`/`_missing_`, and non-negated controls that pin the exact `null`-vs-`false` value each grammar rule produces, which is what caught the over-broad grammar change described above.
- `CleanupQuery_WithNullOrFalseIsNegated_ProducesSameOutput` -- pins that `null` and `false` are interchangeable (see the `bool?` section below).
- `Parse_WithNestedGroupInsideExcludedGroup_IsNodeOrGroupNegatedIgnoresParent` -- pins that `IsNodeOrGroupNegated()` on an already-parenthesized `GroupNode` does not inspect an excluded parent.
- `Parse_WithNotKeywordBeforeFieldGroup_PreservesNegation` -- locks bug 2.
- `Parse_WithNegatedRange_SetsIsNegatedAndRoundTrips` -- locks bug 1, round-tripping through both `GenerateQueryVisitor` and `CleanupQueryVisitor` (the latter branches on `IsNegated.HasValue`, so it's the visitor at risk from the grammar change).
- `Parse_WithNegatedFieldGroup_InnerTermIsNodeOrGroupNegated` -- `-field:(value)`: inner term is not itself excluded, but `IsNodeOrGroupNegated()` is `true`.
- `Parse_WithRequiredPrefixAndNotKeyword_IsNodeOrGroupNegatedIgnoresNegation` -- documents that `NOT +field:value` has `IsExcluded() == true` but `IsNodeOrGroupNegated() == false`, since `+` suppresses it. Pre-existing behavior, now pinned and called out in the docs rather than left as a silent trap.

## Why is `IsNegated` a `bool?` and not just true/false?

Raised in review, and worth recording because the intuitive answer is wrong. `IsNegated` reads like a boolean but is a `bool?`, so the obvious question is whether `null` means something that `false` does not.

It does not. Forcing every combination of parent and child negation states through `CleanupQueryVisitor`'s group-collapse and double-negative logic produces **identical output for `null` and `false`** in all cases; only `true` ever changes the result:

| outer | inner `null` | inner `false` | inner `true` |
|---|---|---|---|
| `null` | `value` | `value` | `NOT value` |
| `false` | `value` | `value` | `NOT value` |
| `true` | `NOT value` | `NOT value` | `value` |

Two places do observe the difference, so "identical everywhere" would be too strong a claim:

- `CopyTo` copies the value only when it is set, so a `null` source leaves an existing `true` target intact while a `false` source overwrites it.
- `DebugQueryVisitor` prints an `IsNegated` line only when the value is set.

Neither is a distinction worth branching on, and which value a non-negated node receives just depends on which grammar rule matched. Every `IsNegated` consumer in the repo, including both `SqlNodeExtensions` sites, tests `HasValue && Value` or `is not true`, so none of them distinguishes `null` from `false`.

So the nullability is a historical artifact. Narrowing it to `bool` would be the cleaner design, but it is a breaking change to the public `IFieldQueryNode` interface and to every node type and custom visitor that implements it, which makes it a major-version change rather than something to slip into this PR. Instead it is now documented on the property itself, explained in the guide, and pinned by `CleanupQuery_WithNullOrFalseIsNegated_ProducesSameOutput` so the equivalence cannot drift silently. The guidance everywhere is the same: compare against `true`, or better, call `IsExcluded()`.

## Known limitations, documented but not changed here

- `IsNodeOrGroupNegated()` inspects only the nearest parenthesized group, not the full ancestor chain, so the inner group in `NOT (a:(b))` reports `false`. **Fixed in #277** (starts the ancestor search at the node's parent instead of matching the node itself); filed as #274.
- `!field` sorts descending (sort uses `IsNodeOrGroupNegated()`) but does not order aggregations descending (aggregations check `Prefix is "-" or "+"` directly). Pre-existing inconsistency, out of scope, now pinned by tests in both contexts. **Tracked as a decision issue for @ejsmith: #273.**
- `NOT +field` sorts **ascending**, because `IsNodeOrGroupNegated()` returns `false` when `IsRequired()` is `true`. The query path is unaffected: it uses `IsExcluded()`, so `NOT +field:value` still produces a `must_not`. Both behaviors are now pinned by tests. **Raised as a sub-question in #273.**
- Post-colon operators (`field1:-value1`) work for terms and groups but throw `FormatException` on ranges (`field4:-[1 TO 2]`), and none of the three forms are accepted by Lucene/Elasticsearch at all. **Tracked as a decision issue for @ejsmith: #272.**

## Follow-up work

Filed while auditing this PR, tracked separately rather than expanding this diff further:

- **#271 / #270** — new `docs/guide/syntax-compatibility.md`, a tiered catalogue of every place this parser's syntax diverges from Lucene/Elasticsearch `query_string`, verified against a live ES 8.19 instance. Merged as pure documentation.
- **#272** (decision, @ejsmith) — should post-colon operator placement (`field:-value`) extend to ranges, or should the existing term/group support be restricted to match Lucene/Elasticsearch, which reject it outright?
- **#273** (decision, @ejsmith) — should aggregation ordering honor `!` the same way sort already does? Elasticsearch documents `!` as a `NOT` alias, so this is standards-alignment rather than an extension.
- **#274 / #277** — bug fix for the `IsNodeOrGroupNegated()` contract violation noted above.
- **#275 / #276** — unrelated flaky-CI bug found while verifying this PR's CI runs: unscoped `SearchAsync` calls in `ElasticNestedQueryParserTests.cs` search every index in the shared test container instead of just their own.



Several assertions in earlier revisions of this branch were reasoned about rather than measured, and three turned out to be wrong. Everything below is now verified against the running code:

| Claim | Verdict |
|---|---|
| `null` and `false` are semantically distinct (`null` enables inheritance from the enclosing group) | **Wrong.** Rendering is identical across 38 probed slots; only `true` matters. Removed. |
| `null` and `false` behave identically *everywhere* | **Too strong.** `CopyTo` and `DebugQueryVisitor` do observe the difference. Corrected above. |
| The `NOT`-on-range fix changes Elasticsearch behavior | **Wrong.** Unqualified ranges are `match_all` regardless; it is a text/AST fix. Scoped above. |
| Normalizing all seven grammar sites is safe | **Wrong.** It broke the public AST for `_exists_`/`_missing_`/ranges/groups. Reverted. |
| All 8 rows of the negation table in the guide | **Correct**, each checked against the parser. |
| `nested-queries.md`: inner group has `Prefix=-` with `IsNegated=False` | **Correct**, confirmed via `DebugQueryVisitor`. |
| Consolidating the negation tests lost no coverage | **Correct.** The test-method inventory is a strict superset of `main` for all three touched files; `InlineData` rows went 6 to 30. |
| `!` is a negation operator equivalent to `NOT` | **Correct**, and matches the Elasticsearch `query_string` docs, which list `!` as a `NOT` alias. |
| `Prefix` round-trips the query verbatim | **Too strong.** Operators are preserved but re-emitted in canonical leading position, so `field:-(value)` renders as `-field:(value)`. Qualified in the guide. |

The audit also surfaced bug 3 above independently of review, via a probe of every prefix-and-negation position against the parser.

## Elasticsearch verification

A grammar change deserves differential proof rather than an assurance, so behavior was captured on `main` and on this branch using an identical throwaway harness over a **90-query corpus** (negation and prefix permutations, ranges, `_exists_`/`_missing_`, groups, boolean operators, quoting and escaping, fuzzy/boost/proximity modifiers, wildcards, dates), plus 15 sort and 22 aggregation expressions. Each case recorded the AST tuple, `GenerateQueryVisitor`/`CleanupQueryVisitor` round trips, and the real request JSON sent to a live Elasticsearch 8.19 instance.

Diffing the two captures, section by section:

| Section | Result |
|---------|--------|
| Elastic **sort** JSON | **byte-identical** |
| Elastic **aggregation** JSON | **byte-identical** |
| Elastic **query** JSON | changed for exactly **2** of 90 queries: `field1:NOT (value1)` and `field1:NOT (value1 value2)` -- the bug being fixed |
| Parser AST | changed for exactly **7** of 90 queries, all of them `NOT`-on-range or `field:NOT (...)` forms; every other node keeps the same `IsNegated`/`Prefix` values as `main` |

This directly answers the risk that changing negation handling could disturb Elastic sort or aggregation behavior: it does not, and the only query-side changes are the two documented bugs.

The new tests were then run against `main` as a falsification check: **18 of 19 pass on `main` and exactly one fails** -- `field1:NOT (value1)`. That confirms the new assertions are genuine regression tests rather than tautologies, and that the other 18 pin pre-existing behavior this PR preserves.

### Exhaustive per-variant verification

The differential harness above compares this branch to `main`, which proves nothing was disturbed but does not prove the *result* is correct. So every variant was additionally checked by **indexing two documents and asserting which ones Elasticsearch actually returns**, rather than by inspecting query JSON. Doc A is the query target (`field1=value1`, `field4=1`), doc B the control (`field1=value2`, `field4=9`); a correct negation must return exactly B.

All 9 term forms, 16 group forms, and 11 range forms behave correctly, including both writing positions for every operator:

| Variant | Returns | Variant | Returns |
|---|---|---|---|
| `field1:value1` | A | `field1:(value1)` | A |
| `NOT field1:value1` | B | `NOT field1:(value1)` | B |
| `field1:NOT value1` | B | `field1:NOT (value1)` | B *(bug 2)* |
| `-field1:value1` | B | `-field1:(value1)` | B |
| `field1:-value1` | B | `field1:-(value1)` | B *(bug 3)* |
| `!field1:value1` | B | `field1:!(value1)` | B *(bug 3)* |
| `+field1:value1` | A | `field1:+(value1)` | A *(bug 3)* |
| `NOT (field1:value1)` | B | `field1:(-value1)` | B |
| `-(field1:value1)` | B | `field1:(NOT value1)` | B |

Double negation folds correctly in all five forms (`NOT (NOT ...)`, `NOT (-...)`, `NOT (!...)`, `-(NOT ...)`, `-(-...)` all return A), and triple negation stays negative (returns B).

Ranges: `NOT field4:[1 TO 2]`, `-field4:[1 TO 2]`, `!field4:[1 TO 2]`, `NOT field4:<3`, `-field4:<3`, and `NOT field4:(>=1 AND <=2)` all correctly return B.

Sort and aggregation contexts were verified the same way, against real responses rather than JSON:

- **Sort**: `-field1`, `!field1`, and `NOT field1` all return `value2,value1` (descending); `field1` and `+field1` return `value1,value2` (ascending). Multi-key sorts behave as expected.
- **Aggregations**: only `-` and `+` on a sub-aggregation emit `order`; `!` and `NOT` emit none. Every expression returns a valid response.

### Round-trip stability

A dropped or duplicated operator shows up as an unstable round trip, so all 46 variants were checked for the fixed-point property `generate(parse(generate(parse(q)))) == generate(parse(q))`. **All 46 are stable.** This is now a permanent test (`Parse_WithNegationOrPrefix_GeneratedQueryReparsesToItself`) rather than a one-off probe, so a future grammar change that drops an operator in either position fails the build.

### One genuine gap found, pre-existing and now documented

Post-colon operators are rejected on ranges: `field4:NOT [1 TO 2]` and `field4:-[1 TO 2]` throw `FormatException`, even though the equivalent post-colon forms work for terms (`field1:-value1`) and for groups (`field1:-(value1)`). The leading forms (`-field4:[1 TO 2]`, `NOT field4:[1 TO 2]`) work correctly.

This was confirmed **identical on `main`** by running the same probe against `main`'s grammar, so it is pre-existing and not a regression from this PR. Making it parse is a grammar change with its own compatibility surface and no reported demand, so this PR documents the asymmetry in `query-syntax.md` instead of silently leaving it as a trap. Whether to close this gap or hold the line is now a decision request for @ejsmith: #272.

For completeness, swapping `main`'s grammar into this branch and re-running the probe shows **exactly 5 behavioral differences** across the corpus, and all 5 are the intended fixes: `field1:-(value1)`, `field1:!(value1)`, `field1:+(value1)`, `field1:NOT (value1)`, and `NOT [1 TO 2]`. Every other variant, including both `FormatException` cases, is unchanged.

## Validation

- `dotnet build Foundatio.Parsers.slnx` -- succeeded, 0 warnings
- Lucene **346/346** and Elastic **223/223** pass (Elastic up from 202 with the new negation coverage).
- The SQL suite's 17 failures are `Failed to connect to SQL Server within timeout`; that project has no dependency on the grammar and the failures reproduce without these changes. Confirmed no MSSQL container is running locally.
- `dotnet format --verify-no-changes` reports the same 3 pre-existing violations with and without this PR's changes, all in files it does not modify.

## Audit trail

This branch has been through several review rounds. For reviewers, the substantive changes since the first revision:

| Round | Outcome |
|---|---|
| 1 | Bug 1 (`NOT` on unqualified ranges) found by review |
| 2 | Over-broad seven-site grammar normalization flagged by review and reverted; bug 2 fixed with a narrow change |
| 3 | Three factually wrong claims in the description and guide identified by self-audit and corrected |
| 4 | Bug 3 (prefix dropped in scoped field groups) found by review |
| 5 | Exhaustive per-variant Elasticsearch verification (documents returned, not JSON inspected); grammar rule collapsed to straight-line assignments; round-trip fixed-point test added; pre-existing range/post-colon gap documented |






