### PR TITLE
Fix IsNodeOrGroupNegated() ignoring excluded parent for already-parenthesized groups

### DIFF
--- a/docs/guide/visitors.md
+++ b/docs/guide/visitors.md
@@ -394,7 +394,7 @@ bool isNegated = node.IsNodeOrGroupNegated();
 
 Two caveats worth knowing:
 
-- `IsNodeOrGroupNegated()` walks up to the nearest enclosing parenthesized group, not the whole ancestor chain beyond it, so the innermost group in `NOT (a:(b:(c)))` reports `false` for `c`. It also returns `false` when the node carries a `+` prefix even if `NOT` is also present.
+- `IsNodeOrGroupNegated()` walks up to the nearest enclosing parenthesized group, not the whole ancestor chain beyond it. Because the walk stops at the first parenthesized group, **two nodes in the same query can disagree**: in `-(field:(value))` both the outer and inner groups report `true`, but the term inside `field:(value)` reports `false`, since its nearest group is parenthesized without being excluded. In the flatter `-(field:value)` that same term reports `true`. Treat this helper as a check for node-local and immediate-group negation rather than a general "is this node negated anywhere up the tree" query. Tracked in [#279](https://github.com/FoundatioFx/Foundatio.Parsers/issues/279). It also returns `false` when the node carries a `+` prefix even if `NOT` is also present.
 - Outside of query contexts these operators are interpreted as ordering, not negation, and the set of operators that is honored differs:
   - **Sort**: `DefaultSortNodeExtensions` calls `IsNodeOrGroupNegated()`, so `-field`, `!field`, and `NOT field` all sort descending. Because that helper ignores negation when `+` is present, `NOT +field` sorts **ascending**.
   - **Aggregations**: `CombineAggregationsVisitor` reads `Prefix` directly and only honors `-` (descending) and `+` (ascending) on a sub-aggregation. `!` and the `NOT` keyword produce no `order` at all.

--- a/docs/guide/visitors.md
+++ b/docs/guide/visitors.md
@@ -378,7 +378,7 @@ In query contexts, use the extension methods instead of inspecting the propertie
 
 - `IsExcluded()` - node-local negation, covering `NOT`, `-`, and `!`
 - `IsRequired()` - the `+` prefix
-- `IsNodeOrGroupNegated()` - `IsExcluded()` plus negation on the nearest enclosing parenthesized group. When called on a `GroupNode` that already has parens, `GetGroupNode()` returns that same node, so only the group's own negation is considered and an excluded parent group is not inspected.
+- `IsNodeOrGroupNegated()` - `IsExcluded()` plus negation on the nearest enclosing parenthesized group.
 
 ```csharp
 // Wrong: misses the ! prefix and any negation on the enclosing group
@@ -394,7 +394,7 @@ bool isNegated = node.IsNodeOrGroupNegated();
 
 Two caveats worth knowing:
 
-- `IsNodeOrGroupNegated()` walks only up to the nearest parenthesized group, not the whole ancestor chain, so the inner group in `NOT (a:(b))` reports `false`. It also returns `false` when the node carries a `+` prefix even if `NOT` is also present.
+- `IsNodeOrGroupNegated()` walks up to the nearest enclosing parenthesized group, not the whole ancestor chain beyond it, so the innermost group in `NOT (a:(b:(c)))` reports `false` for `c`. It also returns `false` when the node carries a `+` prefix even if `NOT` is also present.
 - Outside of query contexts these operators are interpreted as ordering, not negation, and the set of operators that is honored differs:
   - **Sort**: `DefaultSortNodeExtensions` calls `IsNodeOrGroupNegated()`, so `-field`, `!field`, and `NOT field` all sort descending. Because that helper ignores negation when `+` is present, `NOT +field` sorts **ascending**.
   - **Aggregations**: `CombineAggregationsVisitor` reads `Prefix` directly and only honors `-` (descending) and `+` (ascending) on a sub-aggregation. `!` and the `NOT` keyword produce no `order` at all.

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -131,20 +131,21 @@ public static class QueryNodeExtensions
     }
 
     /// <summary>
-    /// Determines whether the node is negated, either directly or by the nearest enclosing parenthesized group.
+    /// Determines whether the node is negated, either directly or by an enclosing parenthesized group.
     /// Returns <c>false</c> when the node is marked as required by the <c>+</c> prefix operator.
     /// </summary>
     /// <remarks>
-    /// Only the nearest parenthesized group is inspected, not the full ancestor chain. When called on a
-    /// <see cref="GroupNode"/> that already has parens, that same node is the nearest group, so an excluded
-    /// parent group does not affect the result.
+    /// Only the nearest parenthesized group is inspected, not the full ancestor chain beyond it, so
+    /// <c>NOT (a:(b:(c)))</c> reports <c>true</c> for <c>b</c> but not for the innermost <c>c</c>.
+    /// The search always starts at the node's parent, so calling this on a <see cref="GroupNode"/> that
+    /// already has parens still finds the nearest *enclosing* group rather than matching itself.
     /// </remarks>
     public static bool IsNodeOrGroupNegated(this IFieldQueryNode node)
     {
         if (node.IsRequired())
             return false;
 
-        return node.IsExcluded() || node.GetGroupNode()?.IsExcluded() is true;
+        return node.IsExcluded() || node.Parent?.GetGroupNode()?.IsExcluded() is true;
     }
 
     public static GroupNode? GetRootNode(this IQueryNode node)

--- a/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
+++ b/src/Foundatio.Parsers.LuceneQueries/Extensions/QueryNodeExtensions.cs
@@ -142,7 +142,7 @@ public static class QueryNodeExtensions
     /// </remarks>
     public static bool IsNodeOrGroupNegated(this IFieldQueryNode node)
     {
-        if (node.IsRequired())
+        if (node == null || node.IsRequired())
             return false;
 
         return node.IsExcluded() || node.Parent?.GetGroupNode()?.IsExcluded() is true;

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -662,6 +662,38 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.False(result.IsNodeOrGroupNegated());
     }
 
+    [Fact]
+    public void IsNodeOrGroupNegated_WithTermInsideNestedFieldGroup_StopsAtNearestParenthesizedGroup()
+    {
+        // Arrange
+        // Pins the documented depth limit: the walk stops at the nearest parenthesized group, so a term
+        // can disagree with the groups enclosing it. See https://github.com/FoundatioFx/Foundatio.Parsers/issues/279.
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var nested = parser.Parse("-(field:(value))");
+        var flat = parser.Parse("-(field:value)");
+
+        // Assert
+        _logger.LogInformation("{Result}", DebugQueryVisitor.Run(nested));
+
+        var nestedOuter = Assert.IsType<GroupNode>(nested.Left);
+        var nestedInner = Assert.IsType<GroupNode>(nestedOuter.Left);
+        var nestedTerm = Assert.IsType<TermNode>(nestedInner.Left);
+
+        Assert.True(nestedOuter.IsNodeOrGroupNegated());
+        Assert.True(nestedInner.IsNodeOrGroupNegated());
+
+        // The term's nearest group is the parenthesized "field:(...)" group, which is not itself
+        // excluded, so the excluded outer group is never reached.
+        Assert.False(nestedTerm.IsNodeOrGroupNegated());
+
+        // Without the intermediate parenthesized field group, the same term does see the negation.
+        var flatOuter = Assert.IsType<GroupNode>(flat.Left);
+        var flatTerm = Assert.IsType<TermNode>(flatOuter.Left);
+        Assert.True(flatTerm.IsNodeOrGroupNegated());
+    }
+
     [Theory]
     [InlineData("NOT field:value", true, null, true, false)]
     [InlineData("NOT [1 TO 2]", true, null, true, false)]

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -633,6 +633,35 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.True(innerGroup.IsNodeOrGroupNegated());
     }
 
+    [Fact]
+    public void IsNodeOrGroupNegated_WithNullNode_ReturnsFalse()
+    {
+        // Arrange
+        // IsExcluded() and IsRequired() both tolerate a null receiver, so this helper must too.
+        // Suppressed because the scenario under test is a caller without nullable reference types enabled.
+        IFieldQueryNode node = null!;
+
+        // Act
+        bool result = node.IsNodeOrGroupNegated();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsNodeOrGroupNegated_WithRootNode_ReturnsFalse()
+    {
+        // Arrange
+        // The root group has no parent, so the parent walk must not throw.
+        var parser = new LuceneQueryParser();
+
+        // Act
+        var result = parser.Parse("field1:value1");
+
+        // Assert
+        Assert.False(result.IsNodeOrGroupNegated());
+    }
+
     [Theory]
     [InlineData("NOT field:value", true, null, true, false)]
     [InlineData("NOT [1 TO 2]", true, null, true, false)]

--- a/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
+++ b/tests/Foundatio.Parsers.LuceneQueries.Tests/QueryParserTests.cs
@@ -608,7 +608,7 @@ public class QueryParserTests : TestWithLoggingBase
     }
 
     [Fact]
-    public void Parse_WithNestedGroupInsideExcludedGroup_IsNodeOrGroupNegatedIgnoresParent()
+    public void Parse_WithNestedGroupInsideExcludedGroup_IsNodeOrGroupNegatedInspectsParent()
     {
         // Arrange
         var parser = new LuceneQueryParser();
@@ -624,13 +624,13 @@ public class QueryParserTests : TestWithLoggingBase
         Assert.Equal("-", outerGroup.Prefix);
         Assert.True(outerGroup.IsExcluded());
 
-        // The inner group already has parens, so GetGroupNode() returns the inner group itself and the
-        // excluded outer group is never inspected. Pinned because sort behavior depends on this helper.
+        // The inner group already has parens, so the search must start at its parent rather than
+        // matching itself, or the excluded outer group would never be inspected.
         var innerGroup = outerGroup.Left as GroupNode;
         Assert.NotNull(innerGroup);
         Assert.True(innerGroup.HasParens);
         Assert.False(innerGroup.IsExcluded());
-        Assert.False(innerGroup.IsNodeOrGroupNegated());
+        Assert.True(innerGroup.IsNodeOrGroupNegated());
     }
 
     [Theory]


### PR DESCRIPTION
Fixes #274. Closes #279.

`IsNodeOrGroupNegated()` is supposed to check the node itself plus its nearest enclosing parenthesized group. But `GetGroupNode()` starts its search at the node itself, so when you call this on a `GroupNode` that already has parens, it matches itself instead of looking outward — the enclosing group never gets checked. For `-(field:(value))`, the inner group returned `false` when it should return `true`.

Fix: start the walk at `node.Parent` instead of `node`.

## Blast radius

This only changes behavior when the receiver is itself a parenthesized `GroupNode`. Every other node type (`TermNode`, `TermRangeNode`, `ExistsNode`, `MissingNode`) already walks past itself in `GetGroupNode()`, so nothing changes for them.

Two checks on this:
- Only one existing test assertion flips — a parens `GroupNode`, `false` → `true`. Everything else added is new coverage.
- Ran the helper over every node in a 27-query corpus (85 evaluations) before/after the fix. 3 changed, all `Group(parens=True)`, all `false` → `true` and all correct. Zero `TermNode`/`TermRangeNode` values changed.

That last point is what makes this safe to merge: the only production consumer is `DefaultSortNodeExtensions`, reached via `GetSortFieldsVisitor`, which only overrides `Visit(TermNode node, ...)`. The helper is therefore never invoked with a `GroupNode` receiver from the sort path — and a `GroupNode` receiver is the only shape this PR changes. Sort behavior is unaffected by construction, and `BuildSortAsync_WithNegationAndPrefixOperators_MapsToSortOrder` passes with no assertion changes.

To be precise about the reason, since I initially got it wrong: it is **not** that sort expressions are flat. `ElasticQueryParserTests.cs:1453` sorts on `"geo -field1 -(field2 field3 +field4) (field5 field3)"`, where `field2`/`field3` inherit descending from the excluded `-( ... )` group with no prefix of their own, and `field4` is ascending via the `IsRequired()` short-circuit. Sort genuinely relies on both halves of this helper. It is safe here because of the *receiver type*, not the input shape.

## Also here

- Restored the null-receiver guard (review caught that the parent-walk dropped the null tolerance `IsExcluded()`/`IsRequired()` both have).
- **Resolves #279, the related inconsistency this uncovered.** @ejsmith called it: keep the behavior, document the limit precisely, and don't narrow the API until a real query consumer needs broader semantics. Implemented in 5e438bd — see below.
- Updated `docs/guide/visitors.md` to match.

## What #279 turned into

#279 asked whether the walk should continue past the nearest parenthesized group. The answer is no, and the docs now say why rather than reading like a pending fix:

- `docs/guide/visitors.md` splits the old single overlong caveat bullet into "What `IsNodeOrGroupNegated()` checks" and a separate ordering-contexts section. It states the two things it checks, the `+` short-circuit, the nested-group disagreement, and reframes #279 from "Tracked in" to a decided, intentional limit — including why a full-ancestor walk would need negation *parity*, since `-(-x)` would have to cancel.
- Added @ejsmith's point that this isn't a check of *effective* negation even within one group: in `NOT (status:active AND region:us)` both terms report `true`, but the query only excludes records matching **both**, so an active record outside the US still matches. A per-node answer describes syntactic context, not how a term participates in the condition. That distinction is now in the XML `<remarks>` too, so it shows up in IntelliSense at the call site.
- `IsNodeOrGroupNegated_WithMultipleTermsInExcludedGroup_ReportsSyntacticContextOnly` pins that example, joining the two tests already pinning the depth limit. The documented behavior is asserted, not just described, so it can't drift.

No behavior change in that commit — docs, XML comments, and one test.

## Worth a deliberate call

This is a visible behavior change on a public extension method — `false` → `true` for parenthesized-group receivers — even though I can show the blast radius is zero for the one internal caller. No changelog or breaking-change label in this repo, so flagging it here rather than letting it merge quietly.

## Verification

- `dotnet build Foundatio.Parsers.slnx` clean, 0 warnings
- 351 Lucene tests green
- `docs` site builds clean (`npm run build`), no dead links
- The one `dotnet format` complaint (`QueryNodeVisitorBase.cs` IDE0005) is pre-existing from an unrelated commit and untouched here

