### PR TITLE
Fix flaky ElasticNestedQueryParserTests by scoping unscoped SearchAsync calls

### DIFF
--- a/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
+++ b/tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs
@@ -49,11 +49,11 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseFieldMap(new FieldMap { { "blah", "nested" } }).UseMappings<MyNestedType>(Client).UseNested());
         var result = await processor.BuildQueryAsync("field1:value1 blah:(blah.field1:value1)", new ElasticQueryVisitorContext().UseScoring());
 
-        var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Query(result), TestCancellationToken);
+        var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index).Query(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
-        var expectedResponse = await Client.SearchAsync<MyNestedType>(d => d
+        var expectedResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index)
             .Query(q => q.Bool(b => b.Must(
                 m => m.Match(ma => ma.Field(e => e.Field1).Query("value1")),
                 m => m.Nested(n => n
@@ -100,11 +100,11 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var processor = new ElasticQueryParser(c => c.SetLoggerFactory(Log).UseFieldMap(new FieldMap { { "blah", "nested" } }).UseMappings<MyNestedType>(Client).UseNested());
         var result = await processor.BuildQueryAsync("field1:value1 blah:(blah.field1:value1 blah.field4:4)", new ElasticQueryVisitorContext().UseScoring());
 
-        var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Query(result), TestCancellationToken);
+        var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index).Query(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
-        var expectedResponse = await Client.SearchAsync<MyNestedType>(d => d
+        var expectedResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index)
             .Query(q => q.Bool(b => b.Must(
                 m => m.Match(ma => ma.Field(e => e.Field1).Query("value1")),
                 m => m.Nested(n => n
@@ -155,11 +155,11 @@ public class ElasticNestedQueryParserTests : ElasticsearchTestBase
         var result = await processor.BuildQueryAsync("field1:value1 nested:(nested.field1:value1 nested.field4:4 nested.field3:value3)",
                 new ElasticQueryVisitorContext { UseScoring = true });
 
-        var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Query(result), TestCancellationToken);
+        var actualResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index).Query(result), TestCancellationToken);
         string actualRequest = actualResponse.GetRequest();
         _logger.LogInformation("Actual: {Request}", actualRequest);
 
-        var expectedResponse = await Client.SearchAsync<MyNestedType>(d => d.Query(q => q.Bool(b => b.Must(
+        var expectedResponse = await Client.SearchAsync<MyNestedType>(d => d.Indices(index).Query(q => q.Bool(b => b.Must(
             m => m.Match(ma => ma.Field(e => e.Field1).Query("value1")),
             m => m.Nested(n => n.Path(p => p.Nested).Query(q2 => q2.Bool(b2 => b2.Must(
                 m2 => m2.Match(ma => ma.Field("nested.field1").Query("value1")),


### PR DESCRIPTION
Fixes #275.

Three tests in `ElasticNestedQueryParserTests.cs` issued unscoped `SearchAsync<MyNestedType>(d => d.Query(...))` calls — no `.Indices(index)` — so each was searching every index in the shared Elasticsearch test container instead of just its own. Scoped all four affected calls to `.Indices(index)`, matching the pattern already used by the other 70 `SearchAsync` calls in the same file.

## Verification (gates from #275)

1. `grep -c "SearchAsync<MyNestedType>(d => d.Query" tests/Foundatio.Parsers.ElasticQueries.Tests/ElasticNestedQueryParserTests.cs` → `0`
2. `ElasticNestedQueryParserTests` passed in 10 consecutive `dotnet test` runs
3. Full Elastic suite (485 tests) passed twice, run concurrently against the same container — the actual condition that triggered the original intermittent failure
