### PR TITLE
Document syntax deviations from Lucene/Elasticsearch query_string

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ var results = await db.Products
 - **Date math**: `created:[now-7d TO now]`
 - **Geo queries**: `location:75044~75mi`
 
-[Full Query Syntax Reference](https://parsers.foundatio.dev/guide/query-syntax)
+[Full Query Syntax Reference](https://parsers.foundatio.dev/guide/query-syntax) | [Syntax Compatibility with Lucene/Elasticsearch](https://parsers.foundatio.dev/guide/syntax-compatibility)
 
 ### Aggregations
 - **Metrics**: `min`, `max`, `avg`, `sum`, `stats`, `cardinality`, `percentiles`

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -42,6 +42,7 @@ export default withMermaid(defineConfig({
           text: 'Core Concepts',
           items: [
             { text: 'Query Syntax', link: '/guide/query-syntax' },
+            { text: 'Syntax Compatibility', link: '/guide/syntax-compatibility' },
             { text: 'Aggregation Syntax', link: '/guide/aggregation-syntax' },
             { text: 'Field Aliases', link: '/guide/field-aliases' },
             { text: 'Query Includes', link: '/guide/query-includes' },

--- a/docs/guide/query-syntax.md
+++ b/docs/guide/query-syntax.md
@@ -80,6 +80,10 @@ Example:
 var result = parser.Parse("email:/.*@example\\.com/");
 ```
 
+::: warning
+`IsRegexTerm` is set on the AST, but `ElasticQueryParser` does not emit a `regexp` query. On analyzed fields the pattern is passed through as a wildcard, and on keyword fields it becomes a `prefix` query, so `.` matches literally. See [Syntax Compatibility](./syntax-compatibility#term-modifiers-this-library-parses-but-does-not-translate).
+:::
+
 ## Range Queries
 
 Range queries filter numeric or date fields within bounds.
@@ -380,6 +384,10 @@ var result = parser.Parse("title:important^2");
 result = parser.Parse("title:\"very important\"^3");
 ```
 
+::: warning
+The boost is parsed and available on the AST (`TermNode.Boost`), but `ElasticQueryParser` does not currently apply it to the generated Elasticsearch query. See [Syntax Compatibility](./syntax-compatibility#term-modifiers-this-library-parses-but-does-not-translate).
+:::
+
 ## Fuzzy Queries
 
 Use `~` for fuzzy matching (edit distance):
@@ -391,6 +399,10 @@ var result = parser.Parse("name:john~");
 // Fuzzy match with specific edit distance
 result = parser.Parse("name:john~2");
 ```
+
+::: warning
+The edit distance is parsed and available on the AST (`TermNode.Proximity`), but `ElasticQueryParser` does not currently apply it to the generated Elasticsearch query -- the term is matched exactly. The same applies to phrase proximity (`"a b"~5`) and to regex terms (`/val.*/`). See [Syntax Compatibility](./syntax-compatibility#term-modifiers-this-library-parses-but-does-not-translate).
+:::
 
 ## Escaping Special Characters
 

--- a/docs/guide/query-syntax.md
+++ b/docs/guide/query-syntax.md
@@ -1,6 +1,6 @@
 # Query Syntax
 
-The query syntax is based on [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) and is compatible with [Elasticsearch query_string](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html).
+The query syntax is based on [Lucene query syntax](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) and is compatible with [Elasticsearch query_string](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html). This library extends both with a few of its own constructs -- see [Syntax Compatibility](./syntax-compatibility) for exactly where it deviates and how much that matters.
 
 ## Basic Queries
 
@@ -435,6 +435,7 @@ string normalized = GenerateQueryVisitor.Run(result);
 
 ## Next Steps
 
+- [Syntax Compatibility](./syntax-compatibility) - Where this syntax deviates from Lucene/Elasticsearch, and how much it matters
 - [Aggregation Syntax](./aggregation-syntax) - Dynamic aggregation expressions
 - [Field Aliases](./field-aliases) - Map field names
 - [Validation](./validation) - Validate and restrict queries

--- a/docs/guide/syntax-compatibility.md
+++ b/docs/guide/syntax-compatibility.md
@@ -1,0 +1,82 @@
+# Syntax Compatibility with Lucene and Elasticsearch
+
+Foundatio.Parsers is a deliberate **superset** of the [Lucene classic query syntax](https://lucene.apache.org/core/10_5_1/queryparser/org/apache/lucene/queryparser/classic/QueryParser.html) and [Elasticsearch's `query_string`](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query), not a strict clone. Most syntax round-trips cleanly between the two. This page catalogues where it does not, so you can tell which constructs are safe to hand to a plain Lucene/`query_string` consumer and which are Foundatio.Parsers extensions.
+
+Every row below was verified against a live **Elasticsearch 8.19** instance using the read-only `_validate/query` endpoint, which reports whether `query_string` accepts a given query without executing a search. Behavior can shift between Elasticsearch major versions; treat this as a snapshot, not a guarantee.
+
+The deviations are grouped by consequence, not by feature area, because the risk they carry is wildly different:
+
+- **Tier 1** -- the query is accepted by `query_string`, but means something else entirely. This is the dangerous tier: nothing errors, so a query that returns real results here can silently return an empty set (or the wrong set) there.
+- **Tier 2** -- the query throws a parse error in `query_string`. Annoying, but safe: it fails loudly instead of returning wrong data.
+- **Tier 3** -- behaves identically in both. Listed for completeness so you know what's safe to rely on.
+
+## Tier 1: Silently means something different
+
+These are the ones to actually worry about. `query_string` parses them as an ordinary field name, since it has no concept of the special prefix, and then reports that field as unmapped.
+
+| Syntax | Our meaning | `query_string` behavior |
+|--------|-------------|--------------------------|
+| `_missing_:field` | Field is null or absent | Looks for a field literally named `_missing_`. Returns `MatchNoDocsQuery("unmapped fields [_missing_]")` -- matches **nothing**, no error. |
+| `@include:name` | Expand a stored query fragment | Looks for a field literally named `@include`. Same `MatchNoDocsQuery`, no error. |
+
+Both were confirmed with `_validate/query`: the response has `"valid": true`, and the `explanation` shows the unmapped-field constant-score-none query rather than an error. If you pass user-authored queries through to a system that also runs `query_string` directly (or if you ever compare this parser's behavior against a bare Elasticsearch client), these two are the ones that will look like they work and then quietly return wrong data.
+
+Note the asymmetry: `_exists_:field` is standard Elasticsearch syntax (see Tier 3), so `_exists_` and `_missing_` are **not** a matched pair even though they read like one here.
+
+## Tier 2: Rejected outright by `query_string`
+
+These fail with a parse error in Elasticsearch, which is a much safer failure mode than Tier 1 -- you find out immediately rather than shipping wrong results.
+
+| Syntax | Our meaning | `query_string` error |
+|--------|-------------|------------------------|
+| `field:-value`, `field:!value`, `field:+value` | Same as `-field:value` / `!field:value` / `+field:value` | `org.apache.lucene.queryparser.classic.ParseException: Cannot parse 'field:-value': Encountered "-" ...` |
+| `field:-(value)` | Same as `-field:(value)` | Same `ParseException` family |
+| `field:1..5` or `field:[1 .. 5]` | Same as `field:[1 TO 5]` | `ParseException: Encountered " <RANGE_GOOP> ".. ""` |
+| `field:location~distance` (geo proximity, e.g. `location:abc123~75mi`) | Geo-distance filter | `QueryShardException: failed to create query: fuzziness cannot be [75mi]`. Elasticsearch's `~` is always fuzzy-search edit distance, so `~75mi` is parsed as an (invalid) fuzziness value, not a geo radius. |
+
+The post-colon and `..` cases are pre-existing behavior, not something introduced recently; the [Lucene grammar](https://lucene.apache.org/core/10_5_1/queryparser/org/apache/lucene/queryparser/classic/QueryParser.html) explains why they are structurally unreachable there:
+
+```
+Query  ::= ( Clause )*
+Clause ::= ["+", "-"] [<TERM> ":"] ( <TERM> | "(" Query ")" )
+```
+
+The `+`/`-` modifier is positioned **before** the optional field in the grammar, so there is no production that reaches a modifier immediately after `field:`. Whether Foundatio.Parsers should extend this further (e.g. to ranges, where `field:-[1 TO 2]` currently throws `FormatException` here too) or hold the line is an open design question -- see the linked issues below.
+
+The geo-proximity collision with fuzzy search is a namespacing consequence of reusing `~`, not a bug in either system; it just means a geo query can never be expressed through a bare `query_string`.
+
+## Tier 3: Compatible
+
+Verified identical behavior in both:
+
+| Syntax | Notes |
+|--------|-------|
+| `_exists_:field` | Standard `query_string` syntax; not a Foundatio.Parsers addition. |
+| `field:>10`, `>=`, `<`, `<=` | Documented directly in the [Elasticsearch ranges reference](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query). |
+| `field:[10 TO *]`, `field:{* TO 10}` | Unbounded range bounds. |
+| `field:/regex/` | Regular expression term. |
+| `field:value~2` | Fuzzy match with edit distance. |
+| `field:value^2` | Boost. |
+| `field:"multi word"~5` | Quoted-phrase proximity search. |
+| `field:(+term1 +term2)` | Field grouping with per-term modifiers. |
+| `escaped\ field\ name:value`, `field\.with\.dots:value` | Backslash-escaped reserved characters in field names. |
+
+Foundatio.Parsers' aggregation expression language (`terms:`, `min:`, `date:`, and so on) and sort expressions have no `query_string` equivalent at all -- they are a separate API surface built on top of the query grammar, not a deviation within it, so they are out of scope for this page.
+
+## Writing portable queries
+
+If a query needs to also work against a plain Elasticsearch `query_string` (or a bare Lucene `QueryParser`), stick to:
+
+- `+`/`-`/`NOT`/`!` and `AND`/`OR` immediately **before** the field name, never after the colon
+- `[min TO max]` / `{min TO max}` for ranges, not the `..` shorthand
+- `>`, `>=`, `<`, `<=` single-sided ranges
+- `_exists_:field` (but not `_missing_:field`, which has no portable equivalent -- express it as `NOT _exists_:field` instead)
+- Standard wildcards, regex, fuzzy, boost, and quoted-phrase proximity
+
+Avoid `@include:` macros, `_missing_:field`, geo proximity (`~distance`), post-colon operator placement, and the `..` range shorthand if the query needs to travel outside this parser.
+
+## Related
+
+- [Query Syntax](./query-syntax) -- the full syntax reference for what this parser accepts
+- [Negation and Prefix Operators](./visitors#negation-and-prefix-operators) -- how `NOT`, `-`, and `!` are represented internally
+- Open design questions on extending or restricting the Tier 2 behaviors are tracked in the linked GitHub issues on post-colon range operators and aggregation `!` handling

--- a/docs/guide/syntax-compatibility.md
+++ b/docs/guide/syntax-compatibility.md
@@ -6,22 +6,42 @@ Every row below was verified against a live **Elasticsearch 8.19** instance usin
 
 The deviations are grouped by consequence, not by feature area, because the risk they carry is wildly different:
 
-- **Tier 1** -- the query is accepted by `query_string`, but means something else entirely. This is the dangerous tier: nothing errors, so a query that returns real results here can silently return an empty set (or the wrong set) there.
+- **Tier 1** -- the query is accepted, but means something else entirely. This is the dangerous tier: nothing errors, so a query that looks correct can silently return the wrong set. Two separate causes land here: syntax `query_string` reinterprets, and syntax *this library* parses but then drops.
 - **Tier 2** -- the query throws a parse error in `query_string`. Annoying, but safe: it fails loudly instead of returning wrong data.
 - **Tier 3** -- behaves identically in both. Listed for completeness so you know what's safe to rely on.
 
 ## Tier 1: Silently means something different
 
-These are the ones to actually worry about. `query_string` parses them as an ordinary field name, since it has no concept of the special prefix, and then reports that field as unmapped.
+These are the ones to actually worry about. There are two distinct causes, and neither produces an error.
+
+### Special prefixes that `query_string` reads as field names
+
+`query_string` has no concept of these prefixes, so it parses them as an ordinary field name and then reports that field as unmapped.
 
 | Syntax | Our meaning | `query_string` behavior |
 |--------|-------------|--------------------------|
 | `_missing_:field` | Field is null or absent | Looks for a field literally named `_missing_`. Returns `MatchNoDocsQuery("unmapped fields [_missing_]")` -- matches **nothing**, no error. |
 | `@include:name` | Expand a stored query fragment | Looks for a field literally named `@include`. Same `MatchNoDocsQuery`, no error. |
 
-Both were confirmed with `_validate/query`: the response has `"valid": true`, and the `explanation` shows the unmapped-field constant-score-none query rather than an error. If you pass user-authored queries through to a system that also runs `query_string` directly (or if you ever compare this parser's behavior against a bare Elasticsearch client), these two are the ones that will look like they work and then quietly return wrong data.
+Both were confirmed with `_validate/query`: the response has `"valid": true`, and the `explanation` shows the unmapped-field query rather than an error. If you pass user-authored queries through to a system that also runs `query_string` directly, these two will look like they work and then quietly return an empty set.
 
 Note the asymmetry: `_exists_:field` is standard Elasticsearch syntax (see Tier 3), so `_exists_` and `_missing_` are **not** a matched pair even though they read like one here.
+
+### Term modifiers this library parses but does not translate
+
+These are accepted by the parser and recorded on the AST, but `ElasticQueryParser` does not carry them into the generated Elasticsearch query. The modifier is silently ignored, so the query still runs and still returns results -- just not the results the syntax asked for. This is a gap in this library rather than a disagreement with Elasticsearch, which supports all of these.
+
+| Syntax | What the syntax implies | What `ElasticQueryParser` actually emits |
+|--------|-------------------------|-------------------------------------------|
+| `field:value~2` | Fuzzy match, edit distance 2 | `match` with **no `fuzziness`** -- an exact match |
+| `field:"a b"~5` | Phrase proximity, slop 5 | `match_phrase` with **no `slop`** -- adjacent terms only |
+| `field:value^2` | Boosted relevance score | `match`/`term` with **no `boost`** -- unweighted |
+| `field:/val.*/` (analyzed field) | Regular expression match | `query_string` with `analyze_wildcard`, treating `val.*` as a **wildcard** |
+| `field:/val.*/` (keyword field) | Regular expression match | `prefix` query for the literal string `val.` -- the `.` matches literally |
+
+Verified by building each query through `ElasticQueryParser` against a mapped index and inspecting the request JSON actually sent to Elasticsearch. The AST does record the modifier -- `Proximity`, `Boost`, and `IsRegexTerm` are all populated, and `GenerateQueryVisitor` round-trips the query text correctly -- so the information is lost specifically during Elasticsearch query generation, not during parsing.
+
+The two regex rows are the most dangerous here, because a wildcard or prefix interpretation of a regex pattern still returns plausible-looking results rather than obviously wrong ones. If you need any of these semantics today, construct that part of the query with the Elasticsearch client directly. Tracked as a bug in [#278](https://github.com/FoundatioFx/Foundatio.Parsers/issues/278).
 
 ## Tier 2: Rejected outright by `query_string`
 
@@ -47,19 +67,22 @@ The geo-proximity collision with fuzzy search is a namespacing consequence of re
 
 ## Tier 3: Compatible
 
-Verified identical behavior in both:
+Verified to behave identically when built through `ElasticQueryParser` and when sent to `query_string`:
 
 | Syntax | Notes |
 |--------|-------|
 | `_exists_:field` | Standard `query_string` syntax; not a Foundatio.Parsers addition. |
 | `field:>10`, `>=`, `<`, `<=` | Documented directly in the [Elasticsearch ranges reference](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-query-string-query). |
 | `field:[10 TO *]`, `field:{* TO 10}` | Unbounded range bounds. |
-| `field:/regex/` | Regular expression term. |
-| `field:value~2` | Fuzzy match with edit distance. |
-| `field:value^2` | Boost. |
-| `field:"multi word"~5` | Quoted-phrase proximity search. |
+| `field:val*` | Trailing wildcard. |
 | `field:(+term1 +term2)` | Field grouping with per-term modifiers. |
-| `escaped\ field\ name:value`, `field\.with\.dots:value` | Backslash-escaped reserved characters in field names. |
+| `field:"exact phrase"` | Quoted phrase (without a `~slop` modifier -- see Tier 1). |
+| `escaped\ field\ name:value` | Backslash-escaped spaces in field names. |
+| `field.with.dots:value` | Dotted (sub-object) field paths, written **unescaped**. |
+
+Note on escaping: only the characters this parser's `escape_sequence` rule recognizes can be backslash-escaped. A dot is not one of them, so `field\.with\.dots:value` throws `FormatException` here even though `query_string` accepts it. Write dotted paths unescaped.
+
+Fuzzy (`~2`), proximity (`~5`), boost (`^2`), and regex (`/.../ `) are **not** in this tier -- Elasticsearch supports them, but `ElasticQueryParser` drops them. See Tier 1.
 
 Foundatio.Parsers' aggregation expression language (`terms:`, `min:`, `date:`, and so on) and sort expressions have no `query_string` equivalent at all -- they are a separate API surface built on top of the query grammar, not a deviation within it, so they are out of scope for this page.
 
@@ -71,9 +94,11 @@ If a query needs to also work against a plain Elasticsearch `query_string` (or a
 - `[min TO max]` / `{min TO max}` for ranges, not the `..` shorthand
 - `>`, `>=`, `<`, `<=` single-sided ranges
 - `_exists_:field` (but not `_missing_:field`, which has no portable equivalent -- express it as `NOT _exists_:field` instead)
-- Standard wildcards, regex, fuzzy, boost, and quoted-phrase proximity
+- Trailing wildcards, quoted phrases, and dotted field paths written unescaped
 
 Avoid `@include:` macros, `_missing_:field`, geo proximity (`~distance`), post-colon operator placement, and the `..` range shorthand if the query needs to travel outside this parser.
+
+Fuzzy, proximity, boost, and regex are portable *as syntax* -- `query_string` handles all four -- but this parser drops them during Elasticsearch query generation (Tier 1), so a query relying on them behaves differently here than elsewhere. That is the opposite direction from the rest of this page: the query is portable, but the local behavior is not.
 
 ## Related
 


### PR DESCRIPTION
Closes #271

See linked issue for the full rationale and verification method.

Adds `docs/guide/syntax-compatibility.md`, cataloguing every place Foundatio.Parsers syntax diverges from Lucene classic query syntax / Elasticsearch `query_string`, grouped by consequence (silent wrong results vs. loud parse error vs. compatible) rather than by feature area.

Cross-linked from `query-syntax.md`, the docs nav, and the README syntax reference. Docs-only change; `vitepress build` passes with no dead links.

## Review follow-up

Review caught that the original verification was one-directional: every row was checked against Elasticsearch via `_validate/query`, which confirms *Elasticsearch* supports a form but never confirms that `ElasticQueryParser` actually emits it.

Closing that gap by building each query through the parser and inspecting the request JSON showed four rows listed as "compatible" were wrong, and wrong in the dangerous direction — the modifier is parsed onto the AST and then silently dropped during Elasticsearch query generation:

| Query | Emitted |
|---|---|
| `field1:value1~2` | `match` with no `fuzziness` |
| `field1:"a b"~5` | `match_phrase` with no `slop` |
| `field1:value1^2` | `match` with no `boost` |
| `field1:/val.*/` (text) | `query_string` wildcard, not a regex |
| `field3:/val.*/` (keyword) | `prefix` query for the literal string `val.` |

These moved to Tier 1, which is now split into two subsections — syntax `query_string` reinterprets (`_missing_`, `@include`) versus syntax this library parses and drops (the five above) — since they have the same consequence but different causes and different fixes. Filed **#278** for the underlying defect.

Also in this revision:

- Corrected the escaped-dot example: `field\.with\.dots:value` throws `FormatException` here because `escape_sequence` does not include `.`. Dotted paths must be written unescaped. The escaped-space form is genuinely fine and was kept.
- Added warning callouts to the Boosting, Fuzzy Queries, and Regex Queries sections of `query-syntax.md`, which previously documented all three as working with no caveat.
- Kept `!` in the portable-operator list after verifying against a live two-document index that `!field1:value1` returns the same document as `NOT` and `-`, consistent with the `query_string` docs. Rationale in the review thread.


## Second review round

Three more findings, all confirmed against a live Elasticsearch instance rather than by reading the grammar. Each one was a case where my original verification method was too narrow.

**Bare `field:1..5` is field-type dependent (a069c17).** It was listed only in Tier 2 as a parse error. Indexing documents so the *result* would distinguish a range from a literal-term match:

```
docs: n3(num=3)  n9(num=9)  lit(num=7, txt='1..5', kw='1..5')

'num:1..5'      REJECT  failed to create query: multiple points
'txt:1..5'      OK      hits=['lit']      <-- literal term match
'kw:1..5'       OK      hits=['lit']      <-- literal term match
'num:[1 .. 5]'  REJECT  Failed to parse query
'kw:[1 .. 5]'   REJECT  Failed to parse query
```

On text/keyword fields it is accepted and parses as the literal term `1..5`, returning the wrong document — Tier 1. Only the numeric case is rejected, and the bracketed form is rejected on every field type. That field-type dependence is the dangerous part, and I had missed it by testing a single mapping: a query that fails loudly against a numeric field can silently return wrong results against a keyword field. Now split into a Tier 1 subsection plus two distinct Tier 2 rows. The `RANGE_GOOP` error I originally cited applies only to the bracketed form, so it has been replaced with the actual per-case errors.

**No `regexp` query is ever emitted (a069c17).** My regex rows described only patterns ending in `*`, which is the one shape that takes the wildcard/prefix path — `GetSingleFieldQuery` selects it on `term.EndsWith("*")` alone. Every other pattern becomes an ordinary term on the raw pattern text:

| Query | Emitted |
|---|---|
| `field3:/[0-9]+/` | `{"term":{"field3":{"value":"[0-9]+"}}}` |
| `field1:/foo.bar/` | `{"match":{"field1":{"query":"foo.bar"}}}` |
| `field1:/.*@example\.com/` | `{"match":{"field1":{"query":".*@example.com"}}}` |

So `/[0-9]+/` searches for those literal characters. Added rows for the non-prefix cases and stated the general rule. #278 updated, since this broadens its test matrix.

**`_exists_` is an Elasticsearch extension, not portable Lucene (a069c17).** The portable-queries section treated "bare Lucene `QueryParser`" and "Elasticsearch `query_string`" as one target. They are not — `query_string` subclasses Lucene's parser and adds mapping-aware extensions, and `_exists_` is one of them (`ExistsFieldQueryExtension`, lowering to `ConstantScore(FieldExistsQuery [field=name])`). Bare Lucene reads `_exists_` as an ordinary field name. Restructured the section by target rather than just deleting the bullet, since the conflation was the root cause; this also caught `>`/`>=`/`<`/`<=`, which had the same incorrect scoping.

**Also:** corrected the verification note (rows were checked against ES 8.19 *and* 9.5, and by asserting returned documents, not only whether a query validates), and added a portability callout to the `..` shorthand section of `query-syntax.md`, which documented the syntax with no caveat at all.

Docs build verified clean with `ignoreDeadLinks` temporarily disabled, and the new anchor target confirmed to resolve.
